### PR TITLE
feat(us-018): role-based dashboards with live stats

### DIFF
--- a/apps/backend/app/api/router.py
+++ b/apps/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow
+from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard
 
 
 api_router = APIRouter()
@@ -14,3 +14,4 @@ api_router.include_router(task_workflow.plans_router, prefix="/plans", tags=["em
 api_router.include_router(onboarding_plan.router, prefix="/plans", tags=["plans"])
 api_router.include_router(task_workflow.tasks_router, prefix="/tasks", tags=["employee-tasks"])
 api_router.include_router(task_workflow.manager_router, prefix="/manager", tags=["manager-tasks"])
+api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])

--- a/apps/backend/app/api/v1/dashboard.py
+++ b/apps/backend/app/api/v1/dashboard.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import require_role
+from app.enums.user_role import UserRole
+from app.models.user import User
+from app.schemas.dashboard import EmployeeDashboardResponse, HRDashboardResponse, ManagerDashboardResponse
+from app.services.dashboard_service import DashboardService
+
+router = APIRouter()
+dashboard_service = DashboardService()
+
+
+@router.get("/hr", response_model=HRDashboardResponse)
+async def get_hr_dashboard(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> HRDashboardResponse:
+    return await dashboard_service.get_hr_stats(db=db)
+
+
+@router.get("/manager", response_model=ManagerDashboardResponse)
+async def get_manager_dashboard(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.MANAGER)),
+) -> ManagerDashboardResponse:
+    return await dashboard_service.get_manager_stats(db=db, manager_id=current_user.id)
+
+
+@router.get("/employee", response_model=EmployeeDashboardResponse)
+async def get_employee_dashboard(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.EMPLOYEE)),
+) -> EmployeeDashboardResponse:
+    return await dashboard_service.get_employee_stats(db=db, user_id=current_user.id)

--- a/apps/backend/app/repositories/department_repository.py
+++ b/apps/backend/app/repositories/department_repository.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.department import Department
@@ -27,3 +27,12 @@ class DepartmentRepository:
     async def create(self, db: AsyncSession, department: Department) -> Department:
         db.add(department)
         return department
+
+    async def count_active(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count()).where(
+                Department.is_active.is_(True),
+                Department.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()

--- a/apps/backend/app/repositories/onboarding_plan_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_repository.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -45,3 +45,12 @@ class OnboardingPlanRepository:
             )
         )
         return result.scalar_one_or_none()
+
+    async def count_active(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count()).where(
+                OnboardingPlan.is_active.is_(True),
+                OnboardingPlan.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()

--- a/apps/backend/app/repositories/onboarding_plan_task_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_task_repository.py
@@ -2,6 +2,8 @@ import uuid
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.models.onboarding_plan import OnboardingPlan
 from app.models.onboarding_plan_task import OnboardingPlanTask
 
 
@@ -27,3 +29,30 @@ class OnboardingPlanTaskRepository:
             )
         )
         return result.scalar_one() or 0
+
+    async def count_completed_across_active_plans(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count())
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+            .where(
+                OnboardingPlanTask.status == OnboardingPlanTaskStatus.COMPLETED,
+                OnboardingPlanTask.deleted_at.is_(None),
+                OnboardingPlan.is_active.is_(True),
+                OnboardingPlan.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()
+
+    async def count_completed_by_manager(self, db: AsyncSession, manager_id: uuid.UUID) -> int:
+        result = await db.execute(
+            select(func.count())
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+            .where(
+                OnboardingPlanTask.status == OnboardingPlanTaskStatus.COMPLETED,
+                OnboardingPlanTask.deleted_at.is_(None),
+                OnboardingPlan.manager_id == manager_id,
+                OnboardingPlan.is_active.is_(True),
+                OnboardingPlan.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()

--- a/apps/backend/app/repositories/user_repository.py
+++ b/apps/backend/app/repositories/user_repository.py
@@ -36,6 +36,15 @@ class UserRepository:
         )
         return result.scalar_one()
 
+    async def count_active(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count()).where(
+                User.is_active.is_(True),
+                User.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()
+
     async def get_all(
         self,
         db: AsyncSession,

--- a/apps/backend/app/schemas/dashboard.py
+++ b/apps/backend/app/schemas/dashboard.py
@@ -1,0 +1,23 @@
+from datetime import date
+from pydantic import BaseModel
+
+
+class HRDashboardResponse(BaseModel):
+    active_users: int
+    active_plans: int
+    active_departments: int
+    pending_approvals: int
+
+
+class ManagerDashboardResponse(BaseModel):
+    active_plans: int
+    pending_approvals: int
+    total_employees: int
+
+
+class EmployeeDashboardResponse(BaseModel):
+    total_tasks: int
+    approved_tasks: int
+    completed_tasks: int
+    in_progress_tasks: int
+    next_deadline: date | None

--- a/apps/backend/app/services/dashboard_service.py
+++ b/apps/backend/app/services/dashboard_service.py
@@ -1,0 +1,74 @@
+import uuid
+from datetime import date
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.repositories.department_repository import DepartmentRepository
+from app.repositories.onboarding_plan_repository import OnboardingPlanRepository
+from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
+from app.repositories.user_repository import UserRepository
+from app.schemas.dashboard import EmployeeDashboardResponse, HRDashboardResponse, ManagerDashboardResponse
+
+user_repository = UserRepository()
+plan_repository = OnboardingPlanRepository()
+plan_task_repository = OnboardingPlanTaskRepository()
+department_repository = DepartmentRepository()
+
+
+class DashboardService:
+
+    async def get_hr_stats(self, db: AsyncSession) -> HRDashboardResponse:
+        active_users = await user_repository.count_active(db)
+        active_plans = await plan_repository.count_active(db)
+        active_departments = await department_repository.count_active(db)
+        pending_approvals = await plan_task_repository.count_completed_across_active_plans(db)
+
+        return HRDashboardResponse(
+            active_users=active_users,
+            active_plans=active_plans,
+            active_departments=active_departments,
+            pending_approvals=pending_approvals,
+        )
+
+    async def get_manager_stats(self, db: AsyncSession, manager_id: uuid.UUID) -> ManagerDashboardResponse:
+        plans = await plan_repository.get_all_by_manager(db, manager_id)
+        pending_approvals = await plan_task_repository.count_completed_by_manager(db, manager_id)
+
+        return ManagerDashboardResponse(
+            active_plans=len(plans),
+            pending_approvals=pending_approvals,
+            total_employees=len({p.user_id for p in plans}),
+        )
+
+    async def get_employee_stats(self, db: AsyncSession, user_id: uuid.UUID) -> EmployeeDashboardResponse:
+        plan = await plan_repository.get_active_by_user(db, user_id)
+
+        if not plan:
+            return EmployeeDashboardResponse(
+                total_tasks=0,
+                approved_tasks=0,
+                completed_tasks=0,
+                in_progress_tasks=0,
+                next_deadline=None,
+            )
+
+        active_tasks = [t for t in plan.tasks if t.deleted_at is None]
+
+        approved = sum(1 for t in active_tasks if t.status == OnboardingPlanTaskStatus.APPROVED)
+        completed = sum(1 for t in active_tasks if t.status == OnboardingPlanTaskStatus.COMPLETED)
+        in_progress = sum(1 for t in active_tasks if t.status == OnboardingPlanTaskStatus.IN_PROGRESS)
+
+        pending_deadlines: list[date] = [
+            t.deadline for t in active_tasks
+            if t.status not in (OnboardingPlanTaskStatus.APPROVED, OnboardingPlanTaskStatus.CANCELLED)
+        ]
+        next_deadline = min(pending_deadlines) if pending_deadlines else None
+
+        return EmployeeDashboardResponse(
+            total_tasks=len(active_tasks),
+            approved_tasks=approved,
+            completed_tasks=completed,
+            in_progress_tasks=in_progress,
+            next_deadline=next_deadline,
+        )

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -44,6 +44,11 @@ export const API = {
   MANAGER: {
     APPROVALS: '/api/v1/manager/approvals',
   },
+  DASHBOARD: {
+    HR: '/api/v1/dashboard/hr',
+    MANAGER: '/api/v1/dashboard/manager',
+    EMPLOYEE: '/api/v1/dashboard/employee',
+  },
   TEMPLATES: {
     LIST: '/api/v1/templates/',
     CREATE: '/api/v1/templates/',

--- a/apps/frontend/src/features/dashboard/hooks/useEmployeeDashboard.ts
+++ b/apps/frontend/src/features/dashboard/hooks/useEmployeeDashboard.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getEmployeeDashboard, type EmployeeDashboardStats } from '@/features/dashboard/services/dashboardService'
+
+export function useEmployeeDashboard() {
+  const [stats, setStats] = useState<EmployeeDashboardStats | null>(null)
+
+  useEffect(() => {
+    getEmployeeDashboard().then(setStats).catch(() => {})
+  }, [])
+
+  return { stats }
+}

--- a/apps/frontend/src/features/dashboard/hooks/useHRDashboard.ts
+++ b/apps/frontend/src/features/dashboard/hooks/useHRDashboard.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getHRDashboard, type HRDashboardStats } from '@/features/dashboard/services/dashboardService'
+
+export function useHRDashboard() {
+  const [stats, setStats] = useState<HRDashboardStats | null>(null)
+
+  useEffect(() => {
+    getHRDashboard().then(setStats).catch(() => {})
+  }, [])
+
+  return { stats }
+}

--- a/apps/frontend/src/features/dashboard/hooks/useManagerDashboard.ts
+++ b/apps/frontend/src/features/dashboard/hooks/useManagerDashboard.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getManagerDashboard, type ManagerDashboardStats } from '@/features/dashboard/services/dashboardService'
+
+export function useManagerDashboard() {
+  const [stats, setStats] = useState<ManagerDashboardStats | null>(null)
+
+  useEffect(() => {
+    getManagerDashboard().then(setStats).catch(() => {})
+  }, [])
+
+  return { stats }
+}

--- a/apps/frontend/src/features/dashboard/services/dashboardService.ts
+++ b/apps/frontend/src/features/dashboard/services/dashboardService.ts
@@ -1,0 +1,38 @@
+import apiClient from '@/lib/apiClient'
+import { API } from '@/constants/apiEndpoints'
+
+export interface HRDashboardStats {
+  active_users: number
+  active_plans: number
+  active_departments: number
+  pending_approvals: number
+}
+
+export interface ManagerDashboardStats {
+  active_plans: number
+  pending_approvals: number
+  total_employees: number
+}
+
+export interface EmployeeDashboardStats {
+  total_tasks: number
+  approved_tasks: number
+  completed_tasks: number
+  in_progress_tasks: number
+  next_deadline: string | null
+}
+
+export async function getHRDashboard(): Promise<HRDashboardStats> {
+  const res = await apiClient.get(API.DASHBOARD.HR)
+  return res.data
+}
+
+export async function getManagerDashboard(): Promise<ManagerDashboardStats> {
+  const res = await apiClient.get(API.DASHBOARD.MANAGER)
+  return res.data
+}
+
+export async function getEmployeeDashboard(): Promise<EmployeeDashboardStats> {
+  const res = await apiClient.get(API.DASHBOARD.EMPLOYEE)
+  return res.data
+}

--- a/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
@@ -1,23 +1,70 @@
 import { Link } from 'react-router-dom'
+import { format } from 'date-fns'
 import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
+import { useEmployeeDashboard } from '@/features/dashboard/hooks/useEmployeeDashboard'
+
+function StatCard({ label, value }: { label: string; value: string | number | undefined }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    </div>
+  )
+}
 
 export default function EmployeeDashboard() {
   const user = useAuthStore((state) => state.user)
+  const { stats } = useEmployeeDashboard()
+
+  const progressPct = stats && stats.total_tasks > 0
+    ? Math.round(((stats.approved_tasks) / stats.total_tasks) * 100)
+    : null
 
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
           <span className="text-blue-700 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">
-          Welcome, {user?.first_name}
-        </h2>
-        <p className="text-sm text-gray-500 mt-2">You're signed in as Employee.</p>
+        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 mt-1">You're signed in as Employee.</p>
       </div>
+
+      {stats && stats.total_tasks > 0 ? (
+        <>
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-sm font-medium text-gray-700">Plan Progress</p>
+              <p className="text-sm font-semibold text-gray-900">{progressPct}%</p>
+            </div>
+            <div className="w-full bg-gray-100 rounded-full h-2">
+              <div
+                className="bg-blue-600 h-2 rounded-full transition-all"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-500 mt-2">
+              {stats.approved_tasks} of {stats.total_tasks} tasks approved
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-4">
+            <StatCard label="In Progress" value={stats.in_progress_tasks} />
+            <StatCard label="Completed" value={stats.completed_tasks} />
+            <StatCard
+              label="Next Deadline"
+              value={stats.next_deadline ? format(new Date(stats.next_deadline), 'dd MMM yyyy') : 'None'}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+          <p className="text-sm text-gray-400">No active onboarding plan assigned.</p>
+        </div>
+      )}
 
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
         <h3 className="text-sm font-medium text-gray-700 mb-3">Quick links</h3>

--- a/apps/frontend/src/features/users/pages/HRDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.tsx
@@ -1,20 +1,36 @@
 import { useAuthStore } from '@/stores/authStore'
+import { useHRDashboard } from '@/features/dashboard/hooks/useHRDashboard'
+
+function StatCard({ label, value }: { label: string; value: number | undefined }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    </div>
+  )
+}
 
 export default function HRDashboard() {
   const user = useAuthStore((state) => state.user)
+  const { stats } = useHRDashboard()
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
           <span className="text-blue-700 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">
-          Welcome, {user?.first_name}
-        </h2>
-        <p className="text-sm text-gray-500 mt-2">You're signed in as HR Admin.</p>
+        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 mt-1">You're signed in as HR Admin.</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <StatCard label="Active Users" value={stats?.active_users} />
+        <StatCard label="Active Plans" value={stats?.active_plans} />
+        <StatCard label="Active Departments" value={stats?.active_departments} />
+        <StatCard label="Pending Approvals" value={stats?.pending_approvals} />
       </div>
     </div>
   )

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -1,22 +1,37 @@
 import { Link } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
+import { useManagerDashboard } from '@/features/dashboard/hooks/useManagerDashboard'
+
+function StatCard({ label, value }: { label: string; value: number | undefined }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    </div>
+  )
+}
 
 export default function ManagerDashboard() {
   const user = useAuthStore((state) => state.user)
+  const { stats } = useManagerDashboard()
 
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
           <span className="text-blue-700 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">
-          Welcome, {user?.first_name}
-        </h2>
-        <p className="text-sm text-gray-500 mt-2">You're signed in as Manager.</p>
+        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 mt-1">You're signed in as Manager.</p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <StatCard label="Active Plans" value={stats?.active_plans} />
+        <StatCard label="Pending Approvals" value={stats?.pending_approvals} />
+        <StatCard label="Employees" value={stats?.total_employees} />
       </div>
 
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">


### PR DESCRIPTION
## Summary

- **BE** — Three role-gated dashboard endpoints (`/api/v1/dashboard/hr`, `/manager`, `/employee`) backed by count methods added to existing repositories
- **FE** — All three dashboard pages replaced with real stat cards; Employee dashboard adds a progress bar and next deadline display

## Changed files

| File | Change |
|------|--------|
| `user_repository.py` | Added `count_active()` |
| `onboarding_plan_repository.py` | Added `count_active()` |
| `department_repository.py` | Added `count_active()` |
| `onboarding_plan_task_repository.py` | Added `count_completed_across_active_plans()`, `count_completed_by_manager()` |
| `schemas/dashboard.py` | New — response schemas per role |
| `services/dashboard_service.py` | New — orchestrates repo calls per role |
| `api/v1/dashboard.py` | New — three role-gated GET endpoints |
| `router.py` | Registered `/dashboard` prefix |
| `apiEndpoints.ts` | Added `DASHBOARD` constants |
| `dashboardService.ts` + 3 hooks | New FE service and per-role hooks |
| `HRDashboard.tsx` | Stat cards: active users, plans, departments, pending approvals |
| `ManagerDashboard.tsx` | Stat cards: active plans, pending approvals, total employees |
| `EmployeeDashboard.tsx` | Progress bar + stat cards: in progress, completed, next deadline |

## Test plan

- [ ] HR Admin dashboard shows correct counts for users, plans, departments, pending approvals
- [ ] Manager dashboard shows stats scoped to their own plans only
- [ ] Employee dashboard shows progress bar and next deadline; empty state when no active plan