### PR TITLE
feat(us-005): my profile page

### DIFF
--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -14,6 +14,7 @@ import { useAuthInit } from './useAuthInit'
 import HRDashboardLayout from '@/layouts/HRDashboardLayout'
 import DepartmentsPage from '@/features/department/pages/DepartmentsPage'
 import UsersPage from '@/features/users/pages/UsersPage'
+import ProfilePage from '@/features/users/pages/ProfilePage'
 
 
 export default function App() {
@@ -31,18 +32,21 @@ export default function App() {
           <Route path={ROUTES.HR_INVITE_USER} element={<InviteUserPage />} />
           <Route path={ROUTES.HR_DEPARTMENTS} element={<DepartmentsPage />} />
           <Route path={ROUTES.HR_USERS} element={<UsersPage />} />
+          <Route path={ROUTES.PROFILE} element={<ProfilePage />} />
         </Route>
       </Route>
 
       <Route element={<RequireRole roles={[USER_ROLES.MANAGER]} />}>
         <Route element={<DashboardLayout />}>
           <Route path={ROUTES.MANAGER_DASHBOARD} element={<ManagerDashboard />} />
+          <Route path={ROUTES.PROFILE} element={<ProfilePage />} />
         </Route>
       </Route>
 
       <Route element={<RequireRole roles={[USER_ROLES.EMPLOYEE]} />}>
         <Route element={<DashboardLayout />}>
           <Route path={ROUTES.EMPLOYEE_DASHBOARD} element={<EmployeeDashboard />} />
+          <Route path={ROUTES.PROFILE} element={<ProfilePage />} />
         </Route>
       </Route>
     </Routes>

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -13,6 +13,7 @@ export const API = {
   },
   USERS: {
     ME: '/api/v1/users/me',
+    UPDATE_ME: '/api/v1/users/me',
     LIST: '/api/v1/users/',
     UPDATE: (id: string) => `/api/v1/users/${id}`,
     DEACTIVATE: (id: string) => `/api/v1/users/${id}/deactivate`,

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
   EMPLOYEE_DASHBOARD: '/employee/dashboard',
   HR_DEPARTMENTS: '/hr/departments',
   HR_USERS: '/hr/users',
+  PROFILE: '/profile',
 }
 
 export const ERROR_ROUTES = {

--- a/apps/frontend/src/features/users/hooks/useProfilePage.ts
+++ b/apps/frontend/src/features/users/hooks/useProfilePage.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { useAuthStore } from '@/stores/authStore'
+import { updateMe } from '@/features/users/services/userService'
+
+export function useProfilePage() {
+  const user = useAuthStore((state) => state.user)
+  const setUser = useAuthStore((state) => state.setUser)
+  const [firstName, setFirstName] = useState(user?.first_name ?? '')
+  const [lastName, setLastName] = useState(user?.last_name ?? '')
+  const [success, setSuccess] = useState(false)
+  const [pageError, setPageError] = useState('')
+
+  async function handleSave() {
+    try {
+      const updated = await updateMe({ first_name: firstName, last_name: lastName })
+      setUser(updated)
+      setSuccess(true)
+      setPageError('')
+    } catch {
+      setPageError('Something went wrong. Please try again.')
+      setSuccess(false)
+    }
+  }
+
+  return {
+    user,
+    firstName,
+    setFirstName,
+    lastName,
+    setLastName,
+    success,
+    pageError,
+    handleSave,
+  }
+}

--- a/apps/frontend/src/features/users/pages/ProfilePage.test.tsx
+++ b/apps/frontend/src/features/users/pages/ProfilePage.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import ProfilePage from './ProfilePage'
+import { useAuthStore } from '@/stores/authStore'
+
+const { mockUpdateMe } = vi.hoisted(() => ({
+  mockUpdateMe: vi.fn(),
+}))
+
+vi.mock('@/features/users/services/userService', () => ({
+  updateMe: mockUpdateMe,
+}))
+
+const mockUser = {
+  id: 'user-1',
+  email: 'hr@example.com',
+  first_name: 'Jane',
+  last_name: 'Doe',
+  role: 'hr_admin' as const,
+  is_active: true,
+  department_id: null,
+  department_name: 'Engineering',
+}
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <ProfilePage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.setState({ user: mockUser, isLoading: false })
+  })
+
+  it('renders user data correctly', () => {
+    renderPage()
+
+    expect(screen.getByDisplayValue('Jane')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Doe')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('hr@example.com')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('HR Admin')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Engineering')).toBeInTheDocument()
+  })
+
+  it('email and role inputs are read-only', () => {
+    renderPage()
+
+    expect(screen.getByDisplayValue('hr@example.com')).toHaveAttribute('readonly')
+    expect(screen.getByDisplayValue('HR Admin')).toHaveAttribute('readonly')
+  })
+
+  it('updates name successfully', async () => {
+    mockUpdateMe.mockResolvedValue({ ...mockUser, first_name: 'Janet', last_name: 'Doe' })
+    renderPage()
+
+    const firstNameInput = screen.getByDisplayValue('Jane')
+    await userEvent.clear(firstNameInput)
+    await userEvent.type(firstNameInput, 'Janet')
+
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateMe).toHaveBeenCalledWith({ first_name: 'Janet', last_name: 'Doe' })
+      expect(screen.getByText('Profile updated successfully.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message on save failure', async () => {
+    mockUpdateMe.mockRejectedValue(new Error('Network error'))
+    renderPage()
+
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/features/users/pages/ProfilePage.tsx
+++ b/apps/frontend/src/features/users/pages/ProfilePage.tsx
@@ -1,0 +1,92 @@
+import { useProfilePage } from '@/features/users/hooks/useProfilePage'
+import { ROLE_LABELS } from '@/constants/userRoles'
+
+export default function ProfilePage() {
+  const {
+    user,
+    firstName,
+    setFirstName,
+    lastName,
+    setLastName,
+    success,
+    pageError,
+    handleSave,
+  } = useProfilePage()
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">My Profile</h2>
+        <p className="text-sm text-gray-500 mt-0.5">View and update your personal details.</p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8 space-y-5">
+        {success && (
+          <div className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+            Profile updated successfully.
+          </div>
+        )}
+        {pageError && (
+          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+            {pageError}
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">First name</label>
+            <input
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">Last name</label>
+            <input
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">Email</label>
+          <input
+            value={user?.email ?? ''}
+            readOnly
+            className="w-full border border-gray-200 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 bg-gray-50 cursor-not-allowed"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">Role</label>
+          <input
+            value={ROLE_LABELS[user?.role ?? ''] ?? user?.role ?? ''}
+            readOnly
+            className="w-full border border-gray-200 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 bg-gray-50 cursor-not-allowed"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">Department</label>
+          <input
+            value={user?.department_name ?? '—'}
+            readOnly
+            className="w-full border border-gray-200 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 bg-gray-50 cursor-not-allowed"
+          />
+        </div>
+
+        <div className="pt-2">
+          <button
+            onClick={handleSave}
+            className="bg-blue-700 hover:bg-blue-800 text-white text-sm font-medium px-5 py-2.5 rounded-lg transition-colors"
+          >
+            Save changes
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/users/services/userService.ts
+++ b/apps/frontend/src/features/users/services/userService.ts
@@ -4,6 +4,12 @@ import { API } from '@/constants/apiEndpoints'
 
 type UserResponse = components['schemas']['UserResponse']
 type UserUpdate = components['schemas']['UserUpdate']
+type UserProfileUpdate = components['schemas']['UserProfileUpdate']
+
+export async function updateMe(data: UserProfileUpdate): Promise<UserResponse> {
+  const res = await apiClient.patch(API.USERS.UPDATE_ME, data)
+  return res.data
+}
 
 export async function getUsers(): Promise<UserResponse[]> {
   const res = await apiClient.get(API.USERS.LIST)

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet, Link } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 import { logout } from '@/features/auth/services/authService'
 import { useAuthStore } from '@/stores/authStore'
@@ -21,9 +21,9 @@ export default function DashboardLayout() {
       <nav className="bg-blue-800 text-white px-6 py-3 flex items-center justify-between shadow-md">
         <span className="text-xl font-bold tracking-tight">StepUp</span>
         <div className="flex items-center gap-3">
-          <span className="text-sm text-blue-200">
+          <Link to={ROUTES.PROFILE} className="text-sm text-blue-200 hover:text-white transition-colors">
             {user?.first_name} {user?.last_name}
-          </span>
+          </Link>
           <span className="text-xs bg-blue-600 px-2.5 py-0.5 rounded-full font-medium uppercase tracking-wide">
             {ROLE_LABELS[user?.role ?? ''] ?? user?.role}
           </span>

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, NavLink } from 'react-router-dom'
+import { Outlet, NavLink, Link } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 import { logout } from '@/features/auth/services/authService'
 import { useAuthStore } from '@/stores/authStore'
@@ -20,9 +20,9 @@ export default function HRDashboardLayout() {
       <nav className="bg-blue-800 text-white px-6 py-3 flex items-center justify-between shadow-md">
         <span className="text-xl font-bold tracking-tight">StepUp</span>
         <div className="flex items-center gap-3">
-          <span className="text-sm text-blue-200">
+          <Link to={ROUTES.PROFILE} className="text-sm text-blue-200 hover:text-white transition-colors">
             {user?.first_name} {user?.last_name}
-          </span>
+          </Link>
           <span className="text-xs bg-blue-600 px-2.5 py-0.5 rounded-full font-medium uppercase tracking-wide">
             HR Admin
           </span>

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -72,23 +72,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/auth/me": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Me */
-        get: operations["get_me_api_v1_auth_me_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/invitations/": {
         parameters: {
             query?: never;
@@ -139,6 +122,24 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/api/v1/users/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Me */
+        get: operations["get_me_api_v1_users_me_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update My Profile */
+        patch: operations["update_my_profile_api_v1_users_me_patch"];
         trace?: never;
     };
     "/api/v1/users/": {
@@ -369,6 +370,13 @@ export interface components {
             /** Password */
             password: string;
         };
+        /** UserProfileUpdate */
+        UserProfileUpdate: {
+            /** First Name */
+            first_name?: string | null;
+            /** Last Name */
+            last_name?: string | null;
+        };
         /** UserResponse */
         UserResponse: {
             /**
@@ -390,6 +398,8 @@ export interface components {
             is_active: boolean;
             /** Department Id */
             department_id: string | null;
+            /** Department Name */
+            department_name?: string | null;
         };
         /**
          * UserRole
@@ -522,26 +532,6 @@ export interface operations {
             };
         };
     };
-    get_me_api_v1_auth_me_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UserResponse"];
-                };
-            };
-        };
-    };
     get_invitations_api_v1_invitations__get: {
         parameters: {
             query?: never;
@@ -644,6 +634,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InvitationValidateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_me_api_v1_users_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+        };
+    };
+    update_my_profile_api_v1_users_me_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserProfileUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- Adds profile page for all roles at `/profile`
- Users can view name, email, role and department
- Users can update first name and last name
- Name in nav bar is now clickable and navigates to `/profile`

## Changes

- `userService.ts` — added `updateMe()` function
- `useProfilePage.ts` — created profile page hook
- `ProfilePage.tsx` — created profile page
- `App.tsx` — added `/profile` route to all three role groups
- `DashboardLayout.tsx` — user name links to `/profile`
- `HRDashboardLayout.tsx` — user name links to `/profile`
