### PR TITLE
feat(be-us-005): add GET /users/me and PATCH /users/me endpoints

### DIFF
--- a/apps/backend/app/api/v1/auth.py
+++ b/apps/backend/app/api/v1/auth.py
@@ -104,8 +104,3 @@ async def refresh(
     )
 
 
-@router.get("/me", response_model=UserResponse)
-async def get_me(
-    current_user: User = Depends(get_current_user),
-) -> UserResponse:
-    return UserResponse.model_validate(current_user)

--- a/apps/backend/app/api/v1/user.py
+++ b/apps/backend/app/api/v1/user.py
@@ -8,7 +8,7 @@ from app.core.database import get_db
 from app.core.dependencies import get_current_user, require_role
 from app.enums.user_role import UserRole
 from app.models.user import User
-from app.schemas.user import UserResponse, UserUpdate
+from app.schemas.user import UserResponse, UserUpdate, UserProfileUpdate
 from app.services.user_service import UserService
 
 router = APIRouter()
@@ -32,6 +32,16 @@ async def get_users(
 ) -> list[UserResponse]:
     users = await user_service.get_users(db=db, role=role, department_id=department_id, is_active=is_active)
     return [UserResponse.model_validate(u) for u in users]
+
+
+@router.patch("/me", response_model=UserResponse)
+async def update_my_profile(
+    data: UserProfileUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserResponse:
+    user = await user_service.update_my_profile(db=db, user=current_user, data=data)
+    return UserResponse.model_validate(user)
 
 
 @router.patch("/{user_id}", response_model=UserResponse)

--- a/apps/backend/app/api/v1/user.py
+++ b/apps/backend/app/api/v1/user.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
-from app.core.dependencies import require_role
+from app.core.dependencies import get_current_user, require_role
 from app.enums.user_role import UserRole
 from app.models.user import User
 from app.schemas.user import UserResponse, UserUpdate
@@ -13,6 +13,13 @@ from app.services.user_service import UserService
 
 router = APIRouter()
 user_service = UserService()
+
+
+@router.get("/me", response_model=UserResponse)
+async def get_me(
+    current_user: User = Depends(get_current_user),
+) -> UserResponse:
+    return UserResponse.model_validate(current_user)
 
 
 @router.get("/", response_model=list[UserResponse], status_code=200)

--- a/apps/backend/app/models/user.py
+++ b/apps/backend/app/models/user.py
@@ -48,3 +48,7 @@ class User(Base, TimestampMixin):
     )
     department: Mapped["Department"] = relationship("Department", back_populates="users")
 
+    @property
+    def department_name(self) -> str | None:
+        return self.department.name if self.department else None
+

--- a/apps/backend/app/repositories/user_repository.py
+++ b/apps/backend/app/repositories/user_repository.py
@@ -51,6 +51,9 @@ class UserRepository:
         if is_active is not None:
             filters.append(User.is_active == is_active)
 
-        result = await db.execute(select(User).where(and_(*filters)).options(joinedload(User.department)))
+        query = select(User).options(joinedload(User.department))
+        if filters:
+            query = query.where(and_(*filters))
+        result = await db.execute(query)
         return list(result.scalars().all())
 

--- a/apps/backend/app/repositories/user_repository.py
+++ b/apps/backend/app/repositories/user_repository.py
@@ -2,6 +2,7 @@ import uuid
 
 from sqlalchemy import select, func, and_
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.enums.user_role import UserRole
 from app.models.user import User
@@ -22,7 +23,7 @@ class UserRepository:
 
     async def get_by_id(self, db: AsyncSession, user_id: uuid.UUID) -> User | None:
         result = await db.execute(
-            select(User).where(User.id == user_id)
+            select(User).where(User.id == user_id).options(joinedload(User.department))
         )
         return result.scalar_one_or_none()
 
@@ -50,6 +51,6 @@ class UserRepository:
         if is_active is not None:
             filters.append(User.is_active == is_active)
 
-        result = await db.execute(select(User).where(and_(*filters)))
+        result = await db.execute(select(User).where(and_(*filters)).options(joinedload(User.department)))
         return list(result.scalars().all())
 

--- a/apps/backend/app/schemas/user.py
+++ b/apps/backend/app/schemas/user.py
@@ -17,6 +17,13 @@ class UserUpdate(BaseModel):
     role: UserRole | None = None
 
 
+class UserProfileUpdate(BaseModel):
+    first_name: str | None = None
+    last_name: str | None = None
+
+    model_config = ConfigDict(extra='forbid')
+
+
 class UserResponse(BaseModel):
     id: uuid.UUID
     email: EmailStr

--- a/apps/backend/app/schemas/user.py
+++ b/apps/backend/app/schemas/user.py
@@ -25,5 +25,6 @@ class UserResponse(BaseModel):
     last_name: str
     is_active: bool
     department_id: uuid.UUID | None
+    department_name: str | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/app/services/user_service.py
+++ b/apps/backend/app/services/user_service.py
@@ -8,7 +8,7 @@ from app.errors import messages
 from app.models.user import User
 from app.repositories.refresh_token_repository import RefreshTokenRepository
 from app.repositories.user_repository import UserRepository
