### PR TITLE
test(be-us-002): add backend unit and integration tests for auth service

### DIFF
--- a/apps/backend/tests/integration/api/test_auth_endpoints.py
+++ b/apps/backend/tests/integration/api/test_auth_endpoints.py
@@ -1,0 +1,69 @@
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from passlib.context import CryptContext
+
+from app.enums.user_role import UserRole
+from app.models.refresh_token import RefreshToken
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class TestLogin:
+
+    async def test_login_returns_200_and_sets_cookies_when_credentials_are_valid(
+        self, client, db_session
+    ):
+        user = User(
+            email="loginuser@test.com",
+            role=UserRole.EMPLOYEE,
+            first_name="Login",
+            last_name="User",
+            password_hash=pwd_context.hash("password123"),
+            is_active=True,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "loginuser@test.com", "password": "password123"},
+        )
+
+        assert response.status_code == 200
+        assert "access_token" in response.cookies or "Set-Cookie" in response.headers
+
+    async def test_login_returns_401_when_password_is_wrong(
+        self, client, db_session
+    ):
+        user = User(
+            email="wrongpass@test.com",
+            role=UserRole.EMPLOYEE,
+            first_name="Wrong",
+            last_name="Pass",
+            password_hash=pwd_context.hash("correctpassword"),
+            is_active=True,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "wrongpass@test.com", "password": "wrongpassword"},
+        )
+
+        assert response.status_code == 401
+
+    async def test_login_returns_401_when_user_does_not_exist(
+        self, client
+    ):
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "nobody@test.com", "password": "password123"},
+        )
+
+        assert response.status_code == 401

--- a/apps/backend/tests/integration/api/test_auth_endpoints.py
+++ b/apps/backend/tests/integration/api/test_auth_endpoints.py
@@ -84,3 +84,40 @@ class TestLogout:
         response = await client.post("/api/v1/auth/logout")
 
         assert response.status_code == 401
