### PR TITLE
feat(us-016): email notifications for plan and task workflow events

### DIFF
--- a/apps/backend/app/services/email_service.py
+++ b/apps/backend/app/services/email_service.py
@@ -6,14 +6,8 @@ from app.core.config import settings
 
 class EmailService:
 
-    async def send_invitation_email(
-        self,
-        to_email: str,
-        token: str,
-        role: str,
-    ) -> None:
+    async def send_invitation_email(self, to_email: str, token: str, role: str) -> None:
         registration_url = f"{settings.FRONTEND_URL}/register?token={token}"
-
         message = Mail(
             from_email=settings.SENDGRID_FROM_EMAIL,
             to_emails=to_email,
@@ -24,6 +18,69 @@ class EmailService:
                 <p>This link expires in 7 days.</p>
             """,
         )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
 
+    async def send_plan_started_email(self, to_email: str, first_name: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject="Your onboarding plan is ready",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>Your onboarding plan has been created. You can now view your tasks and get started.</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_completed_email(self, to_email: str, manager_first_name: str, employee_name: str, task_title: str) -> None:
+        approvals_url = f"{settings.FRONTEND_URL}/manager/approvals"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"{employee_name} completed a task — review required",
+            html_content=f"""
+                <p>Hi {manager_first_name},</p>
+                <p><strong>{employee_name}</strong> has marked the following task as complete and it is awaiting your review:</p>
+                <p><strong>{task_title}</strong></p>
+                <p><a href="{approvals_url}">Go to pending approvals</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_approved_email(self, to_email: str, first_name: str, task_title: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Task approved: {task_title}",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>Your task has been approved by your manager:</p>
+                <p><strong>{task_title}</strong></p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_returned_email(self, to_email: str, first_name: str, task_title: str, comment: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Task returned for revision: {task_title}",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>Your manager has returned the following task for revision:</p>
+                <p><strong>{task_title}</strong></p>
+                <p><strong>Feedback:</strong> {comment}</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
         client = SendGridAPIClient(settings.SENDGRID_API_KEY)
         client.send(message)

--- a/apps/backend/app/services/onboarding_plan_service.py
+++ b/apps/backend/app/services/onboarding_plan_service.py
@@ -18,11 +18,19 @@ from app.schemas.onboarding_plan import (
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 from app.errors import NotFoundError, ValidationError
 from app.errors import messages
+from app.repositories.user_repository import UserRepository
 from app.services.audit_service import AuditService
+from app.services.email_service import EmailService
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 audit_service = AuditService()
+email_service = EmailService()
 
 plan_repository = OnboardingPlanRepository()
+user_repository = UserRepository()
 plan_task_repository = OnboardingPlanTaskRepository()
 template_repository = TemplateRepository()
 template_task_repository = TemplateTaskRepository()
@@ -69,6 +77,15 @@ class OnboardingPlanService:
         if actor_id:
             await audit_service.log(db, actor_id=actor_id, action="plan.created", entity_type="plan", entity_id=plan.id)
             await db.commit()
+        try:
+            employee = await user_repository.get_by_id(db, data.user_id)
+            if employee:
+                await email_service.send_plan_started_email(
+                    to_email=employee.email,
+                    first_name=employee.first_name,
+                )
+        except Exception as e:
+            logger.error(f"Failed to send plan_started email: {e}")
         return await plan_repository.get_by_id(db, plan.id)
 
     async def get_plan(self, db: AsyncSession, plan_id: uuid.UUID) -> OnboardingPlan:

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -10,12 +10,20 @@ from app.models.onboarding_plan_task import OnboardingPlanTask
 from app.models.user import User
 from app.repositories.onboarding_plan_repository import OnboardingPlanRepository
 from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
+from app.repositories.user_repository import UserRepository
 from app.schemas.onboarding_plan import ApprovalTaskResponse, ReturnTask
 from app.services.audit_service import AuditService
+from app.services.email_service import EmailService
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 plan_repository = OnboardingPlanRepository()
 plan_task_repository = OnboardingPlanTaskRepository()
+user_repository = UserRepository()
 audit_service = AuditService()
+email_service = EmailService()
 
 VALID_TRANSITIONS = {
     OnboardingPlanTaskStatus.NOT_STARTED: OnboardingPlanTaskStatus.IN_PROGRESS,
@@ -52,6 +60,20 @@ class TaskWorkflowService:
         await db.refresh(task)
         await audit_service.log(db, actor_id=current_user.id, action="task.completed", entity_type="task", entity_id=task.id)
         await db.commit()
+        try:
+            plan = await plan_repository.get_by_id(db, task.plan_id)
+            if plan:
+                manager = await user_repository.get_by_id(db, plan.manager_id)
+                employee_name = f"{current_user.first_name} {current_user.last_name}"
+                if manager:
+                    await email_service.send_task_completed_email(
+                        to_email=manager.email,
+                        manager_first_name=manager.first_name,
+                        employee_name=employee_name,
+                        task_title=task.title,
+                    )
+        except Exception as e:
+            logger.error(f"Failed to send task_completed email: {e}")
         return task
 
     async def get_pending_approvals(
@@ -88,6 +110,18 @@ class TaskWorkflowService:
         await db.refresh(task)
         await audit_service.log(db, actor_id=current_user.id, action="task.approved", entity_type="task", entity_id=task.id)
         await db.commit()
+        try:
+            plan = await plan_repository.get_by_id(db, task.plan_id)
+            if plan:
+                employee = await user_repository.get_by_id(db, plan.user_id)
+                if employee:
+                    await email_service.send_task_approved_email(
+                        to_email=employee.email,
+                        first_name=employee.first_name,
+                        task_title=task.title,
+                    )
+        except Exception as e:
+            logger.error(f"Failed to send task_approved email: {e}")
         return task
 
     async def return_task(
@@ -104,6 +138,19 @@ class TaskWorkflowService:
         await db.refresh(task)
         await audit_service.log(db, actor_id=current_user.id, action="task.returned", entity_type="task", entity_id=task.id, detail=data.content)
         await db.commit()
+        try:
+            plan = await plan_repository.get_by_id(db, task.plan_id)
+            if plan:
+                employee = await user_repository.get_by_id(db, plan.user_id)
+                if employee:
+                    await email_service.send_task_returned_email(
+                        to_email=employee.email,
+                        first_name=employee.first_name,
+                        task_title=task.title,
+                        comment=data.content,
+                    )
+        except Exception as e:
+            logger.error(f"Failed to send task_returned email: {e}")
         return task
 
     async def _get_task_for_manager(


### PR DESCRIPTION
## Summary

Added email notifications at every key workflow stage via SendGrid.

## Emails added

| Event | Recipient | Trigger |
|-------|-----------|---------|
| Plan assigned | Employee | HR Admin creates onboarding plan |
| Task completed | Manager | Employee marks task as complete |
| Task approved | Employee | Manager approves task |
| Task returned | Employee | Manager returns task with feedback (comment included in email) |

## Implementation

**`email_service.py`** — 4 new methods added alongside existing `send_invitation_email`:
- `send_plan_started_email`
- `send_task_completed_email`
- `send_task_approved_email`
- `send_task_returned_email`

**`onboarding_plan_service.py`** — hook in `create_plan`: fetches employee by `user_id`, sends plan started email.

**`task_workflow_service.py`** — hooks in `complete_task`, `approve_task`, `return_task`: fetches recipient via `user_repository.get_by_id()` from plan, sends appropriate email.

All email calls happen after `db.commit()` wrapped in `try/except` — email failure never rolls back or blocks the main operation. Errors are logged via `logger.error`.

## Test plan

- [ ] HR Admin creates plan → employee receives "Your onboarding plan is ready" email
- [ ] Employee completes task → manager receives "review required" email with task title
- [ ] Manager approves task → employee receives "task approved" email
- [ ] Manager returns task → employee receives "task returned" email with feedback comment
- [ ] SendGrid API failure → operation still succeeds, error logged