### PR TITLE
feat(us-015): manager task review — approve and return completed tasks

### DIFF
--- a/apps/backend/app/api/router.py
+++ b/apps/backend/app/api/router.py
@@ -13,3 +13,4 @@ api_router.include_router(template.router, prefix="/templates", tags=["templates
 api_router.include_router(task_workflow.plans_router, prefix="/plans", tags=["employee-tasks"])
 api_router.include_router(onboarding_plan.router, prefix="/plans", tags=["plans"])
 api_router.include_router(task_workflow.tasks_router, prefix="/tasks", tags=["employee-tasks"])
+api_router.include_router(task_workflow.manager_router, prefix="/manager", tags=["manager-tasks"])

--- a/apps/backend/app/api/v1/task_workflow.py
+++ b/apps/backend/app/api/v1/task_workflow.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import List
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,11 +8,12 @@ from app.core.database import get_db
 from app.core.dependencies import require_role
 from app.enums.user_role import UserRole
 from app.models.user import User
-from app.schemas.onboarding_plan import OnboardingPlanResponse, OnboardingPlanTaskResponse
+from app.schemas.onboarding_plan import ApprovalTaskResponse, OnboardingPlanResponse, OnboardingPlanTaskResponse, ReturnTask
 from app.services.task_workflow_service import TaskWorkflowService
 
 plans_router = APIRouter()
 tasks_router = APIRouter()
+manager_router = APIRouter()
 task_workflow_service = TaskWorkflowService()
 
 
@@ -41,4 +43,33 @@ async def complete_task(
     current_user: User = Depends(require_role(UserRole.EMPLOYEE)),
 ) -> OnboardingPlanTaskResponse:
     task = await task_workflow_service.complete_task(db=db, task_id=task_id, current_user=current_user)
+    return OnboardingPlanTaskResponse.model_validate(task)
+
+
+@manager_router.get("/approvals", response_model=List[ApprovalTaskResponse])
+async def get_pending_approvals(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.MANAGER)),
+) -> List[ApprovalTaskResponse]:
+    return await task_workflow_service.get_pending_approvals(db=db, current_user=current_user)
+
+
+@tasks_router.patch("/{task_id}/approve", response_model=OnboardingPlanTaskResponse)
+async def approve_task(
+    task_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.MANAGER)),
+) -> OnboardingPlanTaskResponse:
+    task = await task_workflow_service.approve_task(db=db, task_id=task_id, current_user=current_user)
+    return OnboardingPlanTaskResponse.model_validate(task)
+
+
+@tasks_router.patch("/{task_id}/return", response_model=OnboardingPlanTaskResponse)
+async def return_task(
+    task_id: uuid.UUID,
+    data: ReturnTask,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.MANAGER)),
+) -> OnboardingPlanTaskResponse:
+    task = await task_workflow_service.return_task(db=db, task_id=task_id, current_user=current_user, data=data)
     return OnboardingPlanTaskResponse.model_validate(task)

