### PR TITLE
test(fe): add component tests for US-001, US-002 and US-003

### DIFF
--- a/apps/frontend/src/components/RequireRole.test.tsx
+++ b/apps/frontend/src/components/RequireRole.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import RequireRole from './RequireRole'
+import { useAuthStore } from '@/stores/authStore'
+
+const mockHrAdmin = { id: '1', email: 'hr@example.com', first_name: 'HR', last_name: 'Admin', role: 'hr_admin' as const }
+const mockEmployee = { id: '2', email: 'emp@example.com', first_name: 'Emp', last_name: 'User', role: 'employee' as const }
+
+function renderWithRoutes(roles: ('hr_admin' | 'manager' | 'employee')[]) {
+  render(
+    <MemoryRouter initialEntries={['/protected']}>
+      <Routes>
+        <Route element={<RequireRole roles={roles} />}>
+          <Route path="/protected" element={<div>Protected Content</div>} />
+        </Route>
+        <Route path="/login" element={<div>Login Page</div>} />
+        <Route path="/403" element={<div>Forbidden Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('RequireRole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.setState({ user: null, isLoading: false })
+  })
+
+  it('renders nothing while loading', () => {
+    useAuthStore.setState({ user: null, isLoading: true })
+
+    renderWithRoutes(['hr_admin'])
+
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument()
+  })
+
+  it('redirects to login when user is not authenticated', () => {
+    useAuthStore.setState({ user: null, isLoading: false })
+
+    renderWithRoutes(['hr_admin'])
+
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+  })
+
+  it('redirects to 403 when user role is not allowed', () => {
+    useAuthStore.setState({ user: mockEmployee, isLoading: false })
+
+    renderWithRoutes(['hr_admin'])
+
+    expect(screen.getByText('Forbidden Page')).toBeInTheDocument()
+  })
+
+  it('renders outlet when user role is allowed', () => {
+    useAuthStore.setState({ user: mockHrAdmin, isLoading: false })
+
+    renderWithRoutes(['hr_admin'])
+
+    expect(screen.getByText('Protected Content')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/auth/pages/LoginPage.test.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import LoginPage from './LoginPage'
+
+const mockNavigate = vi.fn()
+const { mockAuthServiceLogin, mockAuthServiceGetMe } = vi.hoisted(() => ({
+  mockAuthServiceLogin: vi.fn(),
+  mockAuthServiceGetMe: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@/features/auth/services/authService', () => ({
+  login: mockAuthServiceLogin,
+  getMe: mockAuthServiceGetMe,
+}))
+
+const mockHrAdmin = { id: '1', email: 'hr@example.com', first_name: 'HR', last_name: 'Admin', role: 'hr_admin' as const }
+const mockManager = { id: '2', email: 'mgr@example.com', first_name: 'Manager', last_name: 'User', role: 'manager' as const }
+const mockEmployee = { id: '3', email: 'emp@example.com', first_name: 'Employee', last_name: 'User', role: 'employee' as const }
+
+function renderPage(search = '') {
+  render(
+    <MemoryRouter initialEntries={[`/login${search}`]}>
+      <LoginPage />
+    </MemoryRouter>,
+  )
+}
+
+async function fillAndSubmit(email: string, password: string) {
+  await userEvent.type(screen.getByPlaceholderText(/email/i), email)
+  await userEvent.type(screen.getByPlaceholderText(/password/i), password)
+  await userEvent.click(screen.getByRole('button', { name: /login/i }))
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthServiceLogin.mockResolvedValue(undefined)
+  })
+
+  it('renders email and password inputs', () => {
+    renderPage()
+
+    expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument()
+  })
+
+  it('shows error message from URL error param', () => {
+    renderPage('?error=USER_DEACTIVATED')
+
+    expect(screen.getByText('Your account has been deactivated. Please contact your HR Admin.')).toBeInTheDocument()
+  })
+
+  it('navigates to HR dashboard on successful login as hr_admin', async () => {
+    mockAuthServiceGetMe.mockResolvedValue(mockHrAdmin)
+
+    renderPage()
+    await fillAndSubmit('hr@example.com', 'password123')
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/hr/dashboard')
+    })
+  })
+
+  it('navigates to manager dashboard on successful login as manager', async () => {
+    mockAuthServiceGetMe.mockResolvedValue(mockManager)
+
+    renderPage()
+    await fillAndSubmit('mgr@example.com', 'password123')
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/manager/dashboard')
+    })
+  })
+
+  it('navigates to employee dashboard on successful login as employee', async () => {
+    mockAuthServiceGetMe.mockResolvedValue(mockEmployee)
+
+    renderPage()
+    await fillAndSubmit('emp@example.com', 'password123')
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/employee/dashboard')
+    })
+  })
+})

