### PR TITLE
fix: auth, login error display, return_comment persistence, e2e config

### DIFF
--- a/apps/backend/alembic/versions/a3f1c8e2d047_add_return_comment_to_onboarding_plan_tasks.py
+++ b/apps/backend/alembic/versions/a3f1c8e2d047_add_return_comment_to_onboarding_plan_tasks.py
@@ -1,0 +1,25 @@
+"""add_return_comment_to_onboarding_plan_tasks
+
+Revision ID: a3f1c8e2d047
+Revises: 14e90742db5f
+Create Date: 2026-05-14 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a3f1c8e2d047'
+down_revision: Union[str, None] = '14e90742db5f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('onboarding_plan_tasks', sa.Column('return_comment', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('onboarding_plan_tasks', 'return_comment')

--- a/apps/backend/app/models/onboarding_plan_task.py
+++ b/apps/backend/app/models/onboarding_plan_task.py
@@ -41,5 +41,6 @@ class OnboardingPlanTask(Base, TimestampMixin):
     )
     is_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     order: Mapped[int] = mapped_column(Integer, nullable=False)
+    return_comment: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     plan: Mapped["OnboardingPlan"] = relationship("OnboardingPlan", back_populates="tasks")

--- a/apps/backend/app/services/auth_service.py
+++ b/apps/backend/app/services/auth_service.py
@@ -23,6 +23,8 @@ class AuthService:
         user = await user_repository.get_by_email(db, email)
         if not user or not pwd_context.verify(password, user.password_hash):
             raise AuthenticationError(*messages.INVALID_CREDENTIALS)
+        if not user.is_active:
+            raise AuthenticationError(*messages.USER_DEACTIVATED)
 
         access_token = create_access_token(user.id)
         refresh_token_value = create_refresh_token()

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -91,6 +91,7 @@ class TaskWorkflowService:
         if not data.content or not data.content.strip():
             raise ValidationError(*messages.RETURN_COMMENT_REQUIRED)
         task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+        task.return_comment = data.content
         await db.commit()
         await db.refresh(task)
         return task

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   workers: 1,
   use: {
-    baseURL: 'http://frontend:3000',
+    baseURL: process.env.BASE_URL ?? 'http://localhost:5173',
   },
   projects: [
     {

--- a/apps/frontend/src/features/auth/hooks/useLoginForm.ts
+++ b/apps/frontend/src/features/auth/hooks/useLoginForm.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -18,9 +19,11 @@ export function useLoginForm() {
   const setUser = useAuthStore((state) => state.setUser)
 
   const errorCode = searchParams.get('error')
-  const pageError = errorCode ? (ERROR_MESSAGES[errorCode] ?? 'Something went wrong.') : ''
+  const [submitError, setSubmitError] = useState('')
+  const pageError = submitError || (errorCode ? (ERROR_MESSAGES[errorCode] ?? 'Something went wrong.') : '')
 
   async function onSubmit(data: LoginFormData) {
+    setSubmitError('')
     try {
       await login(data)
       const user = await getMe()
@@ -29,7 +32,7 @@ export function useLoginForm() {
       else if (user.role === USER_ROLES.MANAGER) navigate(ROUTES.MANAGER_DASHBOARD)
       else navigate(ROUTES.EMPLOYEE_DASHBOARD)
     } catch (err) {
-      console.error(getErrorMessage(err))
+      setSubmitError(getErrorMessage(err))
     }
   }
 


### PR DESCRIPTION
## Summary

- **BE** — Deactivated users can no longer log in; `AuthService.login()` now raises `USER_DEACTIVATED` immediately instead of issuing a token that fails on the next request.
- **FE** — Login form now displays API error messages (wrong password, deactivated account) to the user; previously errors were only written to `console.error` and the UI gave no feedback.
- **BE** — `return_task` now persists the manager's comment: added `return_comment` column to `OnboardingPlanTask`, Alembic migration, and the missing assignment in `TaskWorkflowService.return_task()`.
- **E2E** — `playwright.config.ts` `baseURL` now reads from `BASE_URL` env var with a local fallback (`http://localhost:5173`); previously it was hardcoded to the Docker hostname and tests could not run locally.

## Changed files

| File | Change |
|------|--------|
| `auth_service.py` | Added `is_active` check after credential verification |
| `useLoginForm.ts` | Added `submitError` state; catch block sets it instead of `console.error` |
| `onboarding_plan_task.py` | Added `return_comment: Text nullable` column |
| `a3f1c8e2d047_add_return_comment…py` | Alembic migration for new column |
| `task_workflow_service.py` | Added `task.return_comment = data.content` |
| `playwright.config.ts` | `baseURL` reads `process.env.BASE_URL` with local fallback |

## Test plan

- [ ] Login with a deactivated account → expect `USER_DEACTIVATED` error on the login page
- [ ] Login with wrong password → expect error message rendered in the form (not just console)
- [ ] Manager returns a task with a comment → verify comment is saved and visible to employee
- [ ] Run e2e tests locally without Docker (`BASE_URL` unset) → tests should hit `localhost:5173`
- [ ] Run e2e tests in Docker (`BASE_URL=http://frontend:3000`) → tests should still pass