+
+
+class TestRefresh:
+
+    async def test_refresh_returns_204_when_cookie_is_valid(
+        self, client, db_session
+    ):
+        user = User(
+            email="refreshuser@test.com",
+            role=UserRole.EMPLOYEE,
+            first_name="Refresh",
+            last_name="User",
+            password_hash=pwd_context.hash("password123"),
+            is_active=True,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        refresh_token = RefreshToken(
+            user_id=user.id,
+            token=secrets.token_urlsafe(32),
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        db_session.add(refresh_token)
+        await db_session.flush()
+
+        client.cookies.set("refresh_token", refresh_token.token)
+        response = await client.post("/api/v1/auth/refresh")
+
+        assert response.status_code == 204
+
+    async def test_refresh_returns_401_when_cookie_is_missing(
+        self, client
+    ):
+        response = await client.post("/api/v1/auth/refresh")
+
+        assert response.status_code == 401

--- a/apps/backend/tests/integration/api/test_auth_endpoints.py
+++ b/apps/backend/tests/integration/api/test_auth_endpoints.py
@@ -67,3 +67,20 @@ class TestLogin:
         )
 
         assert response.status_code == 401
+
+
+class TestLogout:
+
+    async def test_logout_returns_204_when_authenticated(
+        self, authenticated_client
+    ):
+        response = await authenticated_client.post("/api/v1/auth/logout")
+
+        assert response.status_code == 204
+
+    async def test_logout_returns_401_when_not_authenticated(
+        self, client
+    ):
+        response = await client.post("/api/v1/auth/logout")
+
+        assert response.status_code == 401

--- a/apps/backend/tests/unit/services/test_auth_service.py
+++ b/apps/backend/tests/unit/services/test_auth_service.py
@@ -58,3 +58,21 @@ class TestLogin:
 
             with pytest.raises(AuthenticationError):
                 await service.login(mock_db, "unknown@example.com", "password123")
+
+    async def test_login_raises_error_when_password_is_wrong(
+        self, service, mock_db
+    ):
+        mock_user = MagicMock()
+
+        with patch(
+            "app.services.auth_service.user_repository",
+            autospec=True,
+        ) as mock_user_repo, patch(
+            "app.services.auth_service.pwd_context",
+        ) as mock_pwd:
+
+            mock_user_repo.get_by_email = AsyncMock(return_value=mock_user)
+            mock_pwd.verify = MagicMock(return_value=False)
+
+            with pytest.raises(AuthenticationError):
+                await service.login(mock_db, "user@example.com", "wrongpassword")

--- a/apps/backend/tests/unit/services/test_auth_service.py
+++ b/apps/backend/tests/unit/services/test_auth_service.py
@@ -132,3 +132,23 @@ class TestRefresh:
 
             with pytest.raises(AuthenticationError):
                 await service.refresh(mock_db, "expired-token")
+
+
+class TestLogout:
+
+    async def test_logout_deletes_refresh_tokens_for_user(
+        self, service, mock_db
+    ):
+        import uuid
+        user_id = uuid.uuid4()
+
+        with patch(
+            "app.services.auth_service.refresh_token_repository",
+            autospec=True,
+        ) as mock_rt_repo:
+
+            mock_rt_repo.delete_by_user_id = AsyncMock()
+
+            await service.logout(mock_db, user_id)
+
+            mock_rt_repo.delete_by_user_id.assert_called_once_with(mock_db, user_id)

--- a/apps/backend/tests/unit/services/test_auth_service.py
+++ b/apps/backend/tests/unit/services/test_auth_service.py
@@ -103,3 +103,32 @@ class TestRefresh:
 
             assert new_access_token is not None
             assert new_refresh_token is not None
+
+    async def test_refresh_raises_error_when_token_does_not_exist(
+        self, service, mock_db
+    ):
+        with patch(
+            "app.services.auth_service.refresh_token_repository",
+            autospec=True,
+        ) as mock_rt_repo:
+
+            mock_rt_repo.get_by_token = AsyncMock(return_value=None)
+
+            with pytest.raises(AuthenticationError):
+                await service.refresh(mock_db, "nonexistent-token")
+
+    async def test_refresh_raises_error_when_token_is_expired(
+        self, service, mock_db
+    ):
+        mock_refresh_token = MagicMock()
+        mock_refresh_token.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+
+        with patch(
+            "app.services.auth_service.refresh_token_repository",
+            autospec=True,
+        ) as mock_rt_repo:
+
+            mock_rt_repo.get_by_token = AsyncMock(return_value=mock_refresh_token)
+
+            with pytest.raises(AuthenticationError):
+                await service.refresh(mock_db, "expired-token")

--- a/apps/backend/tests/unit/services/test_auth_service.py
+++ b/apps/backend/tests/unit/services/test_auth_service.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.auth_service import AuthService
+from app.errors import AuthenticationError
+
+
+@pytest.fixture
+def service():
+    return AuthService()
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+class TestLogin:
+
+    async def test_login_returns_tokens_when_credentials_are_valid(
+        self, service, mock_db
+    ):
+        mock_user = MagicMock()
+        mock_user.id = MagicMock()
+
+        with patch(
+            "app.services.auth_service.user_repository",
+            autospec=True,
+        ) as mock_user_repo, patch(
+            "app.services.auth_service.refresh_token_repository",
+            autospec=True,
+        ) as mock_rt_repo, patch(
+            "app.services.auth_service.pwd_context",
+        ) as mock_pwd:
+
+            mock_user_repo.get_by_email = AsyncMock(return_value=mock_user)
+            mock_pwd.verify = MagicMock(return_value=True)
+            mock_rt_repo.create = AsyncMock()
+
+            access_token, refresh_token = await service.login(
+                mock_db, "user@example.com", "password123"
+            )
+
+            assert access_token is not None
+            assert refresh_token is not None

--- a/apps/backend/tests/unit/services/test_auth_service.py
+++ b/apps/backend/tests/unit/services/test_auth_service.py
@@ -45,3 +45,16 @@ class TestLogin:
 
             assert access_token is not None
             assert refresh_token is not None
+
+    async def test_login_raises_error_when_user_does_not_exist(
+        self, service, mock_db
+    ):
+        with patch(
+            "app.services.auth_service.user_repository",
+            autospec=True,
+        ) as mock_user_repo:
+
+            mock_user_repo.get_by_email = AsyncMock(return_value=None)
+
+            with pytest.raises(AuthenticationError):
+                await service.login(mock_db, "unknown@example.com", "password123")

--- a/apps/backend/tests/unit/services/test_auth_service.py
+++ b/apps/backend/tests/unit/services/test_auth_service.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.services.auth_service import AuthService
@@ -76,3 +77,29 @@ class TestLogin:
 
             with pytest.raises(AuthenticationError):
                 await service.login(mock_db, "user@example.com", "wrongpassword")
+
+
+class TestRefresh:
+
+    async def test_refresh_returns_new_tokens_when_token_is_valid(
+        self, service, mock_db
+    ):
+        mock_refresh_token = MagicMock()
+        mock_refresh_token.user_id = MagicMock()
+        mock_refresh_token.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+
+        with patch(
+            "app.services.auth_service.refresh_token_repository",
+            autospec=True,
+        ) as mock_rt_repo:
+
+            mock_rt_repo.get_by_token = AsyncMock(return_value=mock_refresh_token)
+            mock_rt_repo.delete_by_token = AsyncMock()
+            mock_rt_repo.create = AsyncMock()
+
+            new_access_token, new_refresh_token = await service.refresh(
+                mock_db, "valid-refresh-token"
+            )
+
+            assert new_access_token is not None
+            assert new_refresh_token is not None


### PR DESCRIPTION
## Summary
- 7 unit tests for `AuthService` (login, refresh, logout)
- 7 integration tests for auth endpoints (POST /auth/login, POST /auth/logout, POST /auth/refresh)

## Test plan
- [x] All 14 tests passing
- [x] Unit tests use `autospec=True` mocking
- [x] Integration tests use real test DB with savepoint-based rollback isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)