### PR TITLE
ci: fix backend test pipeline with postgres service and requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,29 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: stepup
+          POSTGRES_PASSWORD: stepup123
+          POSTGRES_DB: stepup_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://stepup:stepup123@localhost:5432/stepup_test
+      TEST_DATABASE_URL: postgresql+asyncpg://stepup:stepup123@localhost:5432/stepup_test
+      FRONTEND_URL: http://localhost:3000
+      SENDGRID_API_KEY: ci-placeholder
+      SENDGRID_FROM_EMAIL: noreply@stepup.local
+      JWT_SECRET_KEY: ci-test-secret-key
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,13 +46,13 @@ jobs:
         working-directory: apps/backend
         run: |
           pip install --upgrade pip
-          pip install pytest
+          pip install -r requirements.txt
 
       - name: Run tests
         working-directory: apps/backend
         run: |
           if [ -d "tests" ] && [ "$(ls -A tests)" ]; then
-            pytest
+            python -m pytest --tb=short -q
           else
             echo "No tests found, skipping..."
           fi


### PR DESCRIPTION
## Summary
- Install from `requirements.txt` instead of only `pytest`
- Add PostgreSQL 15 service for integration tests
- Set required env vars (DATABASE_URL, TEST_DATABASE_URL, JWT_SECRET_KEY, etc.)
- Use `python -m pytest` instead of bare `pytest`

## Why
CI was failing with `ModuleNotFoundError: No module named 'pytest_asyncio'` because only `pytest` was installed, not the full requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)