### PR TITLE
feat(us-004): department and user management frontend

### DIFF
--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -11,6 +11,9 @@ import DashboardLayout from '@/layouts/DashboardLayout'
 import { ROUTES, ERROR_ROUTES } from '@/constants/routes'
 import { USER_ROLES } from '@/constants/userRoles'
 import { useAuthInit } from './useAuthInit'
+import HRDashboardLayout from '@/layouts/HRDashboardLayout'
+import DepartmentsPage from '@/features/department/pages/DepartmentsPage'
+
 
 export default function App() {
   useAuthInit()
@@ -22,9 +25,10 @@ export default function App() {
       <Route path={ERROR_ROUTES.FORBIDDEN} element={<ForbiddenPage />} />
 
       <Route element={<RequireRole roles={[USER_ROLES.HR_ADMIN]} />}>
-        <Route element={<DashboardLayout />}>
+        <Route element={<HRDashboardLayout />}>
           <Route path={ROUTES.HR_DASHBOARD} element={<HRDashboard />} />
           <Route path={ROUTES.HR_INVITE_USER} element={<InviteUserPage />} />
+          <Route path={ROUTES.HR_DEPARTMENTS} element={<DepartmentsPage />} />
         </Route>
       </Route>
 

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -13,6 +13,7 @@ import { USER_ROLES } from '@/constants/userRoles'
 import { useAuthInit } from './useAuthInit'
 import HRDashboardLayout from '@/layouts/HRDashboardLayout'
 import DepartmentsPage from '@/features/department/pages/DepartmentsPage'
+import UsersPage from '@/features/users/pages/UsersPage'
 
 
 export default function App() {
@@ -29,6 +30,7 @@ export default function App() {
           <Route path={ROUTES.HR_DASHBOARD} element={<HRDashboard />} />
           <Route path={ROUTES.HR_INVITE_USER} element={<InviteUserPage />} />
           <Route path={ROUTES.HR_DEPARTMENTS} element={<DepartmentsPage />} />
+          <Route path={ROUTES.HR_USERS} element={<UsersPage />} />
         </Route>
       </Route>
 

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -16,4 +16,12 @@ export const API = {
     LIST: '/api/v1/users/',
     DEACTIVATE: (id: string) => `/api/v1/users/${id}/deactivate`,
   },
+  DEPARTMENTS: {
+    LIST: '/api/v1/departments/',
+    CREATE: '/api/v1/departments/',
+    UPDATE: (id: string) => `/api/v1/departments/${id}`,
+    DEACTIVATE: (id: string) => `/api/v1/departments/${id}/deactivate`,
+    REACTIVATE: (id: string) => `/api/v1/departments/${id}/reactivate`,
+},
+
 }

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -14,6 +14,7 @@ export const API = {
   },
   USERS: {
     LIST: '/api/v1/users/',
+    UPDATE: (id: string) => `/api/v1/users/${id}`,
     DEACTIVATE: (id: string) => `/api/v1/users/${id}/deactivate`,
   },
   DEPARTMENTS: {

--- a/apps/frontend/src/constants/errorMessages.ts
+++ b/apps/frontend/src/constants/errorMessages.ts
@@ -3,4 +3,5 @@ export const ERROR_MESSAGES: Record<string, string> = {
   INVITATION_ALREADY_USED: 'This invitation link has already been used.',
   USER_ALREADY_EXISTS: 'An account with this email already exists.',
   USER_DEACTIVATED: 'Your account has been deactivated. Please contact your HR Admin.',
+  DEPARTMENT_HAS_ACTIVE_USERS: 'Cannot deactivate a department with active users.',
 }

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -5,6 +5,8 @@ export const ROUTES = {
   HR_INVITE_USER: '/hr/invite-user',
   MANAGER_DASHBOARD: '/manager/dashboard',
   EMPLOYEE_DASHBOARD: '/employee/dashboard',
+  HR_DEPARTMENTS: '/hr/departments',
+  HR_USERS: '/hr/users',
 }
 
 export const ERROR_ROUTES = {

--- a/apps/frontend/src/features/department/hooks/useDepartmentsPage.ts
+++ b/apps/frontend/src/features/department/hooks/useDepartmentsPage.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import {
+  getDepartments,
+  createDepartment,
+  updateDepartment,
+  deactivateDepartment,
+  reactivateDepartment,
+} from '@/features/department/services/departmentService'
+import type { components } from '@/types/api'
+import { ERROR_MESSAGES } from '@/constants/errorMessages'
+
+type DepartmentResponse = components['schemas']['DepartmentResponse']
+
+export function useDepartmentsPage() {
+  const [departments, setDepartments] = useState<DepartmentResponse[]>([])
+  const [newName, setNewName] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState('')
+  const [pageError, setPageError] = useState('')
+
+  useEffect(() => {
+    getDepartments().then(setDepartments).catch(() => {})
+  }, [])
+
+  async function handleCreate() {
+    if (!newName.trim()) return
+    const created = await createDepartment({ name: newName.trim() })
+    setDepartments((prev) => [...prev, created])
+    setNewName('')
+  }
+
+  function startEdit(department: DepartmentResponse) {
+    setEditingId(department.id)
+    setEditingName(department.name)
+  }
+
+  async function handleUpdate() {
+    if (!editingId || !editingName.trim()) return
+    const updated = await updateDepartment(editingId, { name: editingName.trim() })
+    setDepartments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)))
+    setEditingId(null)
+    setEditingName('')
+  }
+
+  async function handleDeactivate(id: string) {
+    try {
+      const updated = await deactivateDepartment(id)
+      setDepartments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)))
+      setPageError('')
+    } catch (err: unknown) {
+      const code = (err as { response?: { data?: { error_code?: string } } }).response?.data?.error_code
+      setPageError(ERROR_MESSAGES[code ?? ''] ?? 'Something went wrong.')
+    }
+  }
+
+  async function handleReactivate(id: string) {
+    const updated = await reactivateDepartment(id)
+    setDepartments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)))
+  }
+
+  return {
+    departments,
+    newName,
+    setNewName,
+    editingId,
+    editingName,
+    setEditingName,
+    pageError,
+    handleCreate,
+    startEdit,
+    handleUpdate,
+    handleDeactivate,
+    handleReactivate,
+  }
+}