--- a/apps/frontend/src/features/invitation/pages/InviteUserPage.test.tsx
+++ b/apps/frontend/src/features/invitation/pages/InviteUserPage.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import InviteUserPage from './InviteUserPage'
+
+const { mockInvitationServiceGetInvitations, mockInvitationServiceCreate, mockInvitationServiceResend } = vi.hoisted(
+  () => ({
+    mockInvitationServiceGetInvitations: vi.fn(),
+    mockInvitationServiceCreate: vi.fn(),
+    mockInvitationServiceResend: vi.fn(),
+  }),
+)
+
+vi.mock('@/features/invitation/services/invitationService', () => ({
+  getInvitations: mockInvitationServiceGetInvitations,
+  createInvitation: mockInvitationServiceCreate,
+  resendInvitation: mockInvitationServiceResend,
+}))
+
+const mockInvitation = {
+  id: 'inv-1',
+  email: 'newuser@example.com',
+  role: 'employee' as const,
+  expires_at: '2026-06-01T00:00:00Z',
+}
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <InviteUserPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('InviteUserPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvitationServiceGetInvitations.mockResolvedValue([])
+  })
+
+  it('displays pending invitations on load', async () => {
+    mockInvitationServiceGetInvitations.mockResolvedValue([mockInvitation])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/newuser@example.com/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows success message after sending invitation', async () => {
+    mockInvitationServiceCreate.mockResolvedValue(mockInvitation)
+    mockInvitationServiceGetInvitations.mockResolvedValue([mockInvitation])
+
+    renderPage()
+
+    await userEvent.type(screen.getByPlaceholderText(/email/i), 'newuser@example.com')
+    await userEvent.click(screen.getByRole('button', { name: /send invitation/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Invitation sent successfully.')).toBeInTheDocument()
+    })
+  })
+
+  it('calls resendInvitation when resend button is clicked', async () => {
+    mockInvitationServiceGetInvitations.mockResolvedValue([mockInvitation])
+    mockInvitationServiceResend.mockResolvedValue(mockInvitation)
+
+    renderPage()
+
+    await waitFor(() => screen.getByText(/newuser@example.com/i))
+
+    await userEvent.click(screen.getByRole('button', { name: /resend/i }))
+
+    await waitFor(() => {
+      expect(mockInvitationServiceResend).toHaveBeenCalledWith('inv-1')
+    })
+  })
+})

