### PR TITLE
test(be-us-003): add backend unit and integration tests for user service

### DIFF
--- a/apps/backend/tests/integration/api/test_user_endpoints.py
+++ b/apps/backend/tests/integration/api/test_user_endpoints.py
@@ -1,0 +1,61 @@
+import pytest
+from passlib.context import CryptContext
+
+from app.enums.user_role import UserRole
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class TestDeactivateUser:
+
+    async def test_deactivate_user_returns_204_when_id_is_valid(
+        self, authenticated_client, db_session
+    ):
+        target_user = User(
+            email="target@test.com",
+            role=UserRole.EMPLOYEE,
+            first_name="Target",
+            last_name="User",
+            password_hash=pwd_context.hash("password123"),
+            is_active=True,
+        )
+        db_session.add(target_user)
+        await db_session.flush()
+
+        response = await authenticated_client.patch(
+            f"/api/v1/users/{target_user.id}/deactivate"
+        )
+
+        assert response.status_code == 204
+
+    async def test_deactivate_user_returns_400_when_deactivating_self(
+        self, authenticated_client, hr_admin_user
+    ):
+        response = await authenticated_client.patch(
+            f"/api/v1/users/{hr_admin_user.id}/deactivate"
+        )
+
+        assert response.status_code == 400
+
+    async def test_deactivate_user_returns_404_when_user_not_found(
+        self, authenticated_client
+    ):
+        import uuid
+        response = await authenticated_client.patch(
+            f"/api/v1/users/{uuid.uuid4()}/deactivate"
+        )
+
+        assert response.status_code == 404
+
+    async def test_deactivate_user_returns_401_when_not_authenticated(
+        self, client
+    ):
+        import uuid
+        response = await client.patch(
+            f"/api/v1/users/{uuid.uuid4()}/deactivate"
+        )
+
+        assert response.status_code == 401

--- a/apps/backend/tests/unit/services/test_user_service.py
+++ b/apps/backend/tests/unit/services/test_user_service.py
@@ -1,0 +1,68 @@
+import uuid
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.user_service import UserService
+from app.errors import NotFoundError, ValidationError
+
+
+@pytest.fixture
+def service():
+    return UserService()
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+class TestDeactivateUser:
+
+    async def test_deactivate_user_deactivates_when_id_is_valid(
+        self, service, mock_db
+    ):
+        user_id = uuid.uuid4()
+        current_user_id = uuid.uuid4()
+        mock_user = MagicMock()
+
+        with patch(
+            "app.services.user_service.user_repository",
+            autospec=True,
+        ) as mock_user_repo, patch(
+            "app.services.user_service.refresh_token_repository",
+            autospec=True,
+        ) as mock_rt_repo:
+
+            mock_user_repo.get_by_id = AsyncMock(return_value=mock_user)
+            mock_rt_repo.delete_by_user_id = AsyncMock()
+
+            await service.deactivate_user(mock_db, user_id, current_user_id)
+
+            assert mock_user.is_active is False
+
+    async def test_deactivate_user_raises_error_when_deactivating_self(
+        self, service, mock_db
+    ):
+        user_id = uuid.uuid4()
+
+        with pytest.raises(ValidationError):
+            await service.deactivate_user(mock_db, user_id, user_id)
+
+    async def test_deactivate_user_raises_error_when_user_not_found(
+        self, service, mock_db
+    ):
+        user_id = uuid.uuid4()
+        current_user_id = uuid.uuid4()
+
+        with patch(
+            "app.services.user_service.user_repository",
+            autospec=True,
+        ) as mock_user_repo:
+
+            mock_user_repo.get_by_id = AsyncMock(return_value=None)
+
+            with pytest.raises(NotFoundError):
+                await service.deactivate_user(mock_db, user_id, current_user_id)


### PR DESCRIPTION
## Summary
- 3 unit tests for `UserService` (deactivate_user)
- 4 integration tests for user endpoints (PATCH /users/{id}/deactivate)

## Test plan
- [x] All 7 tests passing
- [x] Unit tests use `autospec=True` mocking
- [x] Integration tests use real test DB with savepoint-based rollback isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)