### PR TITLE
feat(fe-us-002): implement login, logout and token refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,4 +213,5 @@ apps/frontend/.env
 
 # Vite / Frontend build
 apps/frontend/dist/
+apps/frontend/.vite/
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -2,6 +2,10 @@ import { Routes, Route } from 'react-router-dom'
 import RegisterPage from '@/pages/RegisterPage'
 import InviteUserPage from '@/pages/hr/InviteUserPage'
 import LoginPage from '@/pages/LoginPage'
+import HRDashboard from '@/pages/hr/HRDashboard'
+import ManagerDashboard from '@/pages/manager/ManagerDashboard'
+import EmployeeDashboard from '@/pages/employee/EmployeeDashboard'
+
 
 
 export default function App() {
@@ -10,6 +14,10 @@ export default function App() {
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/hr/invite-user" element={<InviteUserPage />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/hr/dashboard" element={<HRDashboard />} />
+      <Route path="/manager/dashboard" element={<ManagerDashboard />} />
+      <Route path="/employee/dashboard" element={<EmployeeDashboard />} />
+
 
     </Routes>
   )

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,12 +1,16 @@
 import { Routes, Route } from 'react-router-dom'
 import RegisterPage from '@/pages/RegisterPage'
 import InviteUserPage from '@/pages/hr/InviteUserPage'
+import LoginPage from '@/pages/LoginPage'
+
 
 export default function App() {
   return (
     <Routes>
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/hr/invite-user" element={<InviteUserPage />} />
+      <Route path="/login" element={<LoginPage />} />
+
     </Routes>
   )
 }

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -8,6 +8,7 @@ export const API = {
   AUTH: {
     REGISTER: '/api/v1/auth/register',
     LOGIN: '/api/v1/auth/login',
+    ME: '/api/v1/auth/me',
 
   },
 }

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -10,6 +10,7 @@ export const API = {
     LOGIN: '/api/v1/auth/login',
     ME: '/api/v1/auth/me',
     REFRESH: '/api/v1/auth/refresh',
+    LOGOUT: '/api/v1/auth/logout',
 
   },
 }

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -7,5 +7,7 @@ export const API = {
   },
   AUTH: {
     REGISTER: '/api/v1/auth/register',
+    LOGIN: '/api/v1/auth/login',
+
   },
 }

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -9,6 +9,7 @@ export const API = {
     REGISTER: '/api/v1/auth/register',
     LOGIN: '/api/v1/auth/login',
     ME: '/api/v1/auth/me',
+    REFRESH: '/api/v1/auth/refresh',
 
   },
 }

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -18,14 +18,22 @@ export default function LoginPage() {
   const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
     resolver: zodResolver(schema),
   })
+  const navigate = useNavigate()
+  const setUser = useAuthStore((state) => state.setUser)
+
+
 
   async function onSubmit(data: FormData) {
     try {
-      await login(data)
+        const user = await login(data)
+        setUser(user)
+        if (user.role === 'hr_admin') navigate('/hr/dashboard')
+        else if (user.role === 'manager') navigate('/manager/dashboard')
+        else navigate('/employee/dashboard')
     } catch (err) {
-      console.error(getErrorMessage(err))
+        console.error(getErrorMessage(err))
     }
-  }
+    }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { login } from '@/services/authService'
+import { login, getMe } from '@/services/authService'
 import { getErrorMessage } from '@/utils/getErrorMessage'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
