### PR TITLE
Test/fe e2e : add Playwright E2E test infrastructure and Sprint 2 UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,10 @@ apps/frontend/.env
 apps/frontend/dist/
 apps/frontend/.vite/
 
+# Playwright
+apps/frontend/playwright-report/
+apps/frontend/test-results/
+
+# pnpm Docker store
+apps/frontend/.pnpm-store/
+

--- a/README.md
+++ b/README.md
@@ -8,12 +8,10 @@ StepUp streamlines the process of onboarding new employees — structured task a
 
 ## Status
 
-🚧 **In active development** — Sprint 1 complete, Sprint 2 (Auth) next
-
 | Sprint | Theme | Status |
 |---|---|---|
 | Sprint 1 | Infrastructure | ✅ Complete |
-| Sprint 2 | Authentication & Authorization | 🔄 BE Complete, FE Pending |
+| Sprint 2 | Authentication & Authorization | ✅ Complete |
 | Sprint 3 | User & Department Management | — |
 | Sprint 4 | Onboarding Template Management | — |
 | Sprint 5 | Onboarding Plan & Task Workflow | — |
@@ -27,25 +25,13 @@ Sprint progress is tracked on the [StepUp Board](https://github.com/users/aykutc
 
 ---
 
-## Sprint 1 — What's Done
-
-| US | Description |
-|---|---|
-| US-006 | Monorepo setup (Turborepo + pnpm) |
-| US-007 | Docker + docker-compose local environment |
-| US-008 | GCP project (Cloud Run, Cloud SQL, Secret Manager) |
-| US-009 | GitHub Actions CI pipeline |
-| US-010 | Database schema + Alembic initial migration |
-
----
-
 ## Tech Stack
 
 | Layer | Technology |
 |---|---|
 | **Backend** | Python 3.11, FastAPI, SQLAlchemy 2.0, Alembic |
 | **Database** | PostgreSQL 15 |
-| **Frontend** | React 18, TypeScript, Tailwind CSS, shadcn/ui |
+| **Frontend** | React 18, TypeScript, Tailwind CSS |
 | **Infrastructure** | Docker, GCP Cloud Run, GCP Cloud SQL, GCP Secret Manager |
 | **CI/CD** | GitHub Actions |
 | **Package Manager** | pnpm (monorepo with Turborepo) |
@@ -59,24 +45,30 @@ stepup/
   apps/
     backend/          # FastAPI application
       app/
-        core/         # Config, database connection
+        api/          # Route handlers
+        core/         # Config, database, limiter
         models/       # SQLAlchemy models
+        services/     # Business logic
+        repositories/ # Database queries
+        schemas/      # Pydantic schemas
       alembic/        # Database migrations
+      scripts/        # Seed and utility scripts
+      tests/          # Unit and integration tests
     frontend/         # React 18 + TypeScript application
       src/
-        components/   # Reusable UI components
-        pages/        # Route-based pages (hr/, manager/, employee/)
-        hooks/        # Custom React hooks
-        services/     # API call functions
-        store/        # Zustand stores
-        types/        # TypeScript types
-        constants/    # Routes, API endpoints, error messages
-  packages/
-    shared-types/     # Shared TypeScript types
+        app/          # App entry, routing
+        components/   # Shared UI components
+        constants/    # Routes, API endpoints, messages
+        features/     # Feature-based modules (auth, invitation, users)
+        lib/          # API client
+        stores/       # Zustand stores
+        types/        # Generated API types
+      tests/
+        e2e/          # Playwright E2E tests
   docs/
-    product-vision.md # Full product specification
-    guides/           # Technical guides (Docker, Git, FastAPI, Alembic, etc.)
     adr/              # Architecture Decision Records
+    postmortems/      # Debug and incident records
+    guides/           # Technical guides
     scrum/            # Sprint planning and retrospectives
   docker-compose.yml
   turbo.json
@@ -89,43 +81,109 @@ stepup/
 ### Prerequisites
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [Node.js 18+](https://nodejs.org/)
 - [pnpm](https://pnpm.io/installation)
 
-### Setup
+### First-time setup
 
 ```bash
 # 1. Clone the repository
 git clone https://github.com/aykutcihan/stepup.git
 cd stepup
 
-# 2. Start the database
-docker-compose up -d db
+# 2. Install frontend dependencies
+pnpm install
 
-# 3. Run database migrations
+# 3. Create frontend env file
+echo "VITE_API_URL=" > apps/frontend/.env
+
+# 4. Run database migrations
 docker-compose run --rm backend alembic upgrade head
 
-# 4. Start all services
-docker-compose up
+# 5. Seed the database with test users
+docker-compose run --rm backend python scripts/seed.py
 ```
 
-### Services
+### Running the app
+
+There are two ways to run the app locally. The hybrid approach is recommended for active frontend development.
+
+#### Option A — Hybrid (recommended for FE development)
+
+Backend and database run in Docker. Frontend runs locally for instant hot reload.
+
+**Terminal 1:**
+```bash
+docker-compose up db backend
+```
+
+**Terminal 2:**
+```bash
+pnpm --filter frontend dev
+```
 
 | Service | URL |
 |---|---|
+| Frontend | http://localhost:5173 |
 | Backend API | http://localhost:8000 |
 | Swagger UI | http://localhost:8000/docs |
-| Frontend | http://localhost:3000 |
 | Database | localhost:5433 |
 
-> Port 5433 is used instead of the default 5432 (conflict with local PostgreSQL).
+#### Option B — Full Docker
 
-### Useful Commands
+Everything runs in Docker containers.
+
+```bash
+docker-compose up db backend frontend
+```
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:3000 |
+| Backend API | http://localhost:8000 |
+| Swagger UI | http://localhost:8000/docs |
+| Database | localhost:5433 |
+
+> Port 5433 is used instead of the default 5432 to avoid conflicts with a locally installed PostgreSQL.
+
+### Test users
+
+After running the seed script, the following users are available:
+
+| Email | Password | Role |
+|---|---|---|
+| admin@stepup.com | Admin1234! | HR Admin |
+| manager@stepup.com | Manager1234! | Manager |
+| employee@stepup.com | Employee1234! | Employee |
+
+---
+
+## E2E Tests
+
+E2E tests run entirely inside Docker using Playwright.
+
+```bash
+# Run migrations and seed (once, or after DB reset)
+docker-compose run --rm backend alembic upgrade head
+
+# Run all E2E tests
+docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
+
+# Run a specific test file
+docker-compose run --rm playwright sh -c "pnpm install && pnpm exec playwright test tests/e2e/login.spec.ts"
+```
+
+The `seeder` service runs automatically as part of the Playwright dependency chain — no manual seed step needed when running E2E tests.
+
+---
+
+## Useful Commands
 
 ```bash
 # Run database migrations
 docker-compose run --rm backend alembic upgrade head
 
-# Seed the database with initial data
+# Seed the database
 docker-compose run --rm backend python scripts/seed.py
 
 # Create a new migration after model changes
@@ -140,26 +198,11 @@ docker-compose logs -f backend
 # Rebuild backend image (after requirements.txt changes)
 docker-compose build backend
 
-# Run all backend tests
-docker exec stepup-backend python -m pytest --tb=short -q
+# Run backend tests
+docker-compose run --rm backend pytest --tb=short -q
 
-# Run only unit tests
-docker exec stepup-backend python -m pytest tests/unit --tb=short -q
-
-# Run only integration tests
-docker exec stepup-backend python -m pytest tests/integration --tb=short -q
-
-# Start frontend (first time or after Dockerfile changes)
-docker-compose up frontend --build
-
-# Start frontend (subsequent runs)
-docker-compose up frontend
-
-# View frontend logs
-docker-compose logs -f frontend
-
-# Run frontend tests
-docker-compose run --rm frontend node_modules/.bin/vitest run --config vitest.config.ts --passWithNoTests
+# Run frontend unit tests
+pnpm --filter frontend test
 ```
 
 ---
@@ -168,10 +211,11 @@ docker-compose run --rm frontend node_modules/.bin/vitest run --config vitest.co
 
 | Document | Description |
 |---|---|
-| [`docs/product-vision.md`](./docs/product-vision.md) | Full product specification, user roles, workflows, architecture |
-| [`docs/scrum/`](./docs/scrum/) | Sprint goals, refinement notes, reviews, retrospectives |
-| [`docs/guides/`](./docs/guides/) | Technical guides (FastAPI, Docker, Git, Alembic, SQLAlchemy, etc.) |
+| [`docs/product-vision.md`](./docs/product-vision.md) | Full product specification, user roles, workflows |
 | [`docs/adr/`](./docs/adr/) | Architecture Decision Records |
+| [`docs/postmortems/`](./docs/postmortems/) | Debug and incident records |
+| [`docs/guides/`](./docs/guides/) | Technical guides (FastAPI, Docker, Git, Alembic, etc.) |
+| [`docs/scrum/`](./docs/scrum/) | Sprint goals, refinement notes, reviews, retrospectives |
 
 ---
 
@@ -182,8 +226,8 @@ main        → production (stable, merged at sprint end)
 develop     → integration branch
 feature/    → one branch per issue (feature/us-001-invite-user)
 fix/        → bug fixes
-test/be-    → backend tests for a user story (test/be-us-001-invitation-service)
-test/fe-    → frontend tests for a user story (test/fe-us-001-invite-form)
+test/be-    → backend tests (test/be-us-001-invitation-service)
+test/fe-    → frontend tests (test/fe-us-001-invite-form)
 ```
 
 All changes go through Pull Requests into `develop`.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,11 @@ After running the seed script, the following users are available:
 
 ## E2E Tests
 
-E2E tests run entirely inside Docker using Playwright.
+Two modes are available depending on the context.
+
+### Docker (CI / pre-push)
+
+Runs in an isolated container — same environment as CI. Slower due to Vite cold start (~5 min for full suite).
 
 ```bash
 # Run migrations and seed (once, or after DB reset)
@@ -173,7 +177,31 @@ docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
 docker-compose run --rm playwright sh -c "pnpm install && pnpm exec playwright test tests/e2e/login.spec.ts"
 ```
 
-The `seeder` service runs automatically as part of the Playwright dependency chain — no manual seed step needed when running E2E tests.
+The `seeder` service runs automatically as part of the Playwright dependency chain — no manual seed step needed.
+
+### Local (during development)
+
+Runs against the local Vite dev server. Much faster (~1-2 min) since Vite is already warm.
+
+**Prerequisites:** backend running (`docker-compose up db backend`) and frontend running (`pnpm --filter frontend dev`).
+
+```bash
+# First-time setup: install browser binary
+pnpm --filter frontend exec playwright install chromium
+
+# Run all E2E tests locally
+pnpm --filter frontend e2e:local
+
+# Run a specific test file
+pnpm --filter frontend exec playwright test --config apps/frontend/playwright.config.local.ts tests/e2e/login.spec.ts
+```
+
+| | Docker | Local |
+|---|---|---|
+| Speed | ~5 min | ~1-2 min |
+| Workers | 1 | 2 |
+| Test timeout | 120s | 30s |
+| Use when | CI, pre-push | Active development |
 
 ---
 

--- a/apps/backend/app/api/v1/auth.py
+++ b/apps/backend/app/api/v1/auth.py
@@ -10,7 +10,7 @@ from app.schemas.user import RegisterRequest, UserResponse
 from app.services.auth_service import AuthService
 from app.services.invitation_service import InvitationService
 
-from app.core.limiter import limiter
+from app.core.limiter import limiter, LOGIN_RATE_LIMIT
 
 router = APIRouter()
 invitation_service = InvitationService()
@@ -33,7 +33,7 @@ async def register(
 
 
 @router.post("/login", status_code=status.HTTP_200_OK)
-@limiter.limit("5/minute")
+@limiter.limit(LOGIN_RATE_LIMIT)
 async def login(
     request: Request,
     data: LoginRequest,

--- a/apps/backend/app/core/limiter.py
+++ b/apps/backend/app/core/limiter.py
@@ -1,4 +1,7 @@
+import os
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
 limiter = Limiter(key_func=get_remote_address)
+LOGIN_RATE_LIMIT = os.getenv("LOGIN_RATE_LIMIT", "5/minute")

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -4,6 +4,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 from app.api.router import api_router
+from app.core.config import settings
 from app.core.limiter import limiter
 from app.errors.handlers import register_error_handlers
 
@@ -20,7 +21,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=[settings.FRONTEND_URL, "http://localhost:5173"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/apps/backend/scripts/seed.py
+++ b/apps/backend/scripts/seed.py
@@ -15,14 +15,32 @@ from app.core.config import settings
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-HR_ADMIN = {
-    "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
-    "email": "admin@stepup.com",
-    "password": "Admin1234!",
-    "first_name": "HR",
-    "last_name": "Admin",
-    "role": UserRole.HR_ADMIN,
-}
+SEED_USERS = [
+    {
+        "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        "email": "admin@stepup.com",
+        "password": "Admin1234!",
+        "first_name": "HR",
+        "last_name": "Admin",
+        "role": UserRole.HR_ADMIN,
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        "email": "manager@stepup.com",
+        "password": "Manager1234!",
+        "first_name": "Manager",
+        "last_name": "User",
+        "role": UserRole.MANAGER,
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0000-000000000003"),
+        "email": "employee@stepup.com",
+        "password": "Employee1234!",
+        "first_name": "Employee",
+        "last_name": "User",
+        "role": UserRole.EMPLOYEE,
+    },
+]
 
 
 async def seed():
@@ -30,26 +48,28 @@ async def seed():
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as session:
-        result = await session.execute(
-            select(User).where(User.email == HR_ADMIN["email"])
-        )
-        existing = result.scalar_one_or_none()
+        for seed_user in SEED_USERS:
+            result = await session.execute(
+                select(User).where(User.email == seed_user["email"])
+            )
+            existing = result.scalar_one_or_none()
 
-        if existing:
-            print(f"Seed user already exists: {HR_ADMIN['email']}")
-            return
+            if existing:
+                print(f"Seed user already exists: {seed_user['email']}")
+                continue
 
-        user = User(
-            id=HR_ADMIN["id"],
-            email=HR_ADMIN["email"],
-            password_hash=pwd_context.hash(HR_ADMIN["password"]),
-            first_name=HR_ADMIN["first_name"],
-            last_name=HR_ADMIN["last_name"],
-            role=HR_ADMIN["role"],
-        )
-        session.add(user)
+            user = User(
+                id=seed_user["id"],
+                email=seed_user["email"],
+                password_hash=pwd_context.hash(seed_user["password"]),
+                first_name=seed_user["first_name"],
+                last_name=seed_user["last_name"],
+                role=seed_user["role"],
+            )
+            session.add(user)
+            print(f"Seed user created: {seed_user['email']} / {seed_user['password']}")
+
         await session.commit()
-        print(f"Seed user created: {HR_ADMIN['email']} / {HR_ADMIN['password']}")
 
     await engine.dispose()
 

--- a/apps/backend/scripts/seed.py
+++ b/apps/backend/scripts/seed.py
@@ -1,17 +1,19 @@
 import asyncio
+import os
+import sys
 import uuid
+
 from passlib.context import CryptContext
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import select
-import sys
-import os
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.user import User
 from app.enums.user_role import UserRole
-from app.core.config import settings
+
+DATABASE_URL = os.environ["DATABASE_URL"]
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -44,7 +46,7 @@ SEED_USERS = [
 
 
 async def seed():
-    engine = create_async_engine(settings.DATABASE_URL)
+    engine = create_async_engine(DATABASE_URL)
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as session:

--- a/apps/frontend/Dockerfile.e2e
+++ b/apps/frontend/Dockerfile.e2e
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/playwright:v1.49.0-noble
+RUN npm install -g pnpm@10

--- a/apps/frontend/Dockerfile.e2e
+++ b/apps/frontend/Dockerfile.e2e
@@ -1,2 +1,2 @@
-FROM mcr.microsoft.com/playwright:v1.49.0-noble
+FROM mcr.microsoft.com/playwright:v1.59.1-noble
 RUN npm install -g pnpm@10

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run --config vitest.config.ts --passWithNoTests",
     "test:watch": "vitest --config vitest.config.ts",
     "generate-types": "openapi-typescript http://backend:8000/openapi.json -o src/types/api.ts",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "e2e:local": "playwright test --config playwright.config.local.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src",
     "test": "vitest run --config vitest.config.ts --passWithNoTests",
     "test:watch": "vitest --config vitest.config.ts",
-    "generate-types": "openapi-typescript http://backend:8000/openapi.json -o src/types/api.ts"
+    "generate-types": "openapi-typescript http://backend:8000/openapi.json -o src/types/api.ts",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -44,6 +45,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
     "vite": "^6.0.5",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "@playwright/test": "^1.49.0"
   }
 }

--- a/apps/frontend/playwright.config.local.ts
+++ b/apps/frontend/playwright.config.local.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30000,
+  expect: {
+    timeout: 10000,
+  },
+  workers: 2,
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+})

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/e2e',
+  timeout: 120000,
+  expect: {
+    timeout: 15000,
+  },
+  workers: 1,
   use: {
     baseURL: 'http://frontend:3000',
   },

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://frontend:3000',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+})

--- a/apps/frontend/pnpm-lock.yaml
+++ b/apps/frontend/pnpm-lock.yaml
@@ -7,15 +7,6 @@ settings:
 importers:
 
   .:
-    devDependencies:
-      prettier:
-        specifier: ^3.0.0
-        version: 3.8.3
-      turbo:
-        specifier: latest
-        version: 2.9.9
-
-  apps/frontend:
     dependencies:
       '@hookform/resolvers':
         specifier: ^3.9.1
@@ -703,36 +694,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@turbo/darwin-64@2.9.9':
-    resolution: {integrity: sha512-hTEiNu2ABZZOO1qbjnKASI8eF3BdOOzU6iKv5w5uGOK65DDMc10cS40N1kqM99YT0uSAGUwNu6GdFctRPeEeVA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@turbo/darwin-arm64@2.9.9':
-    resolution: {integrity: sha512-MinO40EEcP5mJiTVpfjtEulsEBhVeryfq21QhYtJZ8hQJLHGgy459rcmDVAY8/JERe4dkVU4KW+zoLF22o01EA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@turbo/linux-64@2.9.9':
-    resolution: {integrity: sha512-7JNLw88Isk+gMlbsC8pulLDkrqe2B827ZsKFEHilb17AC6Xn/62pzH7afjY7fEU6Ayp4XP/vGhlRWOzqBvBvIQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@turbo/linux-arm64@2.9.9':
-    resolution: {integrity: sha512-0pnXDwPw1rHii98JZPRg7SvsjIzy7jrhkwGU9Jy5fVYoMdYd3P2vbtLfII+OJ0Mm4Ar5yykdHDTz3RWiRI1o9g==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@turbo/windows-64@2.9.9':
-    resolution: {integrity: sha512-vjDQycz4gQVvIq4n2rPtiiIESwJlAc406qtkiZlqyL+fHZEd9SxYNlBIFYtc5cuMuwrk+sIKrhN7XvwjmvS9YQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@turbo/windows-arm64@2.9.9':
-    resolution: {integrity: sha512-V6NiH43oCctepbOdQFp7UjqLyK8p6Tt824QA+G4TE+B1BBHu80A0W8OCL+H7uBJ3XZjAj/hvPDw3k3l65DoDGw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -756,6 +717,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1009,8 +973,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1127,8 +1091,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.349:
-    resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
+  electron-to-chromium@1.5.352:
+    resolution: {integrity: sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1762,11 +1726,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2015,10 +1974,6 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-
-  turbo@2.9.9:
-    resolution: {integrity: sha512-3xfzXE/yTjhh0S5dIWlE+3E+J9A09REpLI1ZqVh2+HrNZoVzZn0pkvjiRgVK/Ev3PF9XnaTwCntTx+CADWXcyA==}
-    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2719,24 +2674,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@turbo/darwin-64@2.9.9':
-    optional: true
-
-  '@turbo/darwin-arm64@2.9.9':
-    optional: true
-
-  '@turbo/linux-64@2.9.9':
-    optional: true
-
-  '@turbo/linux-arm64@2.9.9':
-    optional: true
-
-  '@turbo/windows-64@2.9.9':
-    optional: true
-
-  '@turbo/windows-arm64@2.9.9':
-    optional: true
-
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -2768,6 +2705,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3009,7 +2948,7 @@ snapshots:
   autoprefixer@10.5.0(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      caniuse-lite: 1.0.30001791
+      caniuse-lite: 1.0.30001792
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.14
@@ -3051,8 +2990,8 @@ snapshots:
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.27
-      caniuse-lite: 1.0.30001791
-      electron-to-chromium: 1.5.349
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.352
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -3067,7 +3006,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001791: {}
+  caniuse-lite@1.0.30001792: {}
 
   chai@5.3.3:
     dependencies:
@@ -3172,7 +3111,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.349: {}
+  electron-to-chromium@1.5.352: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3258,7 +3197,7 @@ snapshots:
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -3304,7 +3243,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -3793,8 +3732,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.3: {}
-
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4062,15 +3999,6 @@ snapshots:
       typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
-
-  turbo@2.9.9:
-    optionalDependencies:
-      '@turbo/darwin-64': 2.9.9
-      '@turbo/darwin-arm64': 2.9.9
-      '@turbo/linux-64': 2.9.9
-      '@turbo/linux-arm64': 2.9.9
-      '@turbo/windows-64': 2.9.9
-      '@turbo/windows-arm64': 2.9.9
 
   type-check@0.4.0:
     dependencies:

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -15,14 +15,15 @@ import { useAuthStore } from '@/stores/authStore'
 
 export default function App() {
   const setUser = useAuthStore((state) => state.setUser)
+  const clearUser = useAuthStore((state) => state.clearUser)
   const setLoading = useAuthStore((state) => state.setLoading)
 
   useEffect(() => {
     getMe()
       .then(setUser)
-      .catch(() => {})
+      .catch(() => clearUser())
       .finally(() => setLoading(false))
-  }, [])
+  }, [setUser, clearUser, setLoading])
 
   return (
     <Routes>

--- a/apps/frontend/src/components/DashboardLayout.tsx
+++ b/apps/frontend/src/components/DashboardLayout.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { logout } from '@/features/auth/services/authService'
+import { useAuthStore } from '@/stores/authStore'
+import { ROUTES } from '@/constants/routes'
+
+const ROLE_LABELS: Record<string, string> = {
+  hr_admin: 'HR Admin',
+  manager: 'Manager',
+  employee: 'Employee',
+}
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  const user = useAuthStore((state) => state.user)
+  const clearUser = useAuthStore((state) => state.clearUser)
+  const navigate = useNavigate()
+
+  async function handleLogout() {
+    await logout()
+    clearUser()
+    navigate(ROUTES.LOGIN)
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <nav className="bg-blue-800 text-white px-6 py-3 flex items-center justify-between shadow-md">
+        <span className="text-xl font-bold tracking-tight">StepUp</span>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-blue-200">
+            {user?.first_name} {user?.last_name}
+          </span>
+          <span className="text-xs bg-blue-600 px-2.5 py-0.5 rounded-full font-medium uppercase tracking-wide">
+            {ROLE_LABELS[user?.role ?? ''] ?? user?.role}
+          </span>
+          <button
+            onClick={handleLogout}
+            className="text-sm bg-white/10 hover:bg-white/20 px-3 py-1.5 rounded-lg transition-colors font-medium"
+          >
+            Logout
+          </button>
+        </div>
+      </nav>
+      <main className="p-6">{children}</main>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/ForbiddenPage.tsx
+++ b/apps/frontend/src/components/ForbiddenPage.tsx
@@ -1,3 +1,37 @@
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
+import { ROUTES } from '@/constants/routes'
+import { USER_ROLES } from '@/constants/userRoles'
+
 export default function ForbiddenPage() {
-  return <h1>403 — You do not have permission to access this page.</h1>
+  const navigate = useNavigate()
+  const user = useAuthStore((state) => state.user)
+
+  function handleBack() {
+    if (!user) {
+      navigate(ROUTES.LOGIN)
+      return
+    }
+    if (user.role === USER_ROLES.HR_ADMIN) navigate(ROUTES.HR_DASHBOARD)
+    else if (user.role === USER_ROLES.MANAGER) navigate(ROUTES.MANAGER_DASHBOARD)
+    else navigate(ROUTES.EMPLOYEE_DASHBOARD)
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+      <div className="text-center">
+        <p className="text-8xl font-extrabold text-blue-800 mb-4">403</p>
+        <h1 className="text-xl font-semibold text-gray-900 mb-2">Access denied</h1>
+        <p className="text-sm text-gray-500 mb-8">
+          You do not have permission to access this page.
+        </p>
+        <button
+          onClick={handleBack}
+          className="bg-blue-700 hover:bg-blue-800 text-white text-sm font-medium px-5 py-2.5 rounded-lg transition-colors"
+        >
+          Go to my dashboard
+        </button>
+      </div>
+    </div>
+  )
 }

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -13,7 +13,7 @@ export const API = {
     LOGOUT: '/api/v1/auth/logout',
   },
   USERS: {
-    LIST: '/api/v1/users',
+    LIST: '/api/v1/users/',
     DEACTIVATE: (id: string) => `/api/v1/users/${id}/deactivate`,
   },
 }

--- a/apps/frontend/src/features/auth/pages/LoginPage.test.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.test.tsx
@@ -38,7 +38,7 @@ function renderPage(search = '') {
 async function fillAndSubmit(email: string, password: string) {
   await userEvent.type(screen.getByPlaceholderText(/email/i), email)
   await userEvent.type(screen.getByPlaceholderText(/password/i), password)
-  await userEvent.click(screen.getByRole('button', { name: /login/i }))
+  await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
 }
 
 describe('LoginPage', () => {

--- a/apps/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/apps/frontend/src/features/auth/pages/LoginPage.tsx
@@ -4,15 +4,63 @@ export default function LoginPage() {
   const { register, handleSubmit, errors, onSubmit, pageError } = useLoginForm()
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      {pageError && <p>{pageError}</p>}
-      <input type="email" {...register('email')} placeholder="Email" />
-      {errors.email && <p>{errors.email.message}</p>}
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-blue-800 rounded-t-2xl px-8 py-6 text-white text-center">
+          <h1 className="text-2xl font-bold tracking-tight">StepUp</h1>
+          <p className="text-blue-200 text-sm mt-1">Human Resources Platform</p>
+        </div>
 
-      <input type="password" {...register('password')} placeholder="Password" />
-      {errors.password && <p>{errors.password.message}</p>}
+        <div className="bg-white rounded-b-2xl shadow-lg px-8 py-8 border border-t-0 border-gray-100">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Welcome back</h2>
+          <p className="text-sm text-gray-500 mb-6">Sign in to your account to continue.</p>
 
-      <button type="submit">Login</button>
-    </form>
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+            {pageError && (
+              <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+                {pageError}
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                Email address
+              </label>
+              <input
+                type="email"
+                {...register('email')}
+                placeholder="Email"
+                className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+              {errors.email && (
+                <p className="mt-1.5 text-xs text-red-600">{errors.email.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                Password
+              </label>
+              <input
+                type="password"
+                {...register('password')}
+                placeholder="Password"
+                className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+              {errors.password && (
+                <p className="mt-1.5 text-xs text-red-600">{errors.password.message}</p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              className="w-full bg-blue-700 hover:bg-blue-800 text-white font-medium py-2.5 rounded-lg transition-colors text-sm mt-2"
+            >
+              Sign in
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/apps/frontend/src/features/invitation/pages/RegisterPage.test.tsx
+++ b/apps/frontend/src/features/invitation/pages/RegisterPage.test.tsx
@@ -77,7 +77,7 @@ describe('RegisterPage', () => {
     await userEvent.type(screen.getByPlaceholderText(/first name/i), 'Jane')
     await userEvent.type(screen.getByPlaceholderText(/last name/i), 'Doe')
     await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123')
-    await userEvent.click(screen.getByRole('button', { name: /register/i }))
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/login')

--- a/apps/frontend/src/features/invitation/pages/RegisterPage.tsx
+++ b/apps/frontend/src/features/invitation/pages/RegisterPage.tsx
@@ -4,19 +4,88 @@ export default function RegisterPage() {
   const { registerField, handleSubmit, errors, onSubmit, email, pageError } = useRegisterForm()
 
   return (
-    <div>
-      <h1>Complete Registration</h1>
-      {pageError && <p>{pageError}</p>}
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <input value={email} readOnly placeholder="Email" />
-        <input {...registerField('first_name')} placeholder="First name" />
-        {errors.first_name && <p>{errors.first_name.message}</p>}
-        <input {...registerField('last_name')} placeholder="Last name" />
-        {errors.last_name && <p>{errors.last_name.message}</p>}
-        <input {...registerField('password')} type="password" placeholder="Password" />
-        {errors.password && <p>{errors.password.message}</p>}
-        <button type="submit">Register</button>
-      </form>
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-blue-800 rounded-t-2xl px-8 py-6 text-white text-center">
+          <h1 className="text-2xl font-bold tracking-tight">StepUp</h1>
+          <p className="text-blue-200 text-sm mt-1">Complete your registration</p>
+        </div>
+
+        <div className="bg-white rounded-b-2xl shadow-lg px-8 py-8 border border-t-0 border-gray-100">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Account details</h2>
+          <p className="text-sm text-gray-500 mb-6">Fill in the fields below to set up your account.</p>
+
+          {pageError && (
+            <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3 mb-5">
+              {pageError}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                Email address
+              </label>
+              <input
+                value={email}
+                readOnly
+                placeholder="Email"
+                className="w-full border border-gray-200 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 bg-gray-50 cursor-not-allowed"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                First name
+              </label>
+              <input
+                {...registerField('first_name')}
+                placeholder="First name"
+                className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+              {errors.first_name && (
+                <p className="mt-1.5 text-xs text-red-600">{errors.first_name.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                Last name
+              </label>
+              <input
+                {...registerField('last_name')}
+                placeholder="Last name"
+                className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+              {errors.last_name && (
+                <p className="mt-1.5 text-xs text-red-600">{errors.last_name.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                Password
+              </label>
+              <input
+                {...registerField('password')}
+                type="password"
+                placeholder="Password"
+                className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+              {errors.password && (
+                <p className="mt-1.5 text-xs text-red-600">{errors.password.message}</p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              className="w-full bg-blue-700 hover:bg-blue-800 text-white font-medium py-2.5 rounded-lg transition-colors text-sm mt-2"
+            >
+              Create account
+            </button>
+          </form>
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
@@ -1,3 +1,24 @@
+import { useAuthStore } from '@/stores/authStore'
+import DashboardLayout from '@/components/DashboardLayout'
+
 export default function EmployeeDashboard() {
-  return <h1>Employee Dashboard</h1>
+  const user = useAuthStore((state) => state.user)
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
+          <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <span className="text-blue-700 text-xl font-bold">
+              {user?.first_name?.[0]}{user?.last_name?.[0]}
+            </span>
+          </div>
+          <h2 className="text-xl font-semibold text-gray-900">
+            Welcome, {user?.first_name}
+          </h2>
+          <p className="text-sm text-gray-500 mt-2">You're signed in as Employee.</p>
+        </div>
+      </div>
+    </DashboardLayout>
+  )
 }

--- a/apps/frontend/src/features/users/pages/HRDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { logout } from '@/features/auth/services/authService'
 import { getUsers, deactivateUser } from '@/features/users/services/userService'
 import { useAuthStore } from '@/stores/authStore'
-import { ROUTES } from '@/constants/routes'
+import DashboardLayout from '@/components/DashboardLayout'
 import type { components } from '@/types/api'
 
 type UserResponse = components['schemas']['UserResponse']
 
+const ROLE_LABELS: Record<string, string> = {
+  hr_admin: 'HR Admin',
+  manager: 'Manager',
+  employee: 'Employee',
+}
+
 export default function HRDashboard() {
-  const navigate = useNavigate()
-  const clearUser = useAuthStore((state) => state.clearUser)
   const currentUser = useAuthStore((state) => state.user)
   const [users, setUsers] = useState<UserResponse[]>([])
 
@@ -18,33 +20,67 @@ export default function HRDashboard() {
     getUsers().then(setUsers).catch(() => {})
   }, [])
 
-  async function handleLogout() {
-    await logout()
-    clearUser()
-    navigate(ROUTES.LOGIN)
-  }
-
   async function handleDeactivate(id: string) {
     await deactivateUser(id)
     setUsers((prev) => prev.filter((u) => u.id !== id))
   }
 
   return (
-    <div>
-      <h1>HR Dashboard</h1>
-      <button onClick={handleLogout}>Logout</button>
+    <DashboardLayout>
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold text-gray-900">Team members</h2>
+          <p className="text-sm text-gray-500 mt-0.5">Manage your organisation's users.</p>
+        </div>
 
-      <h2>Users</h2>
-      <ul>
-        {users.map((u) => (
-          <li key={u.id}>
-            {u.first_name} {u.last_name} — {u.email} — {u.role}
-            {u.id !== currentUser?.id && (
-              <button onClick={() => handleDeactivate(u.id)}>Deactivate</button>
-            )}
-          </li>
-        ))}
-      </ul>
-    </div>
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 bg-gray-50 text-left">
+                <th className="px-5 py-3.5 font-medium text-gray-600">Name</th>
+                <th className="px-5 py-3.5 font-medium text-gray-600">Email</th>
+                <th className="px-5 py-3.5 font-medium text-gray-600">Role</th>
+                <th className="px-5 py-3.5 font-medium text-gray-600 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {users.map((u) => (
+                <tr key={u.id} className="hover:bg-slate-50 transition-colors">
+                  <td className="px-5 py-3.5 font-medium text-gray-900">
+                    {u.first_name} {u.last_name}
+                    {u.id === currentUser?.id && (
+                      <span className="ml-2 text-xs text-blue-600 font-normal">(you)</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-3.5 text-gray-600">{u.email}</td>
+                  <td className="px-5 py-3.5">
+                    <span className="inline-block text-xs bg-blue-50 text-blue-700 border border-blue-100 px-2 py-0.5 rounded-full font-medium">
+                      {ROLE_LABELS[u.role] ?? u.role}
+                    </span>
+                  </td>
+                  <td className="px-5 py-3.5 text-right">
+                    {u.id !== currentUser?.id && (
+                      <button
+                        onClick={() => handleDeactivate(u.id)}
+                        className="text-xs text-red-600 hover:text-red-800 border border-red-200 hover:border-red-300 px-3 py-1.5 rounded-lg transition-colors"
+                      >
+                        Deactivate
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {users.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-5 py-8 text-center text-gray-400 text-sm">
+                    No users found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </DashboardLayout>
   )
 }

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -1,3 +1,24 @@
+import { useAuthStore } from '@/stores/authStore'
+import DashboardLayout from '@/components/DashboardLayout'
+
 export default function ManagerDashboard() {
-  return <h1>Manager Dashboard</h1>
+  const user = useAuthStore((state) => state.user)
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
+          <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <span className="text-blue-700 text-xl font-bold">
+              {user?.first_name?.[0]}{user?.last_name?.[0]}
+            </span>
+          </div>
+          <h2 className="text-xl font-semibold text-gray-900">
+            Welcome, {user?.first_name}
+          </h2>
+          <p className="text-sm text-gray-500 mt-2">You're signed in as Manager.</p>
+        </div>
+      </div>
+    </DashboardLayout>
+  )
 }

--- a/apps/frontend/src/lib/apiClient.ts
+++ b/apps/frontend/src/lib/apiClient.ts
@@ -3,7 +3,7 @@ import { API } from '@/constants/apiEndpoints'
 import { ROUTES } from '@/constants/routes'
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_API_URL || '',
   withCredentials: true,
 })
 

--- a/apps/frontend/src/stores/authStore.ts
+++ b/apps/frontend/src/stores/authStore.ts
@@ -11,10 +11,29 @@ type AuthStore = {
   setLoading: (isLoading: boolean) => void
 }
 
+const STORAGE_KEY = 'auth_user'
+
+function loadUser(): User | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as User) : null
+  } catch {
+    return null
+  }
+}
+
+const cachedUser = loadUser()
+
 export const useAuthStore = create<AuthStore>((set) => ({
-  user: null,
-  isLoading: true,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
+  user: cachedUser,
+  isLoading: cachedUser === null,
+  setUser: (user) => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+    set({ user })
+  },
+  clearUser: () => {
+    sessionStorage.removeItem(STORAGE_KEY)
+    set({ user: null })
+  },
   setLoading: (isLoading) => set({ isLoading }),
 }))

--- a/apps/frontend/tests/e2e/login.spec.ts
+++ b/apps/frontend/tests/e2e/login.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+
+async function login(page: any, email: string, password: string) {
+  await page.goto('/login', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByPlaceholder('Email')).toBeVisible()
+  await page.fill('input[placeholder="Email"]', email)
+  await page.fill('input[placeholder="Password"]', password)
+  await page.click('button[type="submit"]')
+}
+
+test('HR Admin logs in, lands on HR dashboard, and logs out', async ({ page }) => {
+  await login(page, 'admin@stepup.com', 'Admin1234!')
+  await page.waitForURL('**/hr/dashboard')
+  await expect(page).toHaveURL('/hr/dashboard')
+
+  await page.click('button:has-text("Logout")')
+  await page.waitForURL('**/login')
+  await expect(page).toHaveURL('/login')
+})
+
+test('Manager logs in and lands on Manager dashboard', async ({ page }) => {
+  await login(page, 'manager@stepup.com', 'Manager1234!')
+  await page.waitForURL('**/manager/dashboard')
+  await expect(page).toHaveURL('/manager/dashboard')
+})
+
+test('Employee logs in and lands on Employee dashboard', async ({ page }) => {
+  await login(page, 'employee@stepup.com', 'Employee1234!')
+  await page.waitForURL('**/employee/dashboard')
+  await expect(page).toHaveURL('/employee/dashboard')
+})
+
+test('wrong password shows error and does not navigate', async ({ page }) => {
+  await login(page, 'admin@stepup.com', 'wrongpassword')
+  await expect(page).toHaveURL('/login')
+})

--- a/apps/frontend/tests/e2e/rbac.spec.ts
+++ b/apps/frontend/tests/e2e/rbac.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+
+async function login(page: any, email: string, password: string) {
+  await page.goto('/login', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByPlaceholder('Email')).toBeVisible()
+  await page.fill('input[placeholder="Email"]', email)
+  await page.fill('input[placeholder="Password"]', password)
+  await page.click('button[type="submit"]')
+}
+
+test('Employee accessing HR dashboard is redirected to 403', async ({ page }) => {
+  await login(page, 'employee@stepup.com', 'Employee1234!')
+  await page.waitForURL('**/employee/dashboard')
+
+  await page.goto('/hr/dashboard')
+  await expect(page).toHaveURL('/403')
+})
+
+test('deactivated user sees deactivation message on login page', async ({ page }) => {
+  await page.goto('/login?error=USER_DEACTIVATED')
+  await expect(page.getByText('Your account has been deactivated. Please contact your HR Admin.')).toBeVisible()
+})

--- a/apps/frontend/tests/e2e/registration.spec.ts
+++ b/apps/frontend/tests/e2e/registration.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test'
+
+test('expired invitation token shows error message', async ({ page }) => {
+  await page.goto('/register?token=expired-or-invalid-token')
+  await expect(page.getByText('This invitation link is invalid.')).toBeVisible()
+})

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
     },
   },
   server: {
+    allowedHosts: ['frontend'],
+    proxy: {
+      '/api': {
+        target: process.env.BACKEND_URL || 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
     watch: {
       usePolling: true,
     },

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
+    exclude: ['tests/e2e/**', 'node_modules/**'],
   },
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       SENDGRID_API_KEY: ${SENDGRID_API_KEY}
       SENDGRID_FROM_EMAIL: ${SENDGRID_FROM_EMAIL}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      LOGIN_RATE_LIMIT: "1000/minute"
     ports:
       - "8000:8000"
     volumes:
@@ -35,12 +36,34 @@ services:
       context: .
       dockerfile: apps/frontend/Dockerfile
     container_name: stepup-frontend
+    environment:
+      BACKEND_URL: http://backend:8000
+      VITE_API_URL: ""
     ports:
       - "3000:3000"
     volumes:
       - ./apps/frontend:/app
       - /app/node_modules
     depends_on:
+      - backend
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('net').createConnection({host:'localhost',port:3000},()=>process.exit(0)).on('error',()=>process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+
+  seeder:
+    build:
+      context: ./apps/backend
+      dockerfile: Dockerfile
+    command: ["python", "scripts/seed.py"]
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+    volumes:
+      - ./apps/backend:/app
+    depends_on:
+      - db
       - backend
 
   playwright:
@@ -52,8 +75,12 @@ services:
     working_dir: /app
     user: root
     depends_on:
-      - frontend
-      - backend
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_started
+      seeder:
+        condition: service_completed_successfully
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,5 +43,17 @@ services:
     depends_on:
       - backend
 
+  playwright:
+    build:
+      context: .
+      dockerfile: apps/frontend/Dockerfile.e2e
+    volumes:
+      - ./apps/frontend:/app
+    working_dir: /app
+    user: root
+    depends_on:
+      - frontend
+      - backend
+
 volumes:
   postgres_data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Architecture Decision Records. Each file documents one decision: the context, th
 | `ADR-005` | Monorepo with Turborepo |
 | `ADR-006` | API versioning strategy |
 | `ADR-007` | Structured logging |
+| `ADR-008` | Playwright E2E tests in a dedicated Docker container |
 
 ---
 

--- a/docs/adr/ADR-008-playwright-docker.md
+++ b/docs/adr/ADR-008-playwright-docker.md
@@ -19,7 +19,9 @@ We run Playwright tests in a **dedicated Docker service** using the official `mc
 
 ```yaml
 playwright:
-  image: mcr.microsoft.com/playwright:v1.49.0-noble
+  build:
+    context: .
+    dockerfile: apps/frontend/Dockerfile.e2e
   volumes:
     - ./apps/frontend:/app
   working_dir: /app
@@ -28,9 +30,15 @@ playwright:
     - backend
 ```
 
+`Dockerfile.e2e` extends the official Playwright image with pnpm:
+```dockerfile
+FROM mcr.microsoft.com/playwright:v1.49.0-noble
+RUN npm install -g pnpm@10
+```
+
 Run command:
 ```powershell
-docker-compose run --rm playwright pnpm e2e
+docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
 ```
 
 ---

--- a/docs/adr/ADR-008-playwright-docker.md
+++ b/docs/adr/ADR-008-playwright-docker.md
@@ -17,7 +17,42 @@ The frontend runs in a `node:18-slim` Docker container. Two options were conside
 
 We run Playwright tests in a **dedicated Docker service** using the official `mcr.microsoft.com/playwright` image, added to `docker-compose.yml`.
 
+### Service chain
+
+```
+db → backend → frontend (healthy) → playwright
+                    ↑
+              seeder (completed)
+```
+
+- `frontend` must pass a TCP healthcheck on port 3000 before `playwright` starts.
+- `seeder` runs seed users into the database and must exit 0 before `playwright` starts.
+- `playwright` depends on both with `condition: service_healthy` / `condition: service_completed_successfully`.
+
+### docker-compose.yml (relevant services)
+
 ```yaml
+frontend:
+  healthcheck:
+    test: ["CMD", "node", "-e", "require('net').createConnection({host:'localhost',port:3000},()=>process.exit(0)).on('error',()=>process.exit(1))"]
+    interval: 5s
+    timeout: 5s
+    retries: 12
+    start_period: 60s
+
+seeder:
+  build:
+    context: ./apps/backend
+    dockerfile: Dockerfile
+  command: ["python", "scripts/seed.py"]
+  environment:
+    DATABASE_URL: ${DATABASE_URL}
+  volumes:
+    - ./apps/backend:/app
+  depends_on:
+    - db
+    - backend
+
 playwright:
   build:
     context: .
@@ -25,21 +60,85 @@ playwright:
   volumes:
     - ./apps/frontend:/app
   working_dir: /app
+  user: root
   depends_on:
-    - frontend
-    - backend
+    frontend:
+      condition: service_healthy
+    backend:
+      condition: service_started
+    seeder:
+      condition: service_completed_successfully
 ```
 
 `Dockerfile.e2e` extends the official Playwright image with pnpm:
 ```dockerfile
-FROM mcr.microsoft.com/playwright:v1.49.0-noble
+FROM mcr.microsoft.com/playwright:v1.59.1-noble
 RUN npm install -g pnpm@10
 ```
 
-Run command:
+### Playwright config
+
+`playwright.config.ts` is configured for the Docker network environment:
+
+```ts
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 120000,
+  expect: { timeout: 15000 },
+  workers: 1,
+  use: {
+    baseURL: 'http://frontend:3000',
+  },
+})
+```
+
+- `baseURL` uses the Docker service hostname `frontend`, not `localhost`.
+- `workers: 1` prevents parallel requests from overwhelming the Vite dev server's cold compilation.
+- `timeout: 120000` accounts for the full login flow through the Vite proxy.
+
+### Vite configuration requirements
+
+`vite.config.ts` requires two additions for Docker E2E to work:
+
+```ts
+server: {
+  allowedHosts: ['frontend'],   // Vite 5 blocks non-localhost hostnames by default
+  proxy: {
+    '/api': {
+      target: process.env.BACKEND_URL || 'http://localhost:8000',
+      changeOrigin: true,
+    },
+  },
+}
+```
+
+`allowedHosts` is required because the Playwright browser accesses Vite via the `frontend` Docker hostname. Without it, Vite returns a blank "Blocked request" page.
+
+The proxy lets the browser call `/api/*` on the same origin (`frontend:3000`) and have Vite forward to the backend container — avoiding cross-origin issues with cookies.
+
+### API client configuration
+
+`apiClient.ts` uses an empty `baseURL` in Docker so requests go through the Vite proxy:
+
+```ts
+baseURL: import.meta.env.VITE_API_URL || '',
+```
+
+`docker-compose.yml` sets `VITE_API_URL: ""` for the frontend service to override the local `.env` value (`http://localhost:8000`). Locally, the `.env` value is used directly for better performance.
+
+### Run procedure
+
+**Prerequisites (run once, or after DB reset):**
+```powershell
+docker-compose run --rm backend alembic upgrade head
+```
+
+**Run E2E tests:**
 ```powershell
 docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
 ```
+
+The `seeder` service runs automatically as part of the dependency chain — no manual seed step required.
 
 ---
 
@@ -47,7 +146,7 @@ docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
 
 **Install Playwright inside the frontend container (`node:18-slim`)**
 
-`node:18-slim` is a minimal image with no browser dependencies. Installing Playwright inside it requires adding dozens of system packages (`libglib2.0-0`, `libnss3`, `libatk1.0-0`, and many more). This bloats the image, increases build time, and makes the Dockerfile harder to maintain. The browser binaries also need to be downloaded separately on every image rebuild.
+`node:18-slim` is a minimal image with no browser dependencies. Installing Playwright inside it requires adding dozens of system packages (`libglib2.0-0`, `libnss3`, `libatk1.0-0`, and many more). This bloats the image, increases build time, and makes the Dockerfile harder to maintain.
 
 ---
 
@@ -56,9 +155,11 @@ docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
 **Gained:**
 - Frontend container stays clean — no browser dependencies or Playwright binaries
 - Official Playwright image has all browser dependencies pre-installed and versioned
+- Seed users are created automatically before tests run
+- Frontend healthcheck ensures Vite is serving before Playwright starts
 - Same pattern as backend tests: `docker-compose run --rm backend pytest` → `docker-compose run --rm playwright pnpm e2e`
-- Playwright version is pinned via the image tag — consistent across all environments
 
 **Trade-offs:**
 - One additional service in `docker-compose.yml`
 - First run pulls the Playwright image (~1.5GB) — one-time cost
+- Vite dev server (not a production build) is used for E2E — first test run is slower due to on-demand module compilation

--- a/docs/adr/ADR-008-playwright-docker.md
+++ b/docs/adr/ADR-008-playwright-docker.md
@@ -1,0 +1,56 @@
+# ADR-008: Playwright E2E Tests in a Dedicated Docker Container
+
+**Date:** 2026-05-07
+**Status:** Accepted
+
+---
+
+## Context
+
+Sprint 2 requires E2E tests covering login, registration, and role-based routing. Playwright needs browser binaries (Chromium, Firefox, WebKit) and their system-level dependencies to run.
+
+The frontend runs in a `node:18-slim` Docker container. Two options were considered for running Playwright tests in the local Docker environment.
+
+---
+
+## Decision
+
+We run Playwright tests in a **dedicated Docker service** using the official `mcr.microsoft.com/playwright` image, added to `docker-compose.yml`.
+
+```yaml
+playwright:
+  image: mcr.microsoft.com/playwright:v1.49.0-noble
+  volumes:
+    - ./apps/frontend:/app
+  working_dir: /app
+  depends_on:
+    - frontend
+    - backend
+```
+
+Run command:
+```powershell
+docker-compose run --rm playwright pnpm e2e
+```
+
+---
+
+## Alternatives Considered
+
+**Install Playwright inside the frontend container (`node:18-slim`)**
+
+`node:18-slim` is a minimal image with no browser dependencies. Installing Playwright inside it requires adding dozens of system packages (`libglib2.0-0`, `libnss3`, `libatk1.0-0`, and many more). This bloats the image, increases build time, and makes the Dockerfile harder to maintain. The browser binaries also need to be downloaded separately on every image rebuild.
+
+---
+
+## Consequences
+
+**Gained:**
+- Frontend container stays clean — no browser dependencies or Playwright binaries
+- Official Playwright image has all browser dependencies pre-installed and versioned
+- Same pattern as backend tests: `docker-compose run --rm backend pytest` → `docker-compose run --rm playwright pnpm e2e`
+- Playwright version is pinned via the image tag — consistent across all environments
+
+**Trade-offs:**
+- One additional service in `docker-compose.yml`
+- First run pulls the Playwright image (~1.5GB) — one-time cost

--- a/docs/adr/ADR-009-auth-state-persistence.md
+++ b/docs/adr/ADR-009-auth-state-persistence.md
@@ -1,0 +1,81 @@
+# ADR-009: Auth State Persistence via sessionStorage
+
+**Date:** 2026-05-08
+**Status:** Accepted
+
+---
+
+## Context
+
+The frontend uses an in-memory Zustand store (`authStore`) to hold the authenticated user. On every full page load, the store resets to `{ user: null, isLoading: true }` and waits for a `GET /api/v1/auth/me` response before rendering protected content.
+
+This caused two problems:
+
+**1. Blank flash on page reload.**
+Protected pages showed nothing (`null`) while `isLoading: true`, creating a visible loading gap before the route guard could evaluate the user's role.
+
+**2. E2E RBAC test unreliable.**
+The Playwright test navigates to `/hr/dashboard` via `page.goto()`, which triggers a full page reload. React mounts fresh, calls `getMe()` through the Vite proxy, and keeps `isLoading: true` until the request completes. In the Docker E2E environment, this request consistently took longer than the test assertion window (15 seconds), so `RequireRole` never got to evaluate the role and redirect to `/403`. The page stayed blank at `/hr/dashboard` despite the correct content eventually appearing.
+
+---
+
+## Decision
+
+Persist the authenticated user object in `sessionStorage` and restore it synchronously on store initialization.
+
+```ts
+const STORAGE_KEY = 'auth_user'
+
+function loadUser(): User | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as User) : null
+  } catch {
+    return null
+  }
+}
+
+const cachedUser = loadUser()
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  user: cachedUser,
+  isLoading: cachedUser === null,   // skip loading if user is cached
+  setUser: (user) => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+    set({ user })
+  },
+  clearUser: () => {
+    sessionStorage.removeItem(STORAGE_KEY)
+    set({ user: null })
+  },
+  setLoading: (isLoading) => set({ isLoading }),
+}))
+```
+
+`getMe()` still runs in the background on every mount to verify the session is still valid. If it fails (expired token), `clearUser()` is called to remove the stale entry and let `RequireRole` redirect to `/login`.
+
+---
+
+## Alternatives Considered
+
+**Keep in-memory only, fix proxy timing.**
+The root cause of the E2E failure was the Vite proxy connection taking too long for the first request after a page reload. Adding an axios timeout (e.g. 5s) would make `getMe()` fail fast — but then `user` would be `null`, and `RequireRole` would redirect to `/login` instead of `/403`. The test expects `/403`, so this would not fix the test.
+
+**Use localStorage.**
+`localStorage` persists across browser sessions. For auth user data this is unnecessary and slightly riskier. `sessionStorage` is cleared when the tab closes, which is the expected lifetime.
+
+**Use JWT in localStorage.**
+Not applicable — auth tokens are stored in HttpOnly cookies (see ADR-004) and are never accessible to JavaScript.
+
+---
+
+## Consequences
+
+**Gained:**
+- No blank flash on page reload — `RequireRole` evaluates immediately with cached user.
+- E2E RBAC test is deterministic — redirect to `/403` happens before `getMe()` returns.
+- Logout correctly clears the cache via `clearUser()`.
+
+**Trade-offs:**
+- User metadata (`id`, `email`, `role`, `first_name`, `last_name`) is readable from JavaScript via `sessionStorage`. This is not a token exposure risk (tokens remain in HttpOnly cookies), but it is a consideration for XSS scenarios.
+- Stale user data can briefly appear if the session expired between page loads. The background `getMe()` call corrects this within one request cycle.

--- a/docs/guides/tooling/002-docker-commands.md
+++ b/docs/guides/tooling/002-docker-commands.md
@@ -210,6 +210,34 @@ Mapping to 5433 on the host avoids the port conflict.
 
 ---
 
+## Backend-Specific Commands
+
+```powershell
+# Run backend tests
+docker-compose run --rm backend pytest
+
+# Apply database migrations
+docker-compose run --rm backend alembic upgrade head
+
+# Seed the database with initial data (HR Admin user)
+# Creates: admin@stepup.com / Admin1234!
+docker-compose run --rm backend python scripts/seed.py
+```
+
+---
+
+## E2E Tests
+
+```powershell
+# Start the full stack first
+docker-compose up -d db backend frontend
+
+# Run E2E tests (builds playwright container on first run)
+docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
+```
+
+---
+
 ## Frontend-Specific Commands
 
 ```powershell

--- a/docs/guides/tutorials/frontend/016-playwright.md
+++ b/docs/guides/tutorials/frontend/016-playwright.md
@@ -1,0 +1,103 @@
+# Playwright
+
+## What is Playwright?
+
+Playwright is an E2E (end-to-end) test framework. Unlike Vitest which tests components in isolation, Playwright launches a real browser, navigates to pages, fills forms, and clicks buttons — exactly as a user would.
+
+---
+
+## Why a Dedicated Docker Container?
+
+Playwright needs browser binaries (Chromium, Firefox, WebKit) and their system-level dependencies to run. The frontend container uses `node:18-slim` which is a minimal image with none of these dependencies.
+
+We use the official `mcr.microsoft.com/playwright` Docker image as a separate service in `docker-compose.yml`. This image has all browser dependencies pre-installed.
+
+See ADR-008 for the full decision.
+
+---
+
+## Why `@playwright/test` in `package.json`?
+
+Even though Playwright runs inside Docker, we add `@playwright/test` as a local devDependency:
+
+```json
+"@playwright/test": "^1.49.0"
+```
+
+Without it, TypeScript cannot resolve `defineConfig` in `playwright.config.ts` and the type declarations in test files:
+
+```
+Cannot find module '@playwright/test' or its corresponding type declarations.
+```
+
+The package runs inside the Docker container — the local install is only for TypeScript type checking. Same reason Vitest is listed in devDependencies even though tests run via pnpm scripts.
+
+---
+
+## Our `playwright.config.ts` Explained
+
+```typescript
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://frontend:3000',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+})
+```
+
+### `testDir: './tests/e2e'`
+
+E2E tests live in `tests/e2e/` — separate from unit tests which are co-located next to components. E2E tests test the full system, not a single component, so they don't belong next to any specific file.
+
+### `baseURL: 'http://frontend:3000'`
+
+The Playwright container reaches the frontend via Docker's internal network. `frontend` is the service name in `docker-compose.yml` — Docker resolves it to the container's IP automatically.
+
+### `projects: [{ name: 'chromium' }]`
+
+We run tests only in Chromium for now. Playwright supports Firefox and WebKit too — additional projects can be added later if cross-browser coverage is needed.
+
+---
+
+## Running E2E Tests
+
+Start all services first, then run the Playwright container:
+
+```powershell
+# Start the full stack
+docker-compose up -d db backend frontend
+
+# Run E2E tests
+docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
+```
+
+---
+
+## Test File Location
+
+E2E tests live in `tests/e2e/` — not co-located with components:
+
+```
+apps/frontend/
+  src/
+    features/
+      auth/
+        pages/
+          LoginPage.tsx
+          LoginPage.test.tsx    ← unit test, co-located
+  tests/
+    setup.ts
+    e2e/
+      login.spec.ts             ← E2E test, separate
+      register.spec.ts
+```
+
+**Why separate?** E2E tests test full user flows across multiple pages, not a single component. They have no natural "home" next to any one file.

--- a/docs/postmortems/2026-05-08-e2e-docker-setup.md
+++ b/docs/postmortems/2026-05-08-e2e-docker-setup.md
@@ -1,0 +1,490 @@
+# Post-mortem: E2E Docker Infrastructure Setup and Test Stability
+
+**Date:** 2026-05-08
+**Branch:** `test/fe-e2e-sprint-2`
+**Duration:** ~1 day
+**Outcome:** 7/7 tests passing
+
+---
+
+## Initial State
+
+Playwright E2E tests were written as part of Sprint 2, covering the following scenarios:
+
+- HR Admin, Manager, Employee login → redirect to the correct dashboard
+- Wrong password → stay on login page
+- Employee attempting to access `/hr/dashboard` → redirect to `/403`
+- Deactivated user sees error message on login page
+- Invalid invitation token shows error message on registration page
+
+Running `docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"` resulted in **all 7 tests failing**.
+
+At the same time, the local development environment had become noticeably slow — API requests were taking much longer than expected.
+
+---
+
+## Issue 1 — Local development environment was slow
+
+### Symptom
+
+`localhost:3000` responded slowly. Pages loaded but API calls had a visible delay on every request.
+
+### Root Cause
+
+A change had been made to `apiClient.ts`:
+
+```ts
+// Before
+baseURL: import.meta.env.VITE_API_URL,
+
+// After (incorrect change)
+baseURL: '',
+```
+
+With `baseURL: ''`, all API requests were going through the Vite dev server proxy instead of directly to the backend. This extra network hop added latency to every request.
+
+The Vite proxy had been added to `vite.config.ts` to enable Docker E2E networking. The proxy is necessary in Docker but adds unnecessary overhead in local development.
+
+### Fix
+
+`apiClient.ts` was updated to:
+
+```ts
+baseURL: import.meta.env.VITE_API_URL || '',
+```
+
+`docker-compose.yml` was updated to set `VITE_API_URL: ""` for the frontend service:
+
+```yaml
+frontend:
+  environment:
+    VITE_API_URL: ""
+```
+
+The logic works as follows:
+- **Local:** `.env` provides `VITE_API_URL=http://localhost:8000` → connects directly to backend, no proxy, fast.
+- **Docker:** `VITE_API_URL=""` is set as an OS env var, overriding the `.env` file → `baseURL: ''` → proxy routes requests to `http://backend:8000`.
+
+`.env.example` was also updated (`BACKEND_URL` → `VITE_API_URL=http://localhost:8000`).
+
+---
+
+## Issue 2 — Frontend healthcheck made the container unhealthy
+
+### Symptom
+
+Running `docker-compose run --rm playwright` caused the frontend container to hang in `Waiting` state, then fail:
+
+```
+dependency failed to start: container stepup-frontend is unhealthy
+```
+
+### Root Cause
+
+The initial healthcheck used an HTTP request:
+
+```yaml
+test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000', r => process.exit(0)).on('error', () => process.exit(1))"]
+interval: 5s
+timeout: 10s
+```
+
+When Vite starts, it performs on-demand dependency pre-bundling. During this phase it listens on port 3000 but cannot respond to HTTP requests within 10 seconds. Every healthcheck timed out, causing the container to be marked unhealthy.
+
+### Fix
+
+Replaced the HTTP check with a TCP port check:
+
+```yaml
+healthcheck:
+  test: ["CMD", "node", "-e", "require('net').createConnection({host:'localhost',port:3000},()=>process.exit(0)).on('error',()=>process.exit(1))"]
+  interval: 5s
+  timeout: 5s
+  retries: 12
+  start_period: 60s
+```
+
+The TCP check does not wait for Vite to produce an HTTP response. It passes as soon as the port is open, which happens immediately when the Vite process starts. `start_period: 60s` gives extra time for slow volume mount initialization on Windows/Docker Desktop.
+
+The playwright `depends_on` was updated:
+
+```yaml
+playwright:
+  depends_on:
+    frontend:
+      condition: service_healthy
+    backend:
+      condition: service_started
+```
+
+---
+
+## Issue 3 — Playwright container started but all tests timed out: Vite "Blocked request"
+
+### Symptom
+
+After fixing the healthcheck, tests started running. All login tests timed out at 30–60 seconds:
+
+```
+Error: page.fill: Test timeout of 60000ms exceeded.
+Call log:
+  - waiting for locator('input[placeholder="Email"]')
+```
+
+`page.goto('/login')` appeared to succeed, but the form never appeared.
+
+### Diagnosis
+
+The `error-context.md` file inside `test-results/` was read. Playwright automatically generates this file for every failing test and includes a page snapshot:
+
+```yaml
+- generic [ref=e2]: "Blocked request. This host (\"frontend\") is not allowed.
+  To allow this host, add \"frontend\" to server.allowedHosts in vite.config.js."
+```
+
+The page was completely blank. React had never mounted. Vite 5 rejects requests from non-localhost hostnames by default as a security measure against DNS rebinding attacks.
+
+Playwright connects using `baseURL: 'http://frontend:3000'`, where `frontend` is the Docker service name. Vite did not recognize this as an allowed host.
+
+### Fix
+
+One line added to `vite.config.ts`:
+
+```ts
+server: {
+  allowedHosts: ['frontend'],
+  ...
+}
+```
+
+The frontend container was restarted after this change (a running container does not pick up config changes automatically).
+
+**Note:** This issue was diagnosed in under 5 minutes by reading the error-context.md page snapshot. Without it, the failure would likely have been misattributed to Vite cold start, proxy configuration, or React mounting issues — each of which would have taken much longer to investigate.
+
+---
+
+## Issue 4 — Seeder container "exit 1"
+
+### Symptom
+
+The `seeder` service was introduced to automatically seed test users before the playwright container starts. It exited with code 1:
+
+```
+service "seeder" didn't complete successfully: exit 1
+```
+
+### Root Cause
+
+`seed.py` imported the application config at the top level:
+
+```python
+from app.core.config import settings
+engine = create_async_engine(settings.DATABASE_URL)
+```
+
+The `Settings` model (`pydantic_settings.BaseSettings`) declares these fields as required:
+
+```python
+class Settings(BaseSettings):
+    DATABASE_URL: str
+    FRONTEND_URL: str          # required
+    SENDGRID_API_KEY: str      # required
+    SENDGRID_FROM_EMAIL: str   # required
+    JWT_SECRET_KEY: str        # required
+```
+
+The seeder container was only given `DATABASE_URL`. The `ValidationError` was raised at import time, causing the Python process to exit 1 before running any seed logic.
+
+Additionally, the seeder service had no volume mount, so the updated `seed.py` on disk was not reflected in the container. The container ran the version baked into the image at build time.
+
+### Fix
+
+The `settings` dependency was removed from `seed.py`:
+
+```python
+# Before
+from app.core.config import settings
+engine = create_async_engine(settings.DATABASE_URL)
+
+# After
+import os
+DATABASE_URL = os.environ["DATABASE_URL"]
+engine = create_async_engine(DATABASE_URL)
+```
+
+A volume mount was added to the seeder service in `docker-compose.yml`:
+
+```yaml
+seeder:
+  volumes:
+    - ./apps/backend:/app
+```
+
+`seed.py` was already written to be idempotent — if a user exists it skips, if not it creates. This makes it safe to run on every E2E invocation.
+
+---
+
+## Issue 5 — Login endpoint rate limit caused test failures
+
+### Symptom
+
+Backend logs showed `429 Too Many Requests` during some test runs. The login endpoint was protected with `@limiter.limit("5/minute")`. The full E2E suite performs 5+ login attempts, all from the same Docker network IP, hitting the limit.
+
+### Fix
+
+The rate limit was made configurable via an environment variable:
+
+```python
+# limiter.py
+LOGIN_RATE_LIMIT = os.getenv("LOGIN_RATE_LIMIT", "5/minute")
+
+# auth.py
+@limiter.limit(LOGIN_RATE_LIMIT)
+async def login(...):
+```
+
+`docker-compose.yml` backend service:
+
+```yaml
+environment:
+  LOGIN_RATE_LIMIT: "1000/minute"
+```
+
+Production behavior is preserved (default `5/minute`). The Docker dev environment is not rate-limited during E2E runs.
+
+---
+
+## Issue 6 — HR dashboard triggered a 307 Temporary Redirect on every load
+
+### Symptom
+
+Backend logs showed:
+
+```
+GET /api/v1/users → 307 Temporary Redirect → GET /api/v1/users/
+```
+
+An extra round-trip on every user list request.
+
+### Root Cause
+
+The backend route was defined with a trailing slash:
+
+```python
+@router.get("/")  # serves at /api/v1/users/
+```
+
+The frontend called it without one:
+
+```ts
+LIST: '/api/v1/users',  // causes 307
+```
+
+### Fix
+
+One character change in `apiEndpoints.ts`:
+
+```ts
+LIST: '/api/v1/users/',
+```
+
+---
+
+## Issue 7 — RBAC test: URL stayed at `/hr/dashboard` for 60 seconds
+
+This was the most complex issue. It involved multiple overlapping causes and took the longest to diagnose correctly.
+
+### Test Scenario
+
+```ts
+test('Employee accessing HR dashboard is redirected to 403', async ({ page }) => {
+  await login(page, 'employee@stepup.com', 'Employee1234!')
+  await page.waitForURL('**/employee/dashboard')
+
+  await page.goto('/hr/dashboard')
+  await expect(page).toHaveURL('/403')
+})
+```
+
+### Symptom
+
+The test timed out at 60 seconds every run. `toHaveURL('/403')` was retried for 15 seconds and always received `/hr/dashboard`.
+
+### False Trails
+
+Four different code-level approaches were attempted to fix this:
+
+1. Added `useEffect + navigate` inside `RequireRole` → no effect
+2. Added page-level role checks inside each dashboard component → no effect
+3. Rewrote `RequireRole` to wrap children directly instead of using `<Outlet>` → no effect
+4. Added a global path-based guard `useEffect` inside `App.tsx` → no effect
+
+The fact that none of these worked was itself an important signal: the problem was not in the application logic.
+
+### Diagnosis — Layer 1: Was the page rendering at all?
+
+The `error-context.md` file was read after the latest test run:
+
+```yaml
+- heading "403 — You do not have permission to access this page." [level=1]
+```
+
+**The 403 page was rendering.** The redirect was working. But the URL was still `/hr/dashboard` and the test was timing out.
+
+### Diagnosis — Layer 2: Timing
+
+Test durations were examined:
+
+| Test | Duration |
+|------|----------|
+| HR Admin login | 55.1s |
+| Manager login | 40.7s |
+| Employee login | 41.4s |
+| Wrong password | 21.1s |
+| **RBAC (timeout)** | **60s** |
+
+The RBAC test logs in as employee — this takes ~41 seconds based on the Employee login test. After that, `page.goto('/hr/dashboard')` and `expect(toHaveURL('/403'))` need to fit in the remaining time. With a 60-second test timeout, there was not enough room.
+
+The redirect was working correctly. The test was simply running out of time.
+
+### Diagnosis — Layer 3: Why does login take 40 seconds?
+
+`page.goto('/hr/dashboard')` is a full page navigation. React mounts fresh. `App.tsx` calls `getMe()` in a `useEffect`. This request goes through the Vite proxy.
+
+Two compounding factors:
+
+**Factor A — Vite cold compile:**
+On the first several requests, Vite compiles JavaScript modules on demand. This takes 20–40 seconds for the first test runs in a session.
+
+**Factor B — Proxy connection reuse issue:**
+When `page.goto('/hr/dashboard')` fires a full page navigation, any pending request from the previous page (the `getMe()` called when the previous React app was mounted) is cancelled by the browser. The Vite proxy sometimes leaves the corresponding backend connection in an inconsistent state. When the new page's `getMe()` request arrives, the proxy attempts to reuse this stale connection. The request hangs indefinitely. `isLoading` never becomes `false`. `RequireRole` returns `null`. The URL stays at `/hr/dashboard`.
+
+This explains why all four code-level fix attempts failed: the guard code was correct, but the state it depended on (`isLoading: false`) was never reached because `getMe()` never resolved.
+
+### Fix — Two Parts
+
+**Part 1: sessionStorage persistence in authStore**
+
+The authenticated user is now persisted to `sessionStorage` and restored synchronously on store initialization:
+
+```ts
+const STORAGE_KEY = 'auth_user'
+
+function loadUser(): User | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as User) : null
+  } catch {
+    return null
+  }
+}
+
+const cachedUser = loadUser()
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  user: cachedUser,
+  isLoading: cachedUser === null,  // skip loading state if user is cached
+  setUser: (user) => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+    set({ user })
+  },
+  clearUser: () => {
+    sessionStorage.removeItem(STORAGE_KEY)
+    set({ user: null })
+  },
+  setLoading: (isLoading) => set({ isLoading }),
+}))
+```
+
+After employee login, `setUser` saves to sessionStorage. When `page.goto('/hr/dashboard')` triggers a full page reload:
+
+1. React mounts fresh
+2. `loadUser()` reads the employee from sessionStorage synchronously
+3. Store starts with `{ user: employee, isLoading: false }`
+4. `RequireRole` evaluates immediately: employee + HR_ADMIN required → `<Navigate to="/403" />`
+5. Redirect happens before `getMe()` returns
+
+`getMe()` still runs in the background to verify the session. If verification fails (expired token), `clearUser()` removes the stale cache and the user is redirected to login.
+
+**Part 2: Test timeout increase**
+
+```ts
+// playwright.config.ts
+timeout: 120000,  // 60s → 120s
+```
+
+The Vite dev server in Docker genuinely takes 40–55 seconds for the first few test runs due to on-demand module compilation. 120 seconds accommodates the full login flow with room for the subsequent navigation and assertion.
+
+---
+
+## Minor Findings
+
+### Playwright config was missing key settings
+
+```ts
+// Before
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: { baseURL: 'http://frontend:3000' },
+})
+
+// After
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 120000,
+  expect: { timeout: 15000 },
+  workers: 1,
+  use: { baseURL: 'http://frontend:3000' },
+})
+```
+
+`workers: 1` is important: three parallel workers hitting Vite simultaneously tripled the cold compile load. With serial execution, the first test triggers compilation and all subsequent tests benefit from the warm cache.
+
+### Login helper needed an explicit visibility wait
+
+```ts
+// Before
+await page.goto('/login')
+await page.fill('input[placeholder="Email"]', email)
+
+// After
+await page.goto('/login', { waitUntil: 'domcontentloaded' })
+await expect(page.getByPlaceholder('Email')).toBeVisible()
+await page.fill('input[placeholder="Email"]', email)
+```
+
+`domcontentloaded` lets `goto` return earlier. The explicit `toBeVisible()` wait (using `expect.timeout: 15000`) ensures React has mounted and the form is ready before interaction.
+
+### Dashboard components had redundant role checks
+
+While attempting to fix the RBAC test, role check logic was added directly inside `HRDashboard`, `ManagerDashboard`, and `EmployeeDashboard`. This duplicated what `RequireRole` already handles and risked triggering double navigation. These additions were removed after the tests passed.
+
+---
+
+## Summary
+
+| Issue | Root Cause | Fix |
+|-------|-----------|-----|
+| Slow local dev | `baseURL: ''` → all requests through proxy | Context-aware baseURL via `VITE_API_URL` env var |
+| Frontend unhealthy | HTTP healthcheck timed out during Vite pre-bundling | TCP port healthcheck (`net.createConnection`) |
+| Playwright "Blocked request" | Vite 5 blocks non-localhost hostnames | `allowedHosts: ['frontend']` |
+| Seeder exit 1 | `Settings` import required env vars not provided to seeder | Read `DATABASE_URL` directly from `os.environ` |
+| Rate limit 429 | 5/min limit hit by E2E suite from same IP | `LOGIN_RATE_LIMIT` env var, set to `1000/minute` in Docker |
+| 307 redirect | Frontend missing trailing slash on users endpoint | `'/api/v1/users/'` |
+| RBAC test timeout | No sessionStorage → `getMe()` hung → `isLoading: true` → no redirect | sessionStorage persistence + timeout increase |
+
+**Final result: 7/7 tests passing ✓**
+
+---
+
+## Lessons Learned
+
+1. **Read the error context file first.** Playwright generates a `test-results/.../error-context.md` with a page snapshot for every failing test. Reading this before making any code changes would have saved hours on Issues 3 and 7.
+
+2. **Distinguish "logic is wrong" from "logic never runs".** Four guard implementations failed on the RBAC test because the state the guards depended on (`isLoading: false`) was never reached. The symptom (URL unchanged) looked like a routing bug but was actually a timing/networking issue one layer below.
+
+3. **Docker networking resolves in layers.** Container started ≠ service ready. Service ready ≠ application ready. Each layer needs its own readiness strategy.
+
+4. **Shared config models create hidden dependencies.** Standalone scripts like `seed.py` should not load the full application config. They should declare only the env vars they actually need.
+
+5. **Test timing failures are deceptive.** "URL did not change" and "page did not render" look identical in a Playwright timeout but have completely different root causes. A page snapshot is the fastest way to tell them apart.


### PR DESCRIPTION
## Summary

- Sets up Playwright E2E test infrastructure in a dedicated Docker container
- Fixes several blocking issues discovered during E2E setup (Vite hostname, proxy, rate limit, CORS, 307 redirect)
- Adds sessionStorage persistence to auth store for reliable RBAC testing
- Applies corporate blue styling across all pages (login, dashboards, 403)
- Adds local Playwright config for faster development testing

## Changes

**E2E Infrastructure**
- Playwright runs in dedicated Docker container (`Dockerfile.e2e`)
- `seeder` service seeds test users automatically before tests run
- Frontend healthcheck (TCP) ensures Vite is ready before Playwright starts
- `playwright.config.ts` — timeout 120s, workers 1, baseURL `http://frontend:3000`
- `playwright.config.local.ts` — faster local dev config (30s timeout, workers 2, `localhost:5173`)

**Bug Fixes**
- Vite 5 `allowedHosts: ['frontend']` — blocked `frontend` hostname in Docker
- Vite proxy for Docker networking — `VITE_API_URL` env-aware baseURL
- Login rate limit configurable via `LOGIN_RATE_LIMIT` env var (set to 1000/min in Docker)
- `/api/v1/users/` trailing slash — eliminated 307 redirect
- CORS updated to allow `localhost:5173` for local development
- `seed.py` — removed full `Settings` dependency, reads `DATABASE_URL` directly

**Auth**
- `authStore` persists user to `sessionStorage` — survives page reloads without waiting for `getMe()`

**UI**
- `DashboardLayout` — shared nav bar with user info, role badge, logout
- `LoginPage`, `RegisterPage` — corporate blue card design
- `HRDashboard` — styled user table with deactivate buttons
- `ManagerDashboard`, `EmployeeDashboard` — welcome card with initials avatar
- `ForbiddenPage` — styled 403 with back navigation

**Docs**
- ADR-008 updated with full E2E setup and run procedure
- ADR-009 added — auth state sessionStorage persistence decision
- `docs/postmortems/2026-05-08-e2e-docker-setup.md` — full debug record
- `README.md` updated with hybrid dev setup, E2E commands, test users table