--- a/apps/frontend/src/features/invitation/pages/RegisterPage.test.tsx
+++ b/apps/frontend/src/features/invitation/pages/RegisterPage.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import RegisterPage from './RegisterPage'
+
+const mockNavigate = vi.fn()
+const { mockAuthServiceValidateInvitation, mockAuthServiceRegister } = vi.hoisted(() => ({
+  mockAuthServiceValidateInvitation: vi.fn(),
+  mockAuthServiceRegister: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@/features/auth/services/authService', () => ({
+  validateInvitation: mockAuthServiceValidateInvitation,
+  register: mockAuthServiceRegister,
+}))
+
+const mockUser = {
+  id: '1',
+  email: 'invited@example.com',
+  first_name: 'Jane',
+  last_name: 'Doe',
+  role: 'employee' as const,
+}
+
+function renderWithToken(token: string) {
+  render(
+    <MemoryRouter initialEntries={[`/register?token=${token}`]}>
+      <RegisterPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('pre-fills email from token validation', async () => {
+    mockAuthServiceValidateInvitation.mockResolvedValue({ email: mockUser.email, role: mockUser.role })
+
+    renderWithToken('valid-token')
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(mockUser.email)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message when token is expired', async () => {
+    mockAuthServiceValidateInvitation.mockRejectedValue({
+      response: { data: { error_code: 'INVITATION_EXPIRED' } },
+    })
+
+    renderWithToken('expired-token')
+
+    await waitFor(() => {
+      expect(screen.getByText('This invitation link has expired.')).toBeInTheDocument()
+    })
+  })
+
+  it('navigates to login on successful registration', async () => {
+    mockAuthServiceValidateInvitation.mockResolvedValue({ email: mockUser.email, role: mockUser.role })
+    mockAuthServiceRegister.mockResolvedValue(mockUser)
+
+    renderWithToken('valid-token')
+
+    await waitFor(() => screen.getByDisplayValue(mockUser.email))
+
+    await userEvent.type(screen.getByPlaceholderText(/first name/i), 'Jane')
+    await userEvent.type(screen.getByPlaceholderText(/last name/i), 'Doe')
+    await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123')
+    await userEvent.click(screen.getByRole('button', { name: /register/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login')
+    })
+  })
+})

--- a/apps/frontend/src/features/users/pages/HRDashboard.test.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import HRDashboard from './HRDashboard'
+import { useAuthStore } from '@/stores/authStore'
+
+const mockNavigate = vi.fn()
+const { mockUserServiceGetUsers, mockUserServiceDeactivate, mockAuthServiceLogout } = vi.hoisted(() => ({
+  mockUserServiceGetUsers: vi.fn(),
+  mockUserServiceDeactivate: vi.fn(),
+  mockAuthServiceLogout: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@/features/users/services/userService', () => ({
+  getUsers: mockUserServiceGetUsers,
+  deactivateUser: mockUserServiceDeactivate,
+}))
+
+vi.mock('@/features/auth/services/authService', () => ({
+  logout: mockAuthServiceLogout,
+}))
+
+const mockCurrentUser = { id: '1', email: 'hr@example.com', first_name: 'HR', last_name: 'Admin', role: 'hr_admin' as const }
+const mockOtherUser = { id: '2', email: 'emp@example.com', first_name: 'John', last_name: 'Doe', role: 'employee' as const }
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <HRDashboard />
+    </MemoryRouter>,
+  )
+}
+
+describe('HRDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.setState({ user: mockCurrentUser, isLoading: false })
+    mockUserServiceGetUsers.mockResolvedValue([mockCurrentUser, mockOtherUser])
+    mockUserServiceDeactivate.mockResolvedValue(undefined)
+    mockAuthServiceLogout.mockResolvedValue(undefined)
+  })
+
+  it('displays user list on load', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/john doe/i)).toBeInTheDocument()
+    })
+  })
+
+  it('removes user from list after deactivation', async () => {
+    renderPage()
+
+    await waitFor(() => screen.getByText(/john doe/i))
+
+    await userEvent.click(screen.getByRole('button', { name: /deactivate/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/john doe/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('navigates to login after logout', async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole('button', { name: /logout/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login')
+    })
+  })
+})

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -18,8 +18,8 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "tests", "vite.config.ts"],
   "exclude": ["node_modules"]
 }

--- a/docs/guides/tutorials/frontend/003-vitest.md
+++ b/docs/guides/tutorials/frontend/003-vitest.md
@@ -175,12 +175,30 @@ apps/frontend/
 
 ## Running Tests
 
+All commands are run from the **monorepo root**:
+
 ```powershell
-# Run once (CI mode)
-pnpm test
+# Run all frontend tests once (CI mode)
+pnpm --filter frontend test
+
+# Run a single test file
+pnpm --filter frontend test -- src/features/auth/pages/LoginPage.test.tsx
 
 # Watch mode (development)
+pnpm --filter frontend test:watch
+```
+
+From inside `apps/frontend/` directly:
+
+```powershell
+# Run all tests
+pnpm test
+
+# Run a single test file
+pnpm test -- src/features/auth/pages/LoginPage.test.tsx
+
+# Watch mode
 pnpm test:watch
 ```
 
-Both commands use `vitest.config.ts` explicitly via `--config vitest.config.ts`.
+All commands use `vitest.config.ts` explicitly via `--config vitest.config.ts`.


### PR DESCRIPTION
## Summary

- Add component tests for all Sprint 2 FE user stories (18 tests across 5 files)
- Establish FE test conventions (co-located files, naming, mock naming)
- Update docs to reflect feature-based architecture and co-located test structure

## Test Coverage

| File | US | Tests |
|---|---|---|
| `RegisterPage.test.tsx` | US-001 | 3 |
| `InviteUserPage.test.tsx` | US-001 | 3 |
| `LoginPage.test.tsx` | US-002 | 5 |
| `RequireRole.test.tsx` | US-003 | 4 |
| `HRDashboard.test.tsx` | US-003 | 3 |

## Docs Updated

- `009-fe-test-conventions.md` — new file, FE test conventions
- `008-be-test-conventions.md` — renamed from `008-test-conventions.md`
- `003-vitest.md` — co-located structure, running tests commands
- `009-services-and-constants.md` — updated paths to feature-based architecture
- `product-vision.md` — updated FE monorepo structure
- `sprint-2 retrospective` — test decisions documented

## Test plan

- [ ] Run `pnpm --filter frontend test` — all 18 tests pass