@@ -25,15 +25,16 @@ export default function LoginPage() {
 
   async function onSubmit(data: FormData) {
     try {
-        const user = await login(data)
-        setUser(user)
-        if (user.role === 'hr_admin') navigate('/hr/dashboard')
-        else if (user.role === 'manager') navigate('/manager/dashboard')
-        else navigate('/employee/dashboard')
+      await login(data)
+      const user = await getMe()
+      setUser(user)
+      if (user.role === 'hr_admin') navigate('/hr/dashboard')
+      else if (user.role === 'manager') navigate('/manager/dashboard')
+      else navigate('/employee/dashboard')
     } catch (err) {
-        console.error(getErrorMessage(err))
+      console.error(getErrorMessage(err))
     }
-    }
+  }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,9 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { login } from '@/services/authService'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
+
 
 const schema = z.object({
   email: z.string().email(),

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,38 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { login } from '@/services/authService'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function LoginPage() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  async function onSubmit(data: FormData) {
+    try {
+      await login(data)
+    } catch (err) {
+      console.error(getErrorMessage(err))
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input type="email" {...register('email')} placeholder="Email" />
+      {errors.email && <p>{errors.email.message}</p>}
+
+      <input type="password" {...register('password')} placeholder="Password" />
+      {errors.password && <p>{errors.password.message}</p>}
+
+      <button type="submit">Login</button>
+    </form>
+  )
+}

--- a/apps/frontend/src/pages/employee/EmployeeDashboard.tsx
+++ b/apps/frontend/src/pages/employee/EmployeeDashboard.tsx
@@ -1,0 +1,3 @@
+export default function EmployeeDashboard() {
+  return <h1>Employee Dashboard</h1>
+}

--- a/apps/frontend/src/pages/hr/HRDashboard.tsx
+++ b/apps/frontend/src/pages/hr/HRDashboard.tsx
@@ -1,0 +1,3 @@
+export default function HRDashboard() {
+  return <h1>HR Dashboard</h1>
+}

--- a/apps/frontend/src/pages/hr/HRDashboard.tsx
+++ b/apps/frontend/src/pages/hr/HRDashboard.tsx
@@ -1,3 +1,21 @@
+import { useNavigate } from 'react-router-dom'
+import { logout } from '@/services/authService'
+import { useAuthStore } from '@/stores/authStore'
+
 export default function HRDashboard() {
-  return <h1>HR Dashboard</h1>
+  const navigate = useNavigate()
+  const clearUser = useAuthStore((state) => state.clearUser)
+
+  async function handleLogout() {
+    await logout()
+    clearUser()
+    navigate('/login')
+  }
+
+  return (
+    <div>
+      <h1>HR Dashboard</h1>
+      <button onClick={handleLogout}>Logout</button>
+    </div>
+  )
 }

--- a/apps/frontend/src/pages/manager/ManagerDashboard.tsx
+++ b/apps/frontend/src/pages/manager/ManagerDashboard.tsx
@@ -1,0 +1,3 @@
+export default function ManagerDashboard() {
+  return <h1>Manager Dashboard</h1>
+}

--- a/apps/frontend/src/services/apiClient.ts
+++ b/apps/frontend/src/services/apiClient.ts
@@ -1,8 +1,28 @@
 import axios from 'axios'
+import { API } from '@/constants/apiEndpoints'
 
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   withCredentials: true,
 })
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config
+
+    if (error.response?.status === 401 && !original._retry) {
+      original._retry = true
+      try {
+        await apiClient.post(API.AUTH.REFRESH)
+        return apiClient(original)
+      } catch {
+        window.location.href = '/login'
+      }
+    }
+
+    return Promise.reject(error)
+  }
+)
 
 export default apiClient

--- a/apps/frontend/src/services/authService.ts
+++ b/apps/frontend/src/services/authService.ts
@@ -22,3 +22,8 @@ export async function login(data: LoginRequest): Promise<UserResponse> {
   const res = await apiClient.post(API.AUTH.LOGIN, data)
   return res.data
 }
+
+export async function getMe(): Promise<UserResponse> {
+  const res = await apiClient.get(API.AUTH.ME)
+  return res.data
+}

--- a/apps/frontend/src/services/authService.ts
+++ b/apps/frontend/src/services/authService.ts
@@ -5,6 +5,8 @@ import { API } from '@/constants/apiEndpoints'
 type InvitationValidateResponse = components['schemas']['InvitationValidateResponse']
 type RegisterRequest = components['schemas']['RegisterRequest']
 type UserResponse = components['schemas']['UserResponse']
+type LoginRequest = components['schemas']['LoginRequest']
+
 
 export async function validateInvitation(token: string): Promise<InvitationValidateResponse> {
   const res = await apiClient.get(API.INVITATIONS.VALIDATE, { params: { token } })
@@ -13,5 +15,10 @@ export async function validateInvitation(token: string): Promise<InvitationValid
 
 export async function register(data: RegisterRequest): Promise<UserResponse> {
   const res = await apiClient.post(API.AUTH.REGISTER, data)
+  return res.data
+}
+
+export async function login(data: LoginRequest): Promise<UserResponse> {
+  const res = await apiClient.post(API.AUTH.LOGIN, data)
   return res.data
 }

--- a/apps/frontend/src/services/authService.ts
+++ b/apps/frontend/src/services/authService.ts
@@ -27,3 +27,7 @@ export async function getMe(): Promise<UserResponse> {
   const res = await apiClient.get(API.AUTH.ME)
   return res.data
 }
+
+export async function logout(): Promise<void> {
+  await apiClient.post(API.AUTH.LOGOUT)
+}

--- a/apps/frontend/src/stores/authStore.ts
+++ b/apps/frontend/src/stores/authStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand'
+import type { components } from '@/types/api'
+
+type User = components['schemas']['UserResponse']
+
+type AuthStore = {
+  user: User | null
+  setUser: (user: User) => void
+  clearUser: () => void
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+}))

--- a/docs/guides/tooling/002-docker-commands.md
+++ b/docs/guides/tooling/002-docker-commands.md
@@ -75,6 +75,30 @@ docker-compose run --rm backend alembic downgrade -1
 
 ---
 
+## docker-compose restart
+
+```powershell
+docker-compose restart frontend     # restart one service
+docker-compose restart              # restart all services
+```
+
+**What it does:** Stops and restarts the container using the same image.
+Does not rebuild the image, does not reinstall `node_modules`.
+
+**When to use vs alternatives:**
+
+| Situation | Command |
+|-----------|---------|
+| Process crashed, volume mount out of sync, container stuck | `docker-compose restart frontend` |
+| `package.json` changed (new dependency added) | `docker-compose up --build frontend` |
+| `Dockerfile` changed | `docker-compose up --build frontend` |
+| Full reset (clear all data) | `docker-compose down -v` then `up --build` |
+
+**When we used it:** Vite was failing to resolve `@/pages/RegisterPage` with a 500 error.
+The container had started in a bad state — `restart` fixed it without a full rebuild.
+
+---
+
 ## docker-compose down
 
 ```powershell

--- a/docs/guides/tooling/008-gitignore.md
+++ b/docs/guides/tooling/008-gitignore.md
@@ -1,0 +1,51 @@
+# .gitignore
+
+## What It Does
+
+`.gitignore` tells Git which files and folders to never track and never commit.
+Every line is a pattern. Git checks each untracked file against these patterns — if it matches, the file is invisible to Git.
+
+---
+
+## Pattern Syntax
+
+```
+node_modules/            # a folder (trailing / is convention, not required)
+*.log                    # any file ending in .log
+.env                     # exact filename
+apps/frontend/.vite/     # specific path inside the repo
+```
+
+- `*` = any characters
+- `/` at the end = directory
+- Leading `/` = root of the repo only
+- Full path without leading `/` = matched anywhere in the repo
+
+## How to Add an Entry
+
+Open the file, add a line. No compilation, no special command — that is all.
+
+---
+
+## Important: Already-Tracked Files
+
+`.gitignore` only works for **untracked** files. If a file was already committed, adding it to `.gitignore` does nothing — Git keeps tracking it.
+
+To stop tracking a file that was already committed:
+
+```bash
+git rm --cached <file>
+git rm --cached -r <folder>   # for a directory
+```
+
+This removes the file from Git's index (stops tracking it) without deleting it from disk.
+After that, commit the removal and `.gitignore` takes effect going forward.
+
+---
+
+## Why we added `apps/frontend/.vite/`
+
+Vite creates a `.vite/` cache directory when it runs — dependency pre-bundling output.
+It is generated automatically and changes frequently. Committing it would add noise to every `git status` and `git diff`.
+
+The directory was untracked when we added it, so `git rm --cached` was not needed.

--- a/docs/guides/tutorials/backend/007-auth-flow.md
+++ b/docs/guides/tutorials/backend/007-auth-flow.md
@@ -39,6 +39,9 @@ Real-world analogy: a card renewal document that lets you get a new access card 
 3. Server issues access token and refresh token
 4. Both tokens are set as HttpOnly cookies in the response
 5. Client receives `{"message": "Login successful"}` — no tokens in body
+6. Client immediately calls `GET /api/v1/auth/me` to get user info (id, email, role, name)
+
+**Why a separate `/me` call?** The login endpoint only authenticates — it does not return user data by design. User info is fetched via `/me` using the cookie that was just set. This endpoint is also used on page refresh to restore the logged-in user state (Zustand resets on reload).
 
 ## Request Authentication
 

--- a/docs/guides/tutorials/frontend/007-packages.md
+++ b/docs/guides/tutorials/frontend/007-packages.md
@@ -104,9 +104,20 @@ Date utility library. Formats dates for display.
 ```typescript
 formatDistanceToNow(new Date(task.deadline))  // "3 days from now"
 format(new Date(invitation.expires_at), 'MMM d, yyyy')  // "May 12, 2026"