-from app.schemas.user import UserUpdate
+from app.schemas.user import UserUpdate, UserProfileUpdate
 
 user_repository = UserRepository()
 refresh_token_repository = RefreshTokenRepository()
@@ -40,6 +40,20 @@ class UserService:
         if data.role is not None:
             user.role = data.role
 
+        await db.commit()
+        return await user_repository.get_by_id(db, user_id)
+
+    async def update_my_profile(
+        self,
+        db: AsyncSession,
+        user: User,
+        data: UserProfileUpdate,
+    ) -> User:
+        if data.first_name is not None:
+            user.first_name = data.first_name
+        if data.last_name is not None:
+            user.last_name = data.last_name
+        user_id = user.id
         await db.commit()
         return await user_repository.get_by_id(db, user_id)
 

--- a/apps/backend/app/services/user_service.py
+++ b/apps/backend/app/services/user_service.py
@@ -41,8 +41,7 @@ class UserService:
             user.role = data.role
 
         await db.commit()
-        await db.refresh(user)
-        return user
+        return await user_repository.get_by_id(db, user_id)
 
     async def deactivate_user(
         self,

--- a/apps/backend/tests/integration/api/test_user_endpoints.py
+++ b/apps/backend/tests/integration/api/test_user_endpoints.py
@@ -13,6 +13,55 @@ pytestmark = pytest.mark.asyncio(loop_scope="session")
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
+class TestGetMe:
+
+    async def test_get_me_returns_200_with_correct_user(self, authenticated_client, hr_admin_user):
+        response = await authenticated_client.get("/api/v1/users/me")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"] == hr_admin_user.email
+        assert data["first_name"] == hr_admin_user.first_name
+        assert data["last_name"] == hr_admin_user.last_name
+        assert data["role"] == hr_admin_user.role.value
+        assert data["department_name"] is None
+
+    async def test_get_me_returns_401_when_not_authenticated(self, client):
+        response = await client.get("/api/v1/users/me")
+
+        assert response.status_code == 401
+
+
+class TestUpdateMyProfile:
+
+    async def test_patch_me_updates_name(self, authenticated_client):
+        response = await authenticated_client.patch(
+            "/api/v1/users/me",
+            json={"first_name": "Updated", "last_name": "Name"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["first_name"] == "Updated"
+        assert data["last_name"] == "Name"
+
+    async def test_patch_me_cannot_change_role(self, authenticated_client):
+        response = await authenticated_client.patch(
+            "/api/v1/users/me",
+            json={"role": "employee"},
+        )
+
+        assert response.status_code == 422
+
+    async def test_patch_me_returns_401_when_not_authenticated(self, client):
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"first_name": "Hacker"},
+        )
+
+        assert response.status_code == 401
+
+
 class TestUpdateUser:
 
     async def test_patch_user_assigns_department(self, authenticated_client, db_session):

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -8,11 +8,11 @@ export const API = {
   AUTH: {
     REGISTER: '/api/v1/auth/register',
     LOGIN: '/api/v1/auth/login',
-    ME: '/api/v1/auth/me',
     REFRESH: '/api/v1/auth/refresh',
     LOGOUT: '/api/v1/auth/logout',
   },
   USERS: {
+    ME: '/api/v1/users/me',
     LIST: '/api/v1/users/',
     DEACTIVATE: (id: string) => `/api/v1/users/${id}/deactivate`,
   },

--- a/apps/frontend/src/features/auth/services/authService.ts
+++ b/apps/frontend/src/features/auth/services/authService.ts
@@ -24,7 +24,7 @@ export async function login(data: LoginRequest): Promise<UserResponse> {
 }
 
 export async function getMe(): Promise<UserResponse> {
-  const res = await apiClient.get(API.AUTH.ME)
+  const res = await apiClient.get(API.USERS.ME)
   return res.data
 }
 

--- a/apps/frontend/src/lib/apiClient.ts
+++ b/apps/frontend/src/lib/apiClient.ts
@@ -12,7 +12,7 @@ apiClient.interceptors.response.use(
   async (error) => {
     const original = error.config
 
-    const isAuthEndpoint = original.url === API.AUTH.ME || original.url === API.AUTH.REFRESH
+    const isAuthEndpoint = original.url === API.USERS.ME || original.url === API.AUTH.REFRESH
     const errorCode = error.response?.data?.error_code
 
     if (errorCode === 'USER_DEACTIVATED') {


### PR DESCRIPTION
## Summary

Implements the "My Profile" backend endpoints (US-005).

- `GET /api/v1/users/me` — returns the authenticated user's profile
- `PATCH /api/v1/users/me` — updates first/last name only; role and other privileged fields are forbidden via `extra='forbid'` on the schema
- `UserResponse` now includes `department_name` resolved from the joined department relation
- Repository queries updated with `joinedload(User.department)` on `get_by_id` and `get_all` to avoid N+1
- `ME` endpoint moved from `/auth/me` to `/users/me`; frontend `apiClient` interceptor and `authService` updated accordingly

## Test plan

- [ ] `TestGetMe`: 200 with correct user data, 401 when unauthenticated
- [ ] `TestUpdateMyProfile`: updates name, rejects role change with 422, 401 when unauthenticated
- [ ] `docker-compose run --rm backend pytest tests/integration/api/test_user_endpoints.py -v`