--- a/apps/backend/app/errors/messages.py
+++ b/apps/backend/app/errors/messages.py
@@ -38,3 +38,5 @@ EMPLOYEE_ALREADY_HAS_ACTIVE_PLAN = ("EMPLOYEE_ALREADY_HAS_ACTIVE_PLAN", "This em
 TEMPLATE_NOT_ACTIVE = ("TEMPLATE_NOT_ACTIVE", "Template must be active to create a plan")
 TASK_ALREADY_TERMINAL = ("TASK_ALREADY_TERMINAL", "This task is already in a terminal state and cannot be cancelled")
 INVALID_TASK_TRANSITION = ("INVALID_TASK_TRANSITION", "This task cannot transition from its current status")
+TASK_NOT_APPROVABLE = ("TASK_NOT_APPROVABLE", "Only completed tasks can be approved or returned")
+RETURN_COMMENT_REQUIRED = ("RETURN_COMMENT_REQUIRED", "Feedback comment is required when returning a task")

--- a/apps/backend/app/repositories/onboarding_plan_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_repository.py
@@ -22,6 +22,18 @@ class OnboardingPlanRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_all_by_manager(self, db: AsyncSession, manager_id: uuid.UUID) -> list[OnboardingPlan]:
+        result = await db.execute(
+            select(OnboardingPlan)
+            .options(selectinload(OnboardingPlan.tasks), selectinload(OnboardingPlan.employee))
+            .where(
+                OnboardingPlan.manager_id == manager_id,
+                OnboardingPlan.is_active.is_(True),
+                OnboardingPlan.deleted_at.is_(None),
+            )
+        )
+        return list(result.scalars().all())
+
     async def get_active_by_user(self, db: AsyncSession, user_id: uuid.UUID) -> OnboardingPlan | None:
         result = await db.execute(
             select(OnboardingPlan)

--- a/apps/backend/app/schemas/onboarding_plan.py
+++ b/apps/backend/app/schemas/onboarding_plan.py
@@ -5,6 +5,24 @@ from pydantic import BaseModel, ConfigDict
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 
 
+class ReturnTask(BaseModel):
+    content: str
+
+
+class ApprovalTaskResponse(BaseModel):
+    id: uuid.UUID
+    plan_id: uuid.UUID
+    title: str
+    description: str | None
+    deadline: date
+    status: OnboardingPlanTaskStatus
+    is_required: bool
+    order: int
+    created_at: datetime
+    employee_name: str
+    plan_start_date: date
+
+
 class OnboardingPlanCreate(BaseModel):
     user_id: uuid.UUID
     template_id: uuid.UUID

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -10,6 +10,7 @@ from app.models.onboarding_plan_task import OnboardingPlanTask
 from app.models.user import User
 from app.repositories.onboarding_plan_repository import OnboardingPlanRepository
 from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
+from app.schemas.onboarding_plan import ApprovalTaskResponse, ReturnTask
 
 plan_repository = OnboardingPlanRepository()
 plan_task_repository = OnboardingPlanTaskRepository()
@@ -45,6 +46,64 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.COMPLETED
         await db.commit()
         await db.refresh(task)
+        return task
+
+    async def get_pending_approvals(
+        self, db: AsyncSession, current_user: User
+    ) -> list[ApprovalTaskResponse]:
+        plans = await plan_repository.get_all_by_manager(db, current_user.id)
+        result = []
+        for plan in plans:
+            for task in plan.tasks:
+                if task.status == OnboardingPlanTaskStatus.COMPLETED and task.deleted_at is None:
+                    result.append(ApprovalTaskResponse(
+                        id=task.id,
+                        plan_id=task.plan_id,
+                        title=task.title,
+                        description=task.description,
+                        deadline=task.deadline,
+                        status=task.status,
+                        is_required=task.is_required,
+                        order=task.order,
+                        created_at=task.created_at,
+                        employee_name=f"{plan.employee.first_name} {plan.employee.last_name}",
+                        plan_start_date=plan.start_date,
+                    ))
+        return result
+
+    async def approve_task(
+        self, db: AsyncSession, task_id: uuid.UUID, current_user: User
+    ) -> OnboardingPlanTask:
+        task = await self._get_task_for_manager(db, task_id, current_user)
+        if task.status != OnboardingPlanTaskStatus.COMPLETED:
+            raise ValidationError(*messages.TASK_NOT_APPROVABLE)
+        task.status = OnboardingPlanTaskStatus.APPROVED
+        await db.commit()
+        await db.refresh(task)
+        return task
+
+    async def return_task(
+        self, db: AsyncSession, task_id: uuid.UUID, current_user: User, data: ReturnTask
+    ) -> OnboardingPlanTask:
+        task = await self._get_task_for_manager(db, task_id, current_user)
+        if task.status != OnboardingPlanTaskStatus.COMPLETED:
+            raise ValidationError(*messages.TASK_NOT_APPROVABLE)
+        if not data.content or not data.content.strip():
+            raise ValidationError(*messages.RETURN_COMMENT_REQUIRED)
+        task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+        await db.commit()
+        await db.refresh(task)
+        return task
+
+    async def _get_task_for_manager(
+        self, db: AsyncSession, task_id: uuid.UUID, current_user: User
+    ) -> OnboardingPlanTask:
+        task = await plan_task_repository.get_by_id(db, task_id)
+        if not task:
+            raise NotFoundError(*messages.PLAN_TASK_NOT_FOUND)
+        plan = await plan_repository.get_by_id(db, task.plan_id)
+        if not plan or plan.manager_id != current_user.id:
+            raise NotFoundError(*messages.PLAN_TASK_NOT_FOUND)
         return task
 
     async def _get_task_for_user(

--- a/apps/backend/tests/integration/api/test_manager_task_review_endpoints.py
+++ b/apps/backend/tests/integration/api/test_manager_task_review_endpoints.py
@@ -1,0 +1,181 @@
+import pytest
+from datetime import date
+from httpx import AsyncClient, ASGITransport
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.enums.user_role import UserRole
+from app.main import app
+from app.models.department import Department
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
+from app.models.onboarding_template import OnboardingTemplate
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.fixture
+async def department(db_session):
+    dept = Department(name="Manager Review Department")
+    db_session.add(dept)
+    await db_session.flush()
+    return dept
+
+
+@pytest.fixture
+async def employee_user(db_session):
+    user = User(
+        email="employee_mgr_review_test@test.com",
+        role=UserRole.EMPLOYEE,
+        first_name="John",
+        last_name="Employee",
+        password_hash="placeholder",
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.fixture
+async def manager_user(db_session):
+    user = User(
+        email="manager_mgr_review_test@test.com",
+        role=UserRole.MANAGER,
+        first_name="Jane",
+        last_name="Manager",
+        password_hash="placeholder",
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.fixture
+async def plan_with_completed_task(db_session, department, employee_user, manager_user):
+    template = OnboardingTemplate(
+        name="Manager Review Template",
+        department_id=department.id,
+        is_active=True,
+    )
+    db_session.add(template)
+    await db_session.flush()
+
+    plan = OnboardingPlan(
+        user_id=employee_user.id,
+        template_id=template.id,
+        manager_id=manager_user.id,
+        start_date=date(2026, 6, 1),
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    task = OnboardingPlanTask(
+        plan_id=plan.id,
+        title="Review Task",
+        deadline=date(2026, 6, 8),
+        status=OnboardingPlanTaskStatus.COMPLETED,
+        is_required=True,
+        order=1,
+    )
+    db_session.add(task)
+    await db_session.flush()
+
+    return plan, task
+
+
+@pytest.fixture
+async def manager_client(db_session, manager_user):
+    async def override_get_db():
+        yield db_session
+
+    async def override_get_current_user():
+        await db_session.refresh(manager_user)
+        return manager_user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+class TestGetPendingApprovals:
+
+    async def test_returns_200_with_completed_tasks(
+        self, manager_client, plan_with_completed_task
+    ):
+        response = await manager_client.get("/api/v1/manager/approvals")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "Review Task"
+        assert data[0]["employee_name"] == "John Employee"
+        assert data[0]["status"] == "completed"
+
+    async def test_returns_empty_list_when_no_completed_tasks(self, manager_client):
+        response = await manager_client.get("/api/v1/manager/approvals")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestApproveTask:
+
+    async def test_returns_200_with_approved_status(
+        self, manager_client, plan_with_completed_task
+    ):
+        _, task = plan_with_completed_task
+
+        response = await manager_client.patch(f"/api/v1/tasks/{task.id}/approve")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "approved"
+
+    async def test_returns_400_when_task_not_completed(
+        self, manager_client, db_session, plan_with_completed_task
+    ):
+        _, task = plan_with_completed_task
+        task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+        await db_session.flush()
+
+        response = await manager_client.patch(f"/api/v1/tasks/{task.id}/approve")
+
+        assert response.status_code == 400
+        assert response.json()["error_code"] == "TASK_NOT_APPROVABLE"
+
+
+class TestReturnTask:
+
+    async def test_returns_200_with_in_progress_status(
+        self, manager_client, plan_with_completed_task
+    ):
+        _, task = plan_with_completed_task
+
+        response = await manager_client.patch(
+            f"/api/v1/tasks/{task.id}/return",
+            json={"content": "Please redo this task."},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "in_progress"
+
+    async def test_returns_400_when_content_missing(
+        self, manager_client, plan_with_completed_task
+    ):
+        _, task = plan_with_completed_task
+
+        response = await manager_client.patch(
+            f"/api/v1/tasks/{task.id}/return",
+            json={"content": "   "},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error_code"] == "RETURN_COMMENT_REQUIRED"

--- a/apps/backend/tests/unit/services/test_manager_task_review_service.py
+++ b/apps/backend/tests/unit/services/test_manager_task_review_service.py
@@ -1,0 +1,171 @@
+import uuid
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.task_workflow_service import TaskWorkflowService
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.errors import ValidationError, NotFoundError
+from app.schemas.onboarding_plan import ReturnTask
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.fixture
+def service():
+    return TaskWorkflowService()
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+class TestApproveTask:
+
+    async def test_transitions_completed_to_approved(self, service, mock_db):
+        current_user = MagicMock()
+        current_user.id = uuid.uuid4()
+        plan_id = uuid.uuid4()
+
+        mock_task = MagicMock()
+        mock_task.status = OnboardingPlanTaskStatus.COMPLETED
+        mock_task.plan_id = plan_id
+
+        mock_plan = MagicMock()
+        mock_plan.id = plan_id
+        mock_plan.manager_id = current_user.id
+
+        with patch("app.services.task_workflow_service.plan_task_repository") as mock_task_repo, \
+             patch("app.services.task_workflow_service.plan_repository") as mock_plan_repo:
+
+            mock_task_repo.get_by_id = AsyncMock(return_value=mock_task)
+            mock_plan_repo.get_by_id = AsyncMock(return_value=mock_plan)
+
+            await service.approve_task(mock_db, uuid.uuid4(), current_user)
+
+        assert mock_task.status == OnboardingPlanTaskStatus.APPROVED
+
+    async def test_raises_400_when_not_completed(self, service, mock_db):
+        current_user = MagicMock()
+        current_user.id = uuid.uuid4()
+        plan_id = uuid.uuid4()
+
+        mock_task = MagicMock()
+        mock_task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+        mock_task.plan_id = plan_id
+
+        mock_plan = MagicMock()
+        mock_plan.id = plan_id
+        mock_plan.manager_id = current_user.id
+
+        with patch("app.services.task_workflow_service.plan_task_repository") as mock_task_repo, \
+             patch("app.services.task_workflow_service.plan_repository") as mock_plan_repo:
+
+            mock_task_repo.get_by_id = AsyncMock(return_value=mock_task)
+            mock_plan_repo.get_by_id = AsyncMock(return_value=mock_plan)
+
+            with pytest.raises(ValidationError) as exc_info:
+                await service.approve_task(mock_db, uuid.uuid4(), current_user)
+
+            assert exc_info.value.code == "TASK_NOT_APPROVABLE"
+
+    async def test_raises_400_when_already_approved(self, service, mock_db):
+        current_user = MagicMock()
+        current_user.id = uuid.uuid4()
+        plan_id = uuid.uuid4()
+
+        mock_task = MagicMock()
+        mock_task.status = OnboardingPlanTaskStatus.APPROVED
+        mock_task.plan_id = plan_id
+
+        mock_plan = MagicMock()
+        mock_plan.id = plan_id
+        mock_plan.manager_id = current_user.id
+
+        with patch("app.services.task_workflow_service.plan_task_repository") as mock_task_repo, \
+             patch("app.services.task_workflow_service.plan_repository") as mock_plan_repo:
+
+            mock_task_repo.get_by_id = AsyncMock(return_value=mock_task)
+            mock_plan_repo.get_by_id = AsyncMock(return_value=mock_plan)
+
+            with pytest.raises(ValidationError) as exc_info:
+                await service.approve_task(mock_db, uuid.uuid4(), current_user)
+
+            assert exc_info.value.code == "TASK_NOT_APPROVABLE"
+
+
+class TestReturnTask:
+
+    async def test_transitions_completed_to_in_progress(self, service, mock_db):
+        current_user = MagicMock()
+        current_user.id = uuid.uuid4()
+        plan_id = uuid.uuid4()
+
+        mock_task = MagicMock()
+        mock_task.status = OnboardingPlanTaskStatus.COMPLETED
+        mock_task.plan_id = plan_id
+
+        mock_plan = MagicMock()
+        mock_plan.id = plan_id
+        mock_plan.manager_id = current_user.id
+
+        with patch("app.services.task_workflow_service.plan_task_repository") as mock_task_repo, \
+             patch("app.services.task_workflow_service.plan_repository") as mock_plan_repo:
+
+            mock_task_repo.get_by_id = AsyncMock(return_value=mock_task)
+            mock_plan_repo.get_by_id = AsyncMock(return_value=mock_plan)
+
+            await service.return_task(mock_db, uuid.uuid4(), current_user, ReturnTask(content="Please redo"))
+
+        assert mock_task.status == OnboardingPlanTaskStatus.IN_PROGRESS
+
+    async def test_raises_400_when_content_is_empty(self, service, mock_db):
+        current_user = MagicMock()
+        current_user.id = uuid.uuid4()
+        plan_id = uuid.uuid4()
+
+        mock_task = MagicMock()
+        mock_task.status = OnboardingPlanTaskStatus.COMPLETED
+        mock_task.plan_id = plan_id
+
+        mock_plan = MagicMock()
+        mock_plan.id = plan_id
+        mock_plan.manager_id = current_user.id
+
+        with patch("app.services.task_workflow_service.plan_task_repository") as mock_task_repo, \
+             patch("app.services.task_workflow_service.plan_repository") as mock_plan_repo:
+
+            mock_task_repo.get_by_id = AsyncMock(return_value=mock_task)
+            mock_plan_repo.get_by_id = AsyncMock(return_value=mock_plan)
+
+            with pytest.raises(ValidationError) as exc_info:
+                await service.return_task(mock_db, uuid.uuid4(), current_user, ReturnTask(content="   "))
+
+            assert exc_info.value.code == "RETURN_COMMENT_REQUIRED"
+
+    async def test_raises_400_when_not_completed(self, service, mock_db):
+        current_user = MagicMock()
+        current_user.id = uuid.uuid4()
+        plan_id = uuid.uuid4()
+
+        mock_task = MagicMock()
+        mock_task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+        mock_task.plan_id = plan_id
+
+        mock_plan = MagicMock()
+        mock_plan.id = plan_id
+        mock_plan.manager_id = current_user.id
+
+        with patch("app.services.task_workflow_service.plan_task_repository") as mock_task_repo, \
+             patch("app.services.task_workflow_service.plan_repository") as mock_plan_repo:
+
+            mock_task_repo.get_by_id = AsyncMock(return_value=mock_task)
+            mock_plan_repo.get_by_id = AsyncMock(return_value=mock_plan)
+
+            with pytest.raises(ValidationError) as exc_info:
+                await service.return_task(mock_db, uuid.uuid4(), current_user, ReturnTask(content="feedback"))
+
+            assert exc_info.value.code == "TASK_NOT_APPROVABLE"

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -20,6 +20,8 @@ import TemplateDetailPage from '@/features/template/pages/TemplateDetailPage'
 import CreatePlanPage from '@/features/plan/pages/CreatePlanPage'
 import PlanDetailPage from '@/features/plan/pages/PlanDetailPage'
 import EmployeePlanPage from '@/features/plan/pages/EmployeePlanPage'
+import ManagerApprovalsPage from '@/features/plan/pages/ManagerApprovalsPage'
+import ManagerTaskReviewPage from '@/features/plan/pages/ManagerTaskReviewPage'
 
 
 export default function App() {
@@ -48,6 +50,8 @@ export default function App() {
       <Route element={<RequireRole roles={[USER_ROLES.MANAGER]} />}>
         <Route element={<DashboardLayout />}>
           <Route path={ROUTES.MANAGER_DASHBOARD} element={<ManagerDashboard />} />
+          <Route path={ROUTES.MANAGER_APPROVALS} element={<ManagerApprovalsPage />} />
+          <Route path="/manager/tasks/:id" element={<ManagerTaskReviewPage />} />
           <Route path={ROUTES.PROFILE} element={<ProfilePage />} />
         </Route>
       </Route>

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -38,6 +38,11 @@ export const API = {
   TASKS: {
     START: (id: string) => `/api/v1/tasks/${id}/start`,
     COMPLETE: (id: string) => `/api/v1/tasks/${id}/complete`,
+    APPROVE: (id: string) => `/api/v1/tasks/${id}/approve`,
+    RETURN: (id: string) => `/api/v1/tasks/${id}/return`,
+  },
+  MANAGER: {
+    APPROVALS: '/api/v1/manager/approvals',
   },
   TEMPLATES: {
     LIST: '/api/v1/templates/',

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -14,6 +14,8 @@ export const ROUTES = {
   HR_PLAN_NEW: '/hr/plans/new',
   HR_PLAN_DETAIL: (id: string) => `/hr/plans/${id}`,
   EMPLOYEE_PLAN: '/employee/plan',
+  MANAGER_APPROVALS: '/manager/approvals',
+  MANAGER_TASK_REVIEW: (id: string) => `/manager/tasks/${id}`,
 }
 
 export const ERROR_ROUTES = {

--- a/apps/frontend/src/features/plan/hooks/useManagerApprovalsPage.ts
+++ b/apps/frontend/src/features/plan/hooks/useManagerApprovalsPage.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getPendingApprovals, approveTask } from '@/features/plan/services/managerService'
+import { ROUTES } from '@/constants/routes'
+import type { components } from '@/types/api'
+
+type ApprovalTaskResponse = components['schemas']['ApprovalTaskResponse']
+
+export function useManagerApprovalsPage() {
+  const navigate = useNavigate()
+  const [tasks, setTasks] = useState<ApprovalTaskResponse[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    getPendingApprovals()
+      .then(setTasks)
+      .catch(() => {})
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  async function handleApprove(taskId: string) {
+    await approveTask(taskId)
+    setTasks((prev) => prev.filter((t) => t.id !== taskId))
+  }
+
+  function handleReview(taskId: string) {
+    navigate(ROUTES.MANAGER_TASK_REVIEW(taskId))
+  }
+
+  return { tasks, isLoading, handleApprove, handleReview }
+}

--- a/apps/frontend/src/features/plan/hooks/useManagerTaskReviewPage.ts
+++ b/apps/frontend/src/features/plan/hooks/useManagerTaskReviewPage.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { getPendingApprovals, approveTask, returnTask } from '@/features/plan/services/managerService'
+import { ROUTES } from '@/constants/routes'
+import type { components } from '@/types/api'
+
+type ApprovalTaskResponse = components['schemas']['ApprovalTaskResponse']
+
+export function useManagerTaskReviewPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+
+  const [task, setTask] = useState<ApprovalTaskResponse | null>(null)
+  const [showReturnModal, setShowReturnModal] = useState(false)
+  const [returnComment, setReturnComment] = useState('')
+
+  useEffect(() => {
+    if (!id) return
+    getPendingApprovals()
+      .then((tasks) => setTask(tasks.find((t) => t.id === id) ?? null))
+      .catch(() => {})
+  }, [id])
+
+  async function handleApprove() {
+    if (!id) return
+    await approveTask(id)
+    navigate(ROUTES.MANAGER_APPROVALS)
+  }
+
+  async function handleReturn() {
+    if (!id || !returnComment.trim()) return
+    await returnTask(id, returnComment)
+    navigate(ROUTES.MANAGER_APPROVALS)
+  }
+
+  return {
+    task,
+    showReturnModal,
+    setShowReturnModal,
+    returnComment,
+    setReturnComment,
+    handleApprove,
+    handleReturn,
+  }
+}

--- a/apps/frontend/src/features/plan/pages/ManagerApprovalsPage.test.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerApprovalsPage.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import ManagerApprovalsPage from './ManagerApprovalsPage'
+
+const { mockGetPendingApprovals, mockApproveTask, mockNavigate } = vi.hoisted(() => ({
+  mockGetPendingApprovals: vi.fn(),
+  mockApproveTask: vi.fn(),
+  mockNavigate: vi.fn(),
+}))
+
+vi.mock('@/features/plan/services/managerService', () => ({
+  getPendingApprovals: mockGetPendingApprovals,
+  approveTask: mockApproveTask,
+  returnTask: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const mockTask = {
+  id: 'task-1',
+  plan_id: 'plan-1',
+  title: 'Setup laptop',
+  description: null,
+  deadline: '2026-06-08',
+  status: 'completed' as const,
+  is_required: true,
+  order: 1,
+  created_at: '',
+  employee_name: 'John Employee',
+  plan_start_date: '2026-06-01',
+}
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <ManagerApprovalsPage />
+    </MemoryRouter>
+  )
+}
+
+describe('ManagerApprovalsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders pending task list with employee name and deadline', async () => {
+    mockGetPendingApprovals.mockResolvedValue([mockTask])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup laptop')).toBeInTheDocument()
+      expect(screen.getByText('John Employee · Due: 2026-06-08')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no pending tasks', async () => {
+    mockGetPendingApprovals.mockResolvedValue([])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/no tasks pending approval/i)).toBeInTheDocument()
+    })
+  })
+
+  it('approve button calls approveTask and removes task from list', async () => {
+    mockGetPendingApprovals.mockResolvedValue([mockTask])
+    mockApproveTask.mockResolvedValue({ ...mockTask, status: 'approved' })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Setup laptop'))
+    await userEvent.click(screen.getByRole('button', { name: /approve/i }))
+
+    await waitFor(() => expect(mockApproveTask).toHaveBeenCalledWith('task-1'))
+  })
+
+  it('review button navigates to task review page', async () => {
+    mockGetPendingApprovals.mockResolvedValue([mockTask])
+    renderPage()
+
+    await waitFor(() => screen.getByText('Setup laptop'))
+    await userEvent.click(screen.getByRole('button', { name: /review/i }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/manager/tasks/task-1')
+  })
+})

--- a/apps/frontend/src/features/plan/pages/ManagerApprovalsPage.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerApprovalsPage.tsx
@@ -1,0 +1,46 @@
+import { useManagerApprovalsPage } from '@/features/plan/hooks/useManagerApprovalsPage'
+
+export default function ManagerApprovalsPage() {
+  const { tasks, isLoading, handleApprove, handleReview } = useManagerApprovalsPage()
+
+  if (isLoading) return null
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h2 className="text-xl font-semibold text-gray-900 mb-6">Pending Approvals</h2>
+
+      {tasks.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
+          <p className="text-gray-500 text-sm">No tasks pending approval.</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100">
+          {tasks.map((task) => (
+            <div key={task.id} className="px-5 py-4 flex items-center justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900">{task.title}</p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  {task.employee_name} · Due: {task.deadline}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  onClick={() => handleApprove(task.id)}
+                  className="text-xs bg-green-700 hover:bg-green-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => handleReview(task.id)}
+                  className="text-xs border border-gray-300 hover:border-gray-400 text-gray-700 font-medium px-3 py-1.5 rounded-lg transition-colors"
+                >
+                  Review
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.test.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import ManagerTaskReviewPage from './ManagerTaskReviewPage'
+
+const { mockGetPendingApprovals, mockApproveTask, mockReturnTask, mockNavigate } = vi.hoisted(() => ({
+  mockGetPendingApprovals: vi.fn(),
+  mockApproveTask: vi.fn(),
+  mockReturnTask: vi.fn(),
+  mockNavigate: vi.fn(),
+}))
+
+vi.mock('@/features/plan/services/managerService', () => ({
+  getPendingApprovals: mockGetPendingApprovals,
+  approveTask: mockApproveTask,
+  returnTask: mockReturnTask,
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const mockTask = {
+  id: 'task-1',
+  plan_id: 'plan-1',
+  title: 'Setup laptop',
+  description: 'Install all required software',
+  deadline: '2026-06-08',
+  status: 'completed' as const,
+  is_required: true,
+  order: 1,
+  created_at: '',
+  employee_name: 'John Employee',
+  plan_start_date: '2026-06-01',
+}
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={['/manager/tasks/task-1']}>
+      <Routes>
+        <Route path="/manager/tasks/:id" element={<ManagerTaskReviewPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('ManagerTaskReviewPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetPendingApprovals.mockResolvedValue([mockTask])
+  })
+
+  it('renders task detail with approve and return buttons', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup laptop')).toBeInTheDocument()
+      expect(screen.getByText('John Employee')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /return/i })).toBeInTheDocument()
+    })
+  })
+
+  it('approve button calls approveTask and navigates back', async () => {
+    mockApproveTask.mockResolvedValue({ ...mockTask, status: 'approved' })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Setup laptop'))
+    await userEvent.click(screen.getByRole('button', { name: /approve/i }))
+
+    await waitFor(() => {
+      expect(mockApproveTask).toHaveBeenCalledWith('task-1')
+      expect(mockNavigate).toHaveBeenCalledWith('/manager/approvals')
+    })
+  })
+
+  it('return button opens modal', async () => {
+    renderPage()
+
+    await waitFor(() => screen.getByText('Setup laptop'))
+    await userEvent.click(screen.getByRole('button', { name: /^return$/i }))
+
+    expect(screen.getByText('Return Task')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/feedback comment/i)).toBeInTheDocument()
+  })
+
+  it('submit is disabled when comment is empty', async () => {
+    renderPage()
+
+    await waitFor(() => screen.getByText('Setup laptop'))
+    await userEvent.click(screen.getByRole('button', { name: /^return$/i }))
+
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()
+  })
+
+  it('submit with comment calls returnTask and navigates back', async () => {
+    mockReturnTask.mockResolvedValue({ ...mockTask, status: 'in_progress' })
+    renderPage()
+
+    await waitFor(() => screen.getByText('Setup laptop'))
+    await userEvent.click(screen.getByRole('button', { name: /^return$/i }))
+    await userEvent.type(screen.getByPlaceholderText(/feedback comment/i), 'Please redo this.')
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(mockReturnTask).toHaveBeenCalledWith('task-1', 'Please redo this.')
+      expect(mockNavigate).toHaveBeenCalledWith('/manager/approvals')
+    })
+  })
+})

--- a/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.tsx
@@ -1,0 +1,107 @@
+import { Link } from 'react-router-dom'
+import { useManagerTaskReviewPage } from '@/features/plan/hooks/useManagerTaskReviewPage'
+import { ROUTES } from '@/constants/routes'
+
+export default function ManagerTaskReviewPage() {
+  const {
+    task,
+    showReturnModal,
+    setShowReturnModal,
+    returnComment,
+    setReturnComment,
+    handleApprove,
+    handleReturn,
+  } = useManagerTaskReviewPage()
+
+  if (!task) return null
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center gap-3 mb-6">
+        <Link
+          to={ROUTES.MANAGER_APPROVALS}
+          className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          ← Approvals
+        </Link>
+        <span className="text-gray-300">/</span>
+        <h2 className="text-xl font-semibold text-gray-900">Task Review</h2>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5 space-y-3 mb-4">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 w-28">Employee</span>
+          <span className="text-gray-900 font-medium">{task.employee_name}</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 w-28">Task</span>
+          <span className="text-gray-900 font-medium">{task.title}</span>
+        </div>
+        {task.description && (
+          <div className="flex gap-2 text-sm">
+            <span className="text-gray-500 w-28 shrink-0">Description</span>
+            <span className="text-gray-700">{task.description}</span>
+          </div>
+        )}
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 w-28">Deadline</span>
+          <span className="text-gray-900">{task.deadline}</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 w-28">Required</span>
+          <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600' : 'text-gray-400'}`}>
+            {task.is_required ? 'Yes' : 'No'}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={handleApprove}
+          className="bg-green-700 hover:bg-green-800 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+        >
+          Approve
+        </button>
+        <button
+          onClick={() => setShowReturnModal(true)}
+          className="border border-red-300 hover:border-red-400 text-red-700 text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+        >
+          Return
+        </button>
+      </div>
+
+      {showReturnModal && (
+        <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-md mx-4">
+            <h3 className="text-base font-semibold text-gray-900 mb-3">Return Task</h3>
+            <p className="text-sm text-gray-500 mb-3">
+              Provide feedback so the employee knows what to fix.
+            </p>
+            <textarea
+              value={returnComment}
+              onChange={(e) => setReturnComment(e.target.value)}
+              placeholder="Feedback comment (required)"
+              rows={4}
+              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+            <div className="flex gap-2 mt-4 justify-end">
+              <button
+                onClick={() => { setShowReturnModal(false); setReturnComment('') }}
+                className="text-sm border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:border-gray-400 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleReturn}
+                disabled={!returnComment.trim()}
+                className="text-sm bg-red-700 hover:bg-red-800 disabled:opacity-40 disabled:cursor-not-allowed text-white font-medium px-4 py-2 rounded-lg transition-colors"
+              >
+                Submit
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/features/plan/services/managerService.ts
+++ b/apps/frontend/src/features/plan/services/managerService.ts
@@ -1,0 +1,21 @@
+import apiClient from '@/lib/apiClient'
+import type { components } from '@/types/api'
+import { API } from '@/constants/apiEndpoints'
+
+type ApprovalTaskResponse = components['schemas']['ApprovalTaskResponse']
+type OnboardingPlanTaskResponse = components['schemas']['OnboardingPlanTaskResponse']
+
+export async function getPendingApprovals(): Promise<ApprovalTaskResponse[]> {
+  const res = await apiClient.get(API.MANAGER.APPROVALS)
+  return res.data
+}
+
+export async function approveTask(taskId: string): Promise<OnboardingPlanTaskResponse> {
+  const res = await apiClient.patch(API.TASKS.APPROVE(taskId))
+  return res.data
+}
+
+export async function returnTask(taskId: string, content: string): Promise<OnboardingPlanTaskResponse> {
+  const res = await apiClient.patch(API.TASKS.RETURN(taskId), { content })
+  return res.data
+}

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -1,10 +1,12 @@
+import { Link } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
+import { ROUTES } from '@/constants/routes'
 
 export default function ManagerDashboard() {
   const user = useAuthStore((state) => state.user)
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-2xl mx-auto space-y-4">
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
         <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
           <span className="text-blue-700 text-xl font-bold">
@@ -15,6 +17,16 @@ export default function ManagerDashboard() {
           Welcome, {user?.first_name}
         </h2>
         <p className="text-sm text-gray-500 mt-2">You're signed in as Manager.</p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+        <h3 className="text-sm font-medium text-gray-700 mb-3">Quick links</h3>
+        <Link
+          to={ROUTES.MANAGER_APPROVALS}
+          className="inline-flex items-center gap-2 text-sm text-blue-700 hover:text-blue-900 font-medium transition-colors"
+        >
+          Pending Approvals →
+        </Link>
       </div>
     </div>
   )

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -624,6 +624,39 @@ export interface components {
              */
             start_date: string;
         };
+        /** ApprovalTaskResponse */
+        ApprovalTaskResponse: {
+            /** Id */
+            id: string;
+            /** Plan Id */
+            plan_id: string;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string | null;
+            /**
+             * Deadline
+             * Format: date
+             */
+            deadline: string;
+            status: components["schemas"]["OnboardingPlanTaskStatus"];
+            /** Is Required */
+            is_required: boolean;
+            /** Order */
+            order: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Employee Name */
+            employee_name: string;
+            /**
+             * Plan Start Date
+             * Format: date
+             */
+            plan_start_date: string;
+        };
         /** OnboardingPlanResponse */
         OnboardingPlanResponse: {
             /**

--- a/docs/guides/tutorials/backend/012-cross-model-response.md
+++ b/docs/guides/tutorials/backend/012-cross-model-response.md
@@ -1,0 +1,74 @@
+# Cross-Model Response Construction
+
+## The Problem
+
+The standard response pattern is `ResponseSchema.model_validate(orm_instance)` — it works when all response fields map directly to a single ORM object. This breaks when a response needs fields from **multiple related models**.
+
+`ApprovalTaskResponse` is an example: it combines fields from `OnboardingPlanTask`, `OnboardingPlan`, and `User` (the employee). There is no single ORM object to validate against.
+
+---
+
+## The Pattern
+
+When a response spans multiple models, build it manually in the service layer.
+
+**1. Define the schema without `from_attributes`**
+
+```python
+# app/schemas/onboarding_plan.py
+
+class ApprovalTaskResponse(BaseModel):
+    id: uuid.UUID
+    plan_id: uuid.UUID
+    title: str
+    deadline: date
+    status: OnboardingPlanTaskStatus
+    employee_name: str       # from plan.employee
+    plan_start_date: date    # from plan
+    # no model_config — cannot use from_attributes here
+```
+
+**2. Build instances manually in the service**
+
+```python
+# app/services/task_workflow_service.py
+
+async def get_pending_approvals(self, db, current_user):
+    plans = await plan_repository.get_all_by_manager(db, current_user.id)
+    result = []
+    for plan in plans:
+        for task in plan.tasks:
+            if task.status == OnboardingPlanTaskStatus.COMPLETED:
+                result.append(ApprovalTaskResponse(
+                    id=task.id,
+                    plan_id=task.plan_id,
+                    title=task.title,
+                    deadline=task.deadline,
+                    status=task.status,
+                    employee_name=f"{plan.employee.first_name} {plan.employee.last_name}",
+                    plan_start_date=plan.start_date,
+                    ...
+                ))
+    return result
+```
+
+**3. Repository must eager-load all needed relationships**
+
+```python
+# app/repositories/onboarding_plan_repository.py
+
+select(OnboardingPlan)
+    .options(
+        selectinload(OnboardingPlan.tasks),
+        selectinload(OnboardingPlan.employee),  # needed for employee_name
+    )
+```
+
+---
+
+## Rule
+
+> Use `model_validate(orm_instance)` when the response maps to one ORM object.
+> Build manually when the response aggregates fields from multiple objects.
+
+Manual construction is more verbose but avoids lazy-load errors and keeps the schema honest — it doesn't pretend to be an ORM-backed object when it isn't.


### PR DESCRIPTION
## Summary
- Added get_all_by_manager to OnboardingPlanRepository with eager load of tasks and employee
- Added ApprovalTaskResponse and ReturnTask schemas
- Added get_pending_approvals, approve_task, return_task to TaskWorkflowService
- New endpoints: GET /api/v1/manager/approvals, PATCH /api/v1/tasks/{id}/approve|return (MANAGER only)
- FE: ManagerApprovalsPage (/manager/approvals) — pending task list with approve/review actions
- FE: ManagerTaskReviewPage (/manager/tasks/:id) — task detail with approve button and return modal
- Return requires mandatory feedback comment — empty comment returns 400

## Out of scope
File download via presigned URL deferred to US-014b

## Test plan
- [ ] BE: `pytest tests/unit/services/test_manager_task_review_service.py tests/integration/api/test_manager_task_review_endpoints.py`
- [ ] FE: `pnpm test`
- [ ] Login as manager → Pending Approvals → Approve task → status becomes approved
- [ ] Login as manager → Review → Return → empty comment disabled → submit with comment → status back to in_progress