--- a/apps/frontend/src/features/department/pages/DepartmentsPage.test.tsx
+++ b/apps/frontend/src/features/department/pages/DepartmentsPage.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import DepartmentsPage from './DepartmentsPage'
+
+const {
+  mockGetDepartments,
+  mockCreateDepartment,
+  mockUpdateDepartment,
+  mockDeactivateDepartment,
+} = vi.hoisted(() => ({
+  mockGetDepartments: vi.fn(),
+  mockCreateDepartment: vi.fn(),
+  mockUpdateDepartment: vi.fn(),
+  mockDeactivateDepartment: vi.fn(),
+}))
+
+vi.mock('@/features/department/services/departmentService', () => ({
+  getDepartments: mockGetDepartments,
+  createDepartment: mockCreateDepartment,
+  updateDepartment: mockUpdateDepartment,
+  deactivateDepartment: mockDeactivateDepartment,
+  reactivateDepartment: vi.fn(),
+}))
+
+const mockDepartment = { id: '1', name: 'Engineering', is_active: true, created_at: '2024-01-01T00:00:00Z' }
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <DepartmentsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('DepartmentsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetDepartments.mockResolvedValue([mockDepartment])
+  })
+
+  it('displays department list on load', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering')).toBeInTheDocument()
+    })
+  })
+
+  it('creates a new department', async () => {
+    mockCreateDepartment.mockResolvedValue({
+      id: '2', name: 'Marketing', is_active: true, created_at: '2024-01-01T00:00:00Z',
+    })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Engineering'))
+
+    await userEvent.type(screen.getByPlaceholderText(/new department name/i), 'Marketing')
+    await userEvent.click(screen.getByRole('button', { name: /add/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Marketing')).toBeInTheDocument()
+    })
+  })
+
+  it('edits a department name', async () => {
+    mockUpdateDepartment.mockResolvedValue({
+      ...mockDepartment, name: 'Engineering Updated',
+    })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Engineering'))
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }))
+    const input = screen.getByDisplayValue('Engineering')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Engineering Updated')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Updated')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when deactivating department with active users', async () => {
+    mockDeactivateDepartment.mockRejectedValue({
+      response: { data: { error_code: 'DEPARTMENT_HAS_ACTIVE_USERS' } },
+    })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Engineering'))
+    await userEvent.click(screen.getByRole('button', { name: /deactivate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/cannot deactivate/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/features/department/pages/DepartmentsPage.tsx
+++ b/apps/frontend/src/features/department/pages/DepartmentsPage.tsx
@@ -1,0 +1,125 @@
+import { useDepartmentsPage } from '@/features/department/hooks/useDepartmentsPage'
+
+export default function DepartmentsPage() {
+  const {
+    departments,
+    newName,
+    setNewName,
+    editingId,
+    editingName,
+    setEditingName,
+    pageError,
+    handleCreate,
+    startEdit,
+    handleUpdate,
+    handleDeactivate,
+    handleReactivate,
+  } = useDepartmentsPage()
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">Departments</h2>
+        <p className="text-sm text-gray-500 mt-0.5">Manage your organisation's departments.</p>
+      </div>
+
+      {pageError && (
+        <div className="mb-4 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          {pageError}
+        </div>
+      )}
+
+      <div className="flex gap-2 mb-6">
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="New department name"
+          className="flex-1 border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          onClick={handleCreate}
+          className="bg-blue-700 hover:bg-blue-800 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+        >
+          Add
+        </button>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-100 bg-gray-50 text-left">
+              <th className="px-5 py-3.5 font-medium text-gray-600">Name</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600">Status</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {departments.map((d) => (
+              <tr key={d.id} className="hover:bg-slate-50 transition-colors">
+                <td className="px-5 py-3.5">
+                  {editingId === d.id ? (
+                    <input
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      className="border border-gray-300 rounded px-2 py-1 text-sm w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  ) : (
+                    <span className="font-medium text-gray-900">{d.name}</span>
+                  )}
+                </td>
+                <td className="px-5 py-3.5">
+                  <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium border ${
+                    d.is_active
+                      ? 'bg-green-50 text-green-700 border-green-100'
+                      : 'bg-gray-100 text-gray-500 border-gray-200'
+                  }`}>
+                    {d.is_active ? 'Active' : 'Inactive'}
+                  </span>
+                </td>
+                <td className="px-5 py-3.5 text-right space-x-2">
+                  {editingId === d.id ? (
+                    <button
+                      onClick={handleUpdate}
+                      className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 hover:border-blue-300 px-3 py-1.5 rounded-lg transition-colors"
+                    >
+                      Save
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => startEdit(d)}
+                      className="text-xs text-gray-600 hover:text-gray-800 border border-gray-200 hover:border-gray-300 px-3 py-1.5 rounded-lg transition-colors"
+                    >
+                      Edit
+                    </button>
+                  )}
+                  {d.is_active ? (
+                    <button
+                      onClick={() => handleDeactivate(d.id)}
+                      className="text-xs text-red-600 hover:text-red-800 border border-red-200 hover:border-red-300 px-3 py-1.5 rounded-lg transition-colors"
+                    >
+                      Deactivate
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => handleReactivate(d.id)}
+                      className="text-xs text-green-600 hover:text-green-800 border border-green-200 hover:border-green-300 px-3 py-1.5 rounded-lg transition-colors"
+                    >
+                      Reactivate
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {departments.length === 0 && (
+              <tr>
+                <td colSpan={3} className="px-5 py-8 text-center text-gray-400 text-sm">
+                  No departments yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/department/services/departmentService.ts
+++ b/apps/frontend/src/features/department/services/departmentService.ts
@@ -1,0 +1,32 @@
+import apiClient from '@/lib/apiClient'
+import type { components } from '@/types/api'
+import { API } from '@/constants/apiEndpoints'
+
+type DepartmentCreate = components['schemas']['DepartmentCreate']
+type DepartmentUpdate = components['schemas']['DepartmentUpdate']
+type DepartmentResponse = components['schemas']['DepartmentResponse']
+
+export async function getDepartments(): Promise<DepartmentResponse[]> {
+  const res = await apiClient.get(API.DEPARTMENTS.LIST)
+  return res.data
+}
+
+export async function createDepartment(data: DepartmentCreate): Promise<DepartmentResponse> {
+  const res = await apiClient.post(API.DEPARTMENTS.CREATE, data)
+  return res.data
+}
+
+export async function updateDepartment(id: string, data: DepartmentUpdate): Promise<DepartmentResponse> {
+  const res = await apiClient.patch(API.DEPARTMENTS.UPDATE(id), data)
+  return res.data
+}
+
+export async function deactivateDepartment(id: string): Promise<DepartmentResponse> {
+  const res = await apiClient.patch(API.DEPARTMENTS.DEACTIVATE(id))
+  return res.data
+}
+
+export async function reactivateDepartment(id: string): Promise<DepartmentResponse> {
+  const res = await apiClient.patch(API.DEPARTMENTS.REACTIVATE(id))
+  return res.data
+}

--- a/apps/frontend/src/features/users/hooks/useUsersPage.ts
+++ b/apps/frontend/src/features/users/hooks/useUsersPage.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import { getUsers, updateUser, deactivateUser } from '@/features/users/services/userService'
+import { getDepartments } from '@/features/department/services/departmentService'
+import type { components } from '@/types/api'
+
+type UserResponse = components['schemas']['UserResponse']
+type DepartmentResponse = components['schemas']['DepartmentResponse']
+type UserRole = components['schemas']['UserRole']
+
+export function useUsersPage() {
+  const [users, setUsers] = useState<UserResponse[]>([])
+  const [departments, setDepartments] = useState<DepartmentResponse[]>([])
+  const [filterRole, setFilterRole] = useState<UserRole | ''>('')
+  const [filterDepartmentId, setFilterDepartmentId] = useState<string>('')
+  const [filterStatus, setFilterStatus] = useState<'active' | 'inactive' | ''>('')
+
+  useEffect(() => {
+    getUsers().then(setUsers).catch(() => {})
+    getDepartments().then(setDepartments).catch(() => {})
+  }, [])
+
+  const filteredUsers = users.filter((u) => {
+    if (filterRole && u.role !== filterRole) return false
+    if (filterDepartmentId && u.department_id !== filterDepartmentId) return false
+    if (filterStatus === 'active' && !u.is_active) return false
+    if (filterStatus === 'inactive' && u.is_active) return false
+    return true
+  })
+
+  const activeDepartments = departments.filter((d) => d.is_active)
+
+  function getDepartmentName(departmentId: string | null): string {
+    if (!departmentId) return '—'
+    return departments.find((d) => d.id === departmentId)?.name ?? '—'
+  }
+
+  async function handleAssignDepartment(userId: string, departmentId: string) {
+    const updated = await updateUser(userId, { department_id: departmentId || null })
+    setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)))
+  }
+
+  async function handleChangeRole(userId: string, role: UserRole) {
+    const updated = await updateUser(userId, { role })
+    setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)))
+  }
+
+  async function handleDeactivate(userId: string) {
+    await deactivateUser(userId)
+    setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, is_active: false } : u)))
+  }
+
+  return {
+    filteredUsers,
+    departments,
+    activeDepartments,
+    filterRole,
+    setFilterRole,
+    filterDepartmentId,
+    setFilterDepartmentId,
+    filterStatus,
+    setFilterStatus,
+    getDepartmentName,
+    handleAssignDepartment,
+    handleChangeRole,
+    handleDeactivate,
+  }
+}

--- a/apps/frontend/src/features/users/pages/UsersPage.test.tsx
+++ b/apps/frontend/src/features/users/pages/UsersPage.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import UsersPage from './UsersPage'
+import { useAuthStore } from '@/stores/authStore'
+
+const { mockGetUsers, mockUpdateUser, mockDeactivateUser, mockGetDepartments } = vi.hoisted(() => ({
+  mockGetUsers: vi.fn(),
+  mockUpdateUser: vi.fn(),
+  mockDeactivateUser: vi.fn(),
+  mockGetDepartments: vi.fn(),
+}))
+
+vi.mock('@/features/users/services/userService', () => ({
+  getUsers: mockGetUsers,
+  updateUser: mockUpdateUser,
+  deactivateUser: mockDeactivateUser,
+}))
+
+vi.mock('@/features/department/services/departmentService', () => ({
+  getDepartments: mockGetDepartments,
+}))
+
+const mockDepartment = { id: 'dept-1', name: 'Engineering', is_active: true, created_at: '2024-01-01T00:00:00Z' }
+const mockCurrentUser = { id: 'user-1', email: 'hr@example.com', first_name: 'HR', last_name: 'Admin', role: 'hr_admin' as const, is_active: true, department_id: null }
+const mockEmployee = { id: 'user-2', email: 'emp@example.com', first_name: 'John', last_name: 'Doe', role: 'employee' as const, is_active: true, department_id: null }
+const mockManager = { id: 'user-3', email: 'mgr@example.com', first_name: 'Jane', last_name: 'Smith', role: 'manager' as const, is_active: true, department_id: 'dept-1' }
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <UsersPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('UsersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.setState({ user: mockCurrentUser, isLoading: false })
+    mockGetUsers.mockResolvedValue([mockCurrentUser, mockEmployee, mockManager])
+    mockGetDepartments.mockResolvedValue([mockDepartment])
+    mockUpdateUser.mockResolvedValue(mockEmployee)
+    mockDeactivateUser.mockResolvedValue(undefined)
+  })
+
+  it('displays user list on load', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument()
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument()
+    })
+  })
+
+  it('filters users by role', async () => {
+    renderPage()
+
+    await waitFor(() => screen.getByText('John Doe'))
+
+    await userEvent.selectOptions(screen.getByDisplayValue('All roles'), 'manager')
+
+    expect(screen.queryByText('John Doe')).not.toBeInTheDocument()
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument()
+  })
+
+  it('filters users by status', async () => {
+    mockGetUsers.mockResolvedValue([
+      mockCurrentUser,
+      mockEmployee,
+      { ...mockManager, is_active: false },
+    ])
+    renderPage()
+
+    await waitFor(() => screen.getByText('Jane Smith'))
+
+    await userEvent.selectOptions(screen.getByDisplayValue('All statuses'), 'active')
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument()
+    expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument()
+  })
+
+  it('assigns department to user', async () => {
+    mockUpdateUser.mockResolvedValue({ ...mockEmployee, department_id: 'dept-1' })
+    renderPage()
+
+    await waitFor(() => screen.getByText('John Doe'))
+
+    const departmentSelects = screen.getAllByDisplayValue('No department')
+    await userEvent.selectOptions(departmentSelects[1], 'dept-1')
+
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-2', { department_id: 'dept-1' })
+  })
+
+  it('deactivates a user', async () => {
+    renderPage()
+
+    await waitFor(() => screen.getByText('John Doe'))
+
+    const deactivateButtons = screen.getAllByRole('button', { name: /deactivate/i })
+    await userEvent.click(deactivateButtons[0])
+
+    expect(mockDeactivateUser).toHaveBeenCalledWith('user-2')
+  })
+})

--- a/apps/frontend/src/features/users/pages/UsersPage.tsx
+++ b/apps/frontend/src/features/users/pages/UsersPage.tsx
@@ -1,0 +1,150 @@
+import { useAuthStore } from '@/stores/authStore'
+import { ROLE_LABELS } from '@/constants/userRoles'
+import { useUsersPage } from '@/features/users/hooks/useUsersPage'
+import type { components } from '@/types/api'
+
+type UserRole = components['schemas']['UserRole']
+
+export default function UsersPage() {
+  const currentUser = useAuthStore((state) => state.user)
+  const {
+    filteredUsers,
+    activeDepartments,
+    filterRole,
+    setFilterRole,
+    filterDepartmentId,
+    setFilterDepartmentId,
+    filterStatus,
+    setFilterStatus,
+    getDepartmentName,
+    handleAssignDepartment,
+    handleChangeRole,
+    handleDeactivate,
+  } = useUsersPage()
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">Users</h2>
+        <p className="text-sm text-gray-500 mt-0.5">Manage users, roles and department assignments.</p>
+      </div>
+
+      <div className="flex gap-3 mb-6">
+        <select
+          value={filterRole}
+          onChange={(e) => setFilterRole(e.target.value as UserRole | '')}
+          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">All roles</option>
+          <option value="hr_admin">HR Admin</option>
+          <option value="manager">Manager</option>
+          <option value="employee">Employee</option>
+        </select>
+
+        <select
+          value={filterDepartmentId}
+          onChange={(e) => setFilterDepartmentId(e.target.value)}
+          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">All departments</option>
+          {activeDepartments.map((d) => (
+            <option key={d.id} value={d.id}>{d.name}</option>
+          ))}
+        </select>
+
+        <select
+          value={filterStatus}
+          onChange={(e) => setFilterStatus(e.target.value as 'active' | 'inactive' | '')}
+          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">All statuses</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </select>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-100 bg-gray-50 text-left">
+              <th className="px-5 py-3.5 font-medium text-gray-600">Name</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600">Email</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600">Role</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600">Department</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600">Status</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {filteredUsers.map((u) => (
+              <tr key={u.id} className="hover:bg-slate-50 transition-colors">
+                <td className="px-5 py-3.5 font-medium text-gray-900">
+                  {u.first_name} {u.last_name}
+                  {u.id === currentUser?.id && (
+                    <span className="ml-2 text-xs text-blue-600 font-normal">(you)</span>
+                  )}
+                </td>
+                <td className="px-5 py-3.5 text-gray-600">{u.email}</td>
+                <td className="px-5 py-3.5">
+                  {u.id === currentUser?.id ? (
+                    <span className="inline-block text-xs bg-blue-50 text-blue-700 border border-blue-100 px-2 py-0.5 rounded-full font-medium">
+                      {ROLE_LABELS[u.role] ?? u.role}
+                    </span>
+                  ) : (
+                    <select
+                      value={u.role}
+                      onChange={(e) => handleChangeRole(u.id, e.target.value as UserRole)}
+                      className="border border-gray-200 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      <option value="hr_admin">HR Admin</option>
+                      <option value="manager">Manager</option>
+                      <option value="employee">Employee</option>
+                    </select>
+                  )}
+                </td>
+                <td className="px-5 py-3.5">
+                  <select
+                    value={u.department_id ?? ''}
+                    onChange={(e) => handleAssignDepartment(u.id, e.target.value)}
+                    className="border border-gray-200 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="">No department</option>
+                    {activeDepartments.map((d) => (
+                      <option key={d.id} value={d.id}>{d.name}</option>
+                    ))}
+                  </select>
+                </td>
+                <td className="px-5 py-3.5">
+                  <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium border ${
+                    u.is_active
+                      ? 'bg-green-50 text-green-700 border-green-100'
+                      : 'bg-gray-100 text-gray-500 border-gray-200'
+                  }`}>
+                    {u.is_active ? 'Active' : 'Inactive'}
+                  </span>
+                </td>
+                <td className="px-5 py-3.5 text-right">
+                  {u.id !== currentUser?.id && u.is_active && (
+                    <button
+                      onClick={() => handleDeactivate(u.id)}
+                      className="text-xs text-red-600 hover:text-red-800 border border-red-200 hover:border-red-300 px-3 py-1.5 rounded-lg transition-colors"
+                    >
+                      Deactivate
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {filteredUsers.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-5 py-8 text-center text-gray-400 text-sm">
+                  No users found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/users/services/userService.ts
+++ b/apps/frontend/src/features/users/services/userService.ts
@@ -3,9 +3,15 @@ import type { components } from '@/types/api'
 import { API } from '@/constants/apiEndpoints'
 
 type UserResponse = components['schemas']['UserResponse']
+type UserUpdate = components['schemas']['UserUpdate']
 
 export async function getUsers(): Promise<UserResponse[]> {
   const res = await apiClient.get(API.USERS.LIST)
+  return res.data
+}
+
+export async function updateUser(id: string, data: UserUpdate): Promise<UserResponse> {
+  const res = await apiClient.patch(API.USERS.UPDATE(id), data)
   return res.data
 }
 

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -1,0 +1,80 @@
+import { Outlet, NavLink } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import { logout } from '@/features/auth/services/authService'
+import { useAuthStore } from '@/stores/authStore'
+import { ROUTES } from '@/constants/routes'
+
+export default function HRDashboardLayout() {
+  const user = useAuthStore((state) => state.user)
+  const clearUser = useAuthStore((state) => state.clearUser)
+  const navigate = useNavigate()
+
+  async function handleLogout() {
+    await logout()
+    clearUser()
+    navigate(ROUTES.LOGIN)
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex flex-col">
+      <nav className="bg-blue-800 text-white px-6 py-3 flex items-center justify-between shadow-md">
+        <span className="text-xl font-bold tracking-tight">StepUp</span>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-blue-200">
+            {user?.first_name} {user?.last_name}
+          </span>
+          <span className="text-xs bg-blue-600 px-2.5 py-0.5 rounded-full font-medium uppercase tracking-wide">
+            HR Admin
+          </span>
+          <button
+            onClick={handleLogout}
+            className="text-sm bg-white/10 hover:bg-white/20 px-3 py-1.5 rounded-lg transition-colors font-medium"
+          >
+            Logout
+          </button>
+        </div>
+      </nav>
+
+      <div className="flex flex-1">
+        <aside className="w-52 bg-white border-r border-gray-200 shadow-sm">
+          <nav className="flex flex-col p-4 gap-1">
+            <NavLink
+              to={ROUTES.HR_DASHBOARD}
+              className={({ isActive }) =>
+                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                }`
+              }
+            >
+              Dashboard
+            </NavLink>
+            <NavLink
+              to={ROUTES.HR_USERS}
+              className={({ isActive }) =>
+                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                }`
+              }
+            >
+              Users
+            </NavLink>
+            <NavLink
+              to={ROUTES.HR_DEPARTMENTS}
+              className={({ isActive }) =>
+                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                }`
+              }
+            >
+              Departments
+            </NavLink>
+          </nav>
+        </aside>
+
+        <main className="flex-1 p-6">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -158,6 +158,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update User */
+        patch: operations["update_user_api_v1_users__user_id__patch"];
+        trace?: never;
+    };
     "/api/v1/users/{user_id}/deactivate": {
         parameters: {
             query?: never;
@@ -173,6 +190,75 @@ export interface paths {
         head?: never;
         /** Deactivate User */
         patch: operations["deactivate_user_api_v1_users__user_id__deactivate_patch"];
+        trace?: never;
+    };
+    "/api/v1/departments/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Departments */
+        get: operations["get_departments_api_v1_departments__get"];
+        put?: never;
+        /** Create Department */
+        post: operations["create_department_api_v1_departments__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/departments/{department_id}/reactivate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Reactivate Department */
+        patch: operations["reactivate_department_api_v1_departments__department_id__reactivate_patch"];
+        trace?: never;
+    };
+    "/api/v1/departments/{department_id}/deactivate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Deactivate Department */
+        patch: operations["deactivate_department_api_v1_departments__department_id__deactivate_patch"];
+        trace?: never;
+    };
+    "/api/v1/departments/{department_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Department */
+        patch: operations["update_department_api_v1_departments__department_id__patch"];
         trace?: never;
     };
     "/health": {
@@ -196,6 +282,33 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** DepartmentCreate */
+        DepartmentCreate: {
+            /** Name */
+            name: string;
+        };
+        /** DepartmentResponse */
+        DepartmentResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+            /** Is Active */
+            is_active: boolean;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** DepartmentUpdate */
+        DepartmentUpdate: {
+            /** Name */
+            name: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -273,12 +386,22 @@ export interface components {
             first_name: string;
             /** Last Name */
             last_name: string;
+            /** Is Active */
+            is_active: boolean;
+            /** Department Id */
+            department_id: string | null;
         };
         /**
          * UserRole
          * @enum {string}
          */
         UserRole: "employee" | "manager" | "hr_admin";
+        /** UserUpdate */
+        UserUpdate: {
+            /** Department Id */
+            department_id?: string | null;
+            role?: components["schemas"]["UserRole"] | null;
+        };
         /** ValidationError */
         ValidationError: {
             /** Location */
@@ -536,7 +659,11 @@ export interface operations {
     };
     get_users_api_v1_users__get: {
         parameters: {
-            query?: never;
+            query?: {
+                role?: components["schemas"]["UserRole"] | null;
+                department_id?: string | null;
+                is_active?: boolean | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -550,6 +677,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UserResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_user_api_v1_users__user_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -571,6 +742,156 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_departments_api_v1_departments__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepartmentResponse"][];
+                };
+            };
+        };
+    };
+    create_department_api_v1_departments__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DepartmentCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepartmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reactivate_department_api_v1_departments__department_id__reactivate_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                department_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepartmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    deactivate_department_api_v1_departments__department_id__deactivate_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                department_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepartmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_department_api_v1_departments__department_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                department_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DepartmentUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepartmentResponse"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/docs/guides/tutorials/frontend/008-openapi-typescript.md
+++ b/docs/guides/tutorials/frontend/008-openapi-typescript.md
@@ -65,17 +65,13 @@ Two ways:
 
 ## When to Regenerate
 
-Run the generate command whenever BE schemas or endpoints change:
+Run the generate command whenever BE schemas or endpoints change. Backend must be running (`docker compose up`):
 
 ```powershell
-docker-compose run --rm frontend node_modules/.bin/openapi-typescript http://backend:8000/openapi.json -o src/types/api.ts
+pnpm --filter frontend exec openapi-typescript http://localhost:8000/openapi.json -o src/types/api.ts
 ```
 
-Or use the npm script shorthand (all services must be running):
-
-```powershell
-docker-compose run --rm frontend npm run generate-types
-```
+The `generate-types` script in `package.json` uses `http://backend:8000` which only works inside Docker network. Use `localhost:8000` when running from the host terminal.
 
 **When to run:**
 - After a new Pydantic model is added

--- a/docs/guides/tutorials/frontend/015-frontend-architecture.md
+++ b/docs/guides/tutorials/frontend/015-frontend-architecture.md
@@ -54,14 +54,121 @@ Individual tutorials explain each tool in isolation. This document shows how the
 
 ```
 src/
+├── app/
+│   ├── App.tsx             ← route definitions
+│   └── useAuthInit.ts      ← auth state bootstrap on page load
 ├── stores/
 │   └── authStore.ts        ← Zustand: global user state
-├── services/
-│   ├── apiClient.ts        ← Axios instance + interceptor
-│   └── authService.ts      ← login(), logout(), register()
-└── pages/
-    └── LoginPage.tsx       ← useForm + Zod + useNavigate + setUser
+├── layouts/
+│   ├── DashboardLayout.tsx     ← shared layout for Manager + Employee
+│   └── HRDashboardLayout.tsx   ← HR Admin layout with sidebar
+├── constants/
+│   ├── apiEndpoints.ts     ← all API URL strings
+│   ├── routes.ts           ← all frontend route paths
+│   └── errorMessages.ts    ← error_code → human readable message map
+└── features/
+    └── department/
+        ├── services/
+        │   └── departmentService.ts   ← API calls
+        ├── hooks/
+        │   └── useDepartmentsPage.ts  ← state + business logic
+        └── pages/
+            └── DepartmentsPage.tsx    ← render only, no logic
 ```
+
+---
+
+## Feature-Based Folder Structure
+
+Each feature lives under `features/<domain>/` and has three layers:
+
+```
+features/
+└── department/
+    ├── services/   ← talks to the API
+    ├── hooks/      ← owns state and business logic
+    └── pages/      ← renders what the hook gives it
+```
+
+**Why not flat?** When features grow, a flat `services/` and `pages/` folder mixes unrelated files. Feature folders keep everything for one domain together — easier to find, easier to delete if the feature is removed.
+
+---
+
+## Hook as Business Logic Container
+
+Pages are dumb renderers. All state and logic lives in a hook:
+
+```typescript
+// ❌ Logic inside the page
+export default function DepartmentsPage() {
+  const [departments, setDepartments] = useState([])
+  useEffect(() => { getDepartments().then(setDepartments) }, [])
+  async function handleCreate() { ... }
+  return <table>...</table>
+}
+
+// ✅ Logic in the hook, page only renders
+export default function DepartmentsPage() {
+  const { departments, handleCreate } = useDepartmentsPage()
+  return <table>...</table>
+}
+```
+
+**Why?** The page component becomes trivial to read. The hook is independently testable — you can mock services and test business logic without rendering any UI.
+
+---
+
+## Layout Routing Pattern
+
+React Router v6 supports layout routes — a parent route that wraps children with a shared shell. The child page renders into `<Outlet />`.
+
+```tsx
+// App.tsx — three nested layers
+<Route element={<RequireRole roles={[USER_ROLES.HR_ADMIN]} />}>   // auth guard
+  <Route element={<HRDashboardLayout />}>                          // layout shell
+    <Route path={ROUTES.HR_DASHBOARD} element={<HRDashboard />} />
+    <Route path={ROUTES.HR_DEPARTMENTS} element={<DepartmentsPage />} />
+  </Route>
+</Route>
+```
+
+Each layer has one responsibility:
+- `RequireRole` — checks auth, redirects if not allowed
+- `HRDashboardLayout` — renders nav bar + sidebar + `<Outlet />`
+- Page component — renders only its own content
+
+**Before this pattern**, each page imported and wrapped itself in the layout:
+```tsx
+// ❌ Old — every page knows about the layout
+export default function DepartmentsPage() {
+  return (
+    <DashboardLayout>
+      <div>content</div>
+    </DashboardLayout>
+  )
+}
+```
+
+**After**, pages know nothing about the layout:
+```tsx
+// ✅ New — page is just content
+export default function DepartmentsPage() {
+  return <div>content</div>
+}
+```
+
+---
+
+## Role-Based Layouts
+
+Different roles use different layouts. HR Admin has a sidebar, others have a simple top bar:
+
+```
+Manager / Employee  →  DashboardLayout     (top bar only)
+HR Admin            →  HRDashboardLayout   (top bar + sidebar)
+```
+
+This is achieved by wrapping each role's route group with its own layout route. No conditional rendering inside the layout — each layout is simple and knows only its own structure.
 
 ---
 

--- a/docs/guides/tutorials/frontend/017-soft-delete.md
+++ b/docs/guides/tutorials/frontend/017-soft-delete.md
@@ -1,0 +1,122 @@
+# Soft Delete — Frontend Perspective
+
+Backend soft delete doc: `docs/guides/tutorials/backend/010-soft-delete.md`
+
+This document covers how the frontend handles soft-deleted entities.
+
+---
+
+## What the Backend Sends
+
+Soft-deleted entities are never removed from API responses. Instead, the response includes a boolean flag:
+
+```ts
+// UserResponse
+is_active: boolean
+
+// DepartmentResponse
+is_active: boolean
+```
+
+The frontend receives all records — active and inactive — and decides what to show based on `is_active`.
+
+---
+
+## Rule: Never Filter Inactive Records from Lists
+
+Admin views show everything. `is_active` is displayed as a status badge — the HR Admin sees both active and inactive records and can act on them.
+
+```tsx
+// ✅ Show all, display status
+{departments.map((d) => (
+  <tr key={d.id}>
+    <td>{d.name}</td>
+    <td>{d.is_active ? 'Active' : 'Inactive'}</td>
+    <td>
+      {d.is_active
+        ? <button onClick={() => handleDeactivate(d.id)}>Deactivate</button>
+        : <button onClick={() => handleReactivate(d.id)}>Reactivate</button>
+      }
+    </td>
+  </tr>
+))}
+```
+
+---
+
+## Rule: Filter Inactive Records from Dropdowns
+
+When a user selects a department to assign to another user, inactive departments must not appear. Showing a deactivated department as a selectable option would let the user assign someone to a department that no longer exists operationally.
+
+```ts
+// In the hook — split into two lists
+const activeDepartments = departments.filter((d) => d.is_active)
+
+// In the page — admin list uses departments (all)
+//               assignment dropdown uses activeDepartments (active only)
+{activeDepartments.map((d) => (
+  <option key={d.id} value={d.id}>{d.name}</option>
+))}
+```
+
+---
+
+## Deactivate / Reactivate Flow
+
+The frontend calls a dedicated endpoint for each state transition — never sends `is_active` directly as a field in a PATCH body.
+
+```ts
+// ✅ Dedicated endpoints
+deactivateDepartment(id)   // PATCH /departments/{id}/deactivate
+reactivateDepartment(id)   // PATCH /departments/{id}/reactivate
+
+// ❌ Not this
+updateDepartment(id, { is_active: false })
+```
+
+**Why?** State transitions have business rules on the backend (e.g. cannot deactivate a department with active users). A dedicated endpoint makes the intent explicit and lets the backend enforce the rule cleanly.
+
+---
+
+## Error Handling for Business Rule Violations
+
+When the backend rejects a deactivation (e.g. department has active users), it returns a structured error:
+
+```json
+{ "error_code": "DEPARTMENT_HAS_ACTIVE_USERS" }
+```
+
+The frontend maps this to a human-readable message via `errorMessages.ts` and displays it inline:
+
+```ts
+// constants/errorMessages.ts
+DEPARTMENT_HAS_ACTIVE_USERS: 'Cannot deactivate a department with active users.'
+```
+
+```ts
+// In the hook
+async function handleDeactivate(id: string) {
+  try {
+    const updated = await deactivateDepartment(id)
+    setDepartments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)))
+    setPageError('')
+  } catch (err: unknown) {
+    const code = (err as { response?: { data?: { error_code?: string } } }).response?.data?.error_code
+    setPageError(ERROR_MESSAGES[code ?? ''] ?? 'Something went wrong.')
+  }
+}
+```
+
+The page renders `pageError` inline above the table — no modal, no toast, no redirect.
+
+---
+
+## Summary
+
+| Situation | Behaviour |
+|-----------|-----------|
+| Admin list | Show all records (active + inactive) |
+| Assignment dropdown | Show active records only |
+| Deactivate action | Call dedicated endpoint, catch business rule errors |
+| Reactivate action | Call dedicated endpoint |
+| Backend rejects | Show inline error message from `errorMessages.ts` |


### PR DESCRIPTION
## Summary

- Implements HR Admin panel with sidebar layout (`HRDashboardLayout`)
- Adds department management page: create, edit, deactivate, reactivate
- Adds users page: filterable list with department assignment, role change, deactivate
- Refactors layout routing — pages no longer wrap themselves in layout components

## Changes

### Architecture
- Extracted `useAuthInit` hook from `App.tsx`
- Moved `DashboardLayout` to `layouts/`, created `HRDashboardLayout` with sidebar
- Moved `ROLE_LABELS` to `constants/userRoles.ts`
- Moved `validateInvitation` from `authService` to `invitationService`
- Removed unused `QueryClientProvider`

### Features
- `DepartmentsPage` — list, create, inline edit, deactivate/reactivate with error handling
- `UsersPage` — filterable by role, department, status; inline department assignment and role change
- Route group `/hr/*` now uses `HRDashboardLayout` with sidebar nav (Dashboard, Users, Departments)

### Tests
- `DepartmentsPage.test.tsx` — 4 tests (list, create, edit, deactivate blocked by active users)
- `UsersPage.test.tsx` — 5 tests (list, role filter, status filter, assign department, deactivate)
- `DashboardLayout.test.tsx` — logout navigation

### Docs
- Updated `008-openapi-typescript.md` — correct type generation command for host machine
- Updated `015-frontend-architecture.md` — layout routing, feature folder structure, hook pattern
- Added `017-soft-delete.md` — frontend soft delete pattern