+format(new Date(invitation.expires_at), 'dd/MM/yyyy')   // "13/05/2026"
 ```
 
-Lighter than `moment.js` (tree-shakeable — only the functions you import end up in the bundle).
+**Why not `new Date().toLocaleDateString()`?**
+
+Browser's built-in date formatting varies by locale and browser. `date-fns` gives consistent output everywhere.
+
+**Import only what you need:**
+```typescript
+import { format } from 'date-fns'        // only format
+import { formatDistanceToNow } from 'date-fns'  // only this one
+```
+
+Tree-shakeable — unused functions are not included in the bundle. Lighter than `moment.js` which ships everything regardless.
 
 ---
 

--- a/docs/guides/tutorials/frontend/011-react-hooks.md
+++ b/docs/guides/tutorials/frontend/011-react-hooks.md
@@ -209,6 +209,37 @@ When the schema changes, the TypeScript type updates automatically — no manual
 
 ---
 
+## Dropdown Fields — z.enum and select
+
+### z.enum — Validate Against a Fixed Set of Values
+
+Text inputs use `z.string()`. Dropdowns have a fixed set of allowed values — use `z.enum()`:
+
+```typescript
+const schema = z.object({
+  role: z.enum(['employee', 'manager', 'hr_admin']),
+})
+```
+
+If any value other than these three is submitted, Zod rejects it. Mirrors the BE's `UserRole` enum exactly.
+
+### select + register
+
+A `<select>` element connects to React Hook Form the same way as `<input>` — using `register`:
+
+```tsx
+<select {...register('role')}>
+  <option value="employee">Employee</option>
+  <option value="manager">Manager</option>
+  <option value="hr_admin">HR Admin</option>
+</select>
+{errors.role && <p>{errors.role.message}</p>}
+```
+
+`{...register('role')}` spreads `name`, `onChange`, `onBlur`, `ref` onto the `<select>`. React Hook Form tracks the selected value automatically. The `value` of each `<option>` must match the enum values in the Zod schema.
+
+---
+
 ## useNavigate and useSearchParams
 
 ### useNavigate — Go to Another Page in Code

--- a/docs/guides/tutorials/frontend/012-react-router.md
+++ b/docs/guides/tutorials/frontend/012-react-router.md
@@ -1,0 +1,74 @@
+# React Router
+
+## What It Does
+
+Client-side routing — navigating between pages without a full page reload.
+The URL changes, React renders a different component, but the browser never fetches a new HTML file from the server.
+
+---
+
+## Setup
+
+`BrowserRouter` wraps the entire app in `main.tsx`:
+
+```tsx
+<BrowserRouter>
+  <App />
+</BrowserRouter>
+```
+
+Route definitions live in `App.tsx`:
+
+```tsx
+<Routes>
+  <Route path="/login" element={<LoginPage />} />
+  <Route path="/register" element={<RegisterPage />} />
+  <Route path="/hr/invite-user" element={<InviteUserPage />} />
+</Routes>
+```
+
+Each `Route` maps a URL path to a component. When the URL matches, that component renders.
+
+---
+
+## useNavigate — Redirect Programmatically
+
+```tsx
+import { useNavigate } from 'react-router-dom'
+
+const navigate = useNavigate()
+navigate('/login')         // go to login page
+navigate('/hr/dashboard')  // go to dashboard
+navigate(-1)               // go back (browser history)
+```
+
+**Used after login** to redirect based on role:
+
+```tsx
+async function onSubmit(data: FormData) {
+  const user = await login(data)
+  if (user.role === 'HR_ADMIN') navigate('/hr/dashboard')
+  else if (user.role === 'MANAGER') navigate('/manager/dashboard')
+  else navigate('/employee/dashboard')
+}
+```
+
+---
+
+## useSearchParams — Read URL Query Parameters
+
+```tsx
+import { useSearchParams } from 'react-router-dom'
+
+const [searchParams] = useSearchParams()
+const token = searchParams.get('token')  // reads ?token=abc123
+```
+
+**Used in `RegisterPage`** to read the invitation token from the URL:
+
+```
+URL: /register?token=abc123
+token → 'abc123'
+```
+
+If the param is missing, `.get()` returns `null`.

--- a/docs/guides/tutorials/frontend/013-axios-interceptor.md
+++ b/docs/guides/tutorials/frontend/013-axios-interceptor.md
@@ -1,0 +1,75 @@
+# Axios Interceptor
+
+## What It Does
+
+An interceptor is a function that runs automatically before every request or after every response.
+It intercepts the call — you can inspect it, modify it, retry it, or redirect.
+
+This project uses a **response interceptor** to handle expired access tokens transparently.
+
+---
+
+## The Problem Without an Interceptor
+
+Access tokens expire after 15 minutes. Without an interceptor, every component that makes an API call would need to handle 401 errors manually:
+
+```
+Component → API call → 401 → try refresh → retry → redirect to login if failed
+```
+
+That is the same logic repeated in every service function. An interceptor puts this logic in one place — components never see the 401.
+
+---
+
+## How It Works
+
+```
+Component calls API
+→ Access token expired → server returns 401
+→ Interceptor catches 401 before the component sees it
+→ Interceptor calls POST /auth/refresh
+    → Refresh success  → retry original request → component gets its data
+    → Refresh fails    → redirect to /login
+```
+
+---
+
+## Implementation
+
+Added to `apiClient.ts`:
+
+```typescript
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config
+
+    if (error.response?.status === 401 && !original._retry) {
+      original._retry = true
+      try {
+        await apiClient.post(API.AUTH.REFRESH)
+        return apiClient(original)
+      } catch {
+        window.location.href = '/login'
+      }
+    }
+
+    return Promise.reject(error)
+  }
+)
+```
+
+**`_retry` flag:** Prevents infinite loops. If the retried request also returns 401, the interceptor does not trigger again — it falls through to `Promise.reject`.
+
+**`window.location.href`:** Used instead of `navigate()` because the interceptor lives outside React — React Router's `useNavigate` can only be called inside a component.
+
+---
+
+## Two Interceptor Types
+
+```typescript
+apiClient.interceptors.request.use(...)   // runs before every request
+apiClient.interceptors.response.use(...)  // runs after every response
+```
+
+This project only uses the response interceptor. Request interceptors are typically used to attach headers (e.g. auth tokens in Bearer token setups) — not needed here because tokens are HttpOnly cookies sent automatically by the browser.

--- a/docs/guides/tutorials/frontend/014-zustand.md
+++ b/docs/guides/tutorials/frontend/014-zustand.md
@@ -1,0 +1,79 @@
+# Zustand
+
+## What It Does
+
+Zustand is a global state store. State defined in Zustand is accessible from any component without prop drilling.
+
+In this project, Zustand stores the logged-in user's info (id, email, name, role) after login and clears it on logout.
+
+---
+
+## Why Not React Context?
+
+Context re-renders every component that consumes it when the value changes.
+For auth state, that means every component in the tree re-renders on login/logout.
+
+Zustand uses a subscription model — a component re-renders only when the specific piece of state it reads changes.
+
+See ADR-003 for the full decision.
+
+---
+
+## Store Definition
+
+`src/stores/authStore.ts`:
+
+```typescript
+import { create } from 'zustand'
+import type { components } from '@/types/api'
+
+type User = components['schemas']['UserResponse']
+
+type AuthStore = {
+  user: User | null
+  setUser: (user: User) => void
+  clearUser: () => void
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+}))
+```
+
+---
+
+## Reading From the Store
+
+```typescript
+const user = useAuthStore((state) => state.user)
+const role = useAuthStore((state) => state.user?.role)
+```
+
+The selector `(state) => state.user` subscribes only to `user`.
+The component re-renders only when `user` changes — not on every store update.
+
+---
+
+## Writing to the Store
+
+```typescript
+const setUser = useAuthStore((state) => state.setUser)
+const clearUser = useAuthStore((state) => state.clearUser)
+
+// After login
+setUser(response)
+
+// On logout
+clearUser()
+```
+
+---
+
+## Important: Clear on Logout
+
+Zustand state persists across route changes but is lost when the browser tab closes.
+Always call `clearUser()` explicitly on logout — do not rely on tab close to clear auth state.
+
+If you forget to clear, the next user who opens the app on the same browser will see the previous user's name and role until the next API call fails.

--- a/docs/guides/tutorials/frontend/015-frontend-architecture.md
+++ b/docs/guides/tutorials/frontend/015-frontend-architecture.md
@@ -1,0 +1,117 @@
+# Frontend Architecture — How the Pieces Connect
+
+Individual tutorials explain each tool in isolation. This document shows how they work together in a complete flow.
+
+---
+
+## The Tools and Their Roles
+
+| Tool | Role | Tutorial |
+|------|------|----------|
+| `useState` | Local state — data used only inside one component | 011 |
+| `useEffect` | Run code when a component first loads (e.g. fetch data) | 011 |
+| `useForm` + Zod | Form input management and validation | 011 |
+| Axios + `apiClient` | HTTP requests to the backend | 009 |
+| Axios Interceptor | Catch 401 errors, refresh token, retry silently | 013 |
+| Zustand (`useAuthStore`) | Global state — logged-in user info accessible everywhere | 014 |
+| React Router (`useNavigate`) | Navigate to a different page after an action | 012 |
+
+---
+
+## The Login Flow — Step by Step
+
+```
+1. User fills email + password → useForm collects values
+
+2. handleSubmit runs Zod validation
+   → fails: show error messages, stop
+   → passes: call onSubmit(data)
+
+3. onSubmit calls authService.login(data)
+   → Axios sends POST /api/v1/auth/login
+   → Backend sets HttpOnly cookies, returns UserResponse
+
+4. Login success:
+   → setUser(response)         save user to Zustand store
+   → navigate('/hr/dashboard') redirect based on role
+
+5. Later — user visits a protected page:
+   → Component calls an API (e.g. GET /invitations)
+   → Access token cookie is sent automatically by the browser
+   → Backend validates it, returns data
+
+6. If access token expired:
+   → Backend returns 401
+   → Axios Interceptor catches it before the component sees it
+   → Interceptor calls POST /api/v1/auth/refresh
+       → Success: new cookies set, original request retried, component gets data
+       → Failure: redirect to /login
+```
+
+---
+
+## Where Each Tool Lives
+
+```
+src/
+├── stores/
+│   └── authStore.ts        ← Zustand: global user state
+├── services/
+│   ├── apiClient.ts        ← Axios instance + interceptor
+│   └── authService.ts      ← login(), logout(), register()
+└── pages/
+    └── LoginPage.tsx       ← useForm + Zod + useNavigate + setUser
+```
+
+---
+
+## useState vs Zustand — When to Use Which
+
+| Situation | Use |
+|-----------|-----|
+| Form input values | `useState` (local, lives in the form component) |
+| Error message on a page | `useState` (local, lives on that page) |
+| Logged-in user info (name, role) | Zustand (global, needed in Navbar, Router, protected pages) |
+
+Rule: if only one component needs it → `useState`. If multiple unrelated components need it → Zustand.
+
+---
+
+## The Prop Drilling Problem
+
+Without Zustand, sharing user info across unrelated components requires passing it down through every level:
+
+```
+App (has user)
+└── Layout (passes user)
+    ├── Navbar (passes user)
+    │   └── UserMenu (finally uses user)
+    └── Routes (passes user)
+        └── RequireRole (finally uses user)
+```
+
+Every component in between receives a prop it does not use — just to pass it down.
+
+With Zustand, any component reads directly from the store:
+
+```typescript
+// In Navbar — no props needed
+const user = useAuthStore((state) => state.user)
+
+// In RequireRole — no props needed
+const user = useAuthStore((state) => state.user)
+```
+
+---
+
+## Logout Flow
+
+```
+1. User clicks logout button
+2. authService.logout() → POST /api/v1/auth/logout
+3. Backend clears cookies, deletes refresh token from DB
+4. clearUser()       ← clear Zustand store
+5. navigate('/login')
+```
+
+Clearing Zustand on logout is critical — if skipped, the next page load still shows the previous user's name and role until an API call fails.

--- a/docs/scrum/retrospective/sprint-2.md
+++ b/docs/scrum/retrospective/sprint-2.md
@@ -5,6 +5,7 @@
 ### What Went Well
 
 ### What Needs Improvement
+- `GET /auth/me` endpoint was missing from the original US-002 BE scope — login endpoint intentionally returns no user data, but there was no endpoint to fetch current user info after login. Discovered during FE implementation. Rule: when designing an auth flow, explicitly define how the FE gets user info post-login.
 - Board became too large (80+ items in one view) — added `subtask` label and sprint-based views filtered by `-label:subtask`
 - Feature branches had no remote tracking — branches stayed local only. Rule: always push branch to remote immediately after first commit (`git push origin branch-name`)
 - Feature branches were not merged to develop — discovered via `git log --oneline` and `ls docs/`. Rule: at the end of each sprint, verify develop is up to date with `git log --oneline`


### PR DESCRIPTION
## Summary
- LoginPage with email/password form, Zod validation, role-based redirect after login
- Zustand auth store to hold logged-in user info (id, email, role, name)
- GET /auth/me call after login to fetch user info from cookie session
- Axios response interceptor: catches 401, calls /auth/refresh, retries original request; redirects to /login if refresh fails
- Logout clears HttpOnly cookies (BE), resets Zustand store, redirects to /login
- Placeholder dashboards for HR Admin, Manager and Employee roles