### PR TITLE
feat: US-020 Admin Reports & Export

### DIFF
--- a/apps/backend/alembic/versions/c9a4b2e1f8d3_add_audit_log_table.py
+++ b/apps/backend/alembic/versions/c9a4b2e1f8d3_add_audit_log_table.py
@@ -1,7 +1,7 @@
 """add_audit_log_table
 
 Revision ID: c9a4b2e1f8d3
-Revises: a3f1c8e2d047
+Revises: 14e90742db5f
 Create Date: 2026-05-14 12:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 
 revision: str = 'c9a4b2e1f8d3'
-down_revision: Union[str, None] = 'a3f1c8e2d047'
+down_revision: Union[str, None] = '14e90742db5f'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -23,7 +23,7 @@ def upgrade() -> None:
         'audit_logs',
         sa.Column('id', UUID(as_uuid=True), primary_key=True),
         sa.Column('actor_id', UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
-        sa.Column('action', sa.String(64), nullable=False, index=True),
+        sa.Column('action', sa.String(64), nullable=False),
         sa.Column('entity_type', sa.String(64), nullable=False),
         sa.Column('entity_id', UUID(as_uuid=True), nullable=False),
         sa.Column('detail', sa.Text(), nullable=True),

--- a/apps/backend/app/api/router.py
+++ b/apps/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard, audit
+from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard, audit, reports
 
 
 api_router = APIRouter()
@@ -16,3 +16,4 @@ api_router.include_router(task_workflow.tasks_router, prefix="/tasks", tags=["em
 api_router.include_router(task_workflow.manager_router, prefix="/manager", tags=["manager-tasks"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 api_router.include_router(audit.router, prefix="/audit", tags=["audit"])
+api_router.include_router(reports.router, prefix="/reports", tags=["reports"])

--- a/apps/backend/app/api/v1/reports.py
+++ b/apps/backend/app/api/v1/reports.py
@@ -1,0 +1,75 @@
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import require_role
+from app.enums.user_role import UserRole
+from app.models.user import User
+from app.schemas.reports import DepartmentCompletionRow, TemplateCompletionRow, BottleneckRow
+from app.services.reports_service import ReportsService
+
+router = APIRouter()
+reports_service = ReportsService()
+
+
+@router.get("/completion-time", response_model=list[DepartmentCompletionRow])
+async def get_completion_time(
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
+    format: str = Query("json", pattern="^(json|csv)$"),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> list[DepartmentCompletionRow] | StreamingResponse:
+    rows = await reports_service.get_completion_time(db, start_date, end_date)
+    if format == "csv":
+        headers = ["department_name", "total_plans", "avg_completion_days"]
+        csv_data = reports_service.to_csv(headers, [r.model_dump() for r in rows])
+        return StreamingResponse(
+            iter([csv_data]),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=completion-time.csv"},
+        )
+    return rows
+
+
+@router.get("/task-completion-rates", response_model=list[TemplateCompletionRow])
+async def get_task_completion_rates(
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
+    format: str = Query("json", pattern="^(json|csv)$"),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> list[TemplateCompletionRow] | StreamingResponse:
+    rows = await reports_service.get_task_completion_rates(db, start_date, end_date)
+    if format == "csv":
+        headers = ["template_name", "total_tasks", "completed_tasks", "completion_rate"]
+        csv_data = reports_service.to_csv(headers, [r.model_dump() for r in rows])
+        return StreamingResponse(
+            iter([csv_data]),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=task-completion-rates.csv"},
+        )
+    return rows
+
+
+@router.get("/bottlenecks", response_model=list[BottleneckRow])
+async def get_bottlenecks(
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
+    format: str = Query("json", pattern="^(json|csv)$"),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> list[BottleneckRow] | StreamingResponse:
+    rows = await reports_service.get_bottlenecks(db, start_date, end_date)
+    if format == "csv":
+        headers = ["task_title", "returned_count", "overdue_count"]
+        csv_data = reports_service.to_csv(headers, [r.model_dump() for r in rows])
+        return StreamingResponse(
+            iter([csv_data]),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=bottlenecks.csv"},
+        )
+    return rows

--- a/apps/backend/app/repositories/reports_repository.py
+++ b/apps/backend/app/repositories/reports_repository.py
@@ -1,0 +1,146 @@
+from datetime import date
+from sqlalchemy import func, case, and_, cast
+from sqlalchemy.dialects.postgresql import TIMESTAMP
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.models.department import Department
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
+from app.models.onboarding_template import OnboardingTemplate
+from app.models.user import User
+
+_TERMINAL = [
+    OnboardingPlanTaskStatus.COMPLETED,
+    OnboardingPlanTaskStatus.APPROVED,
+    OnboardingPlanTaskStatus.CANCELLED,
+]
+
+
+class ReportsRepository:
+
+    async def get_completion_time_by_department(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[dict]:
+        # Subquery: last approval timestamp per plan (= plan completion moment)
+        last_approval = (
+            select(
+                OnboardingPlanTask.plan_id,
+                func.max(OnboardingPlanTask.updated_at).label("completed_at"),
+            )
+            .where(OnboardingPlanTask.status == OnboardingPlanTaskStatus.APPROVED)
+            .group_by(OnboardingPlanTask.plan_id)
+            .subquery()
+        )
+
+        days_expr = (
+            func.extract(
+                "epoch",
+                last_approval.c.completed_at - cast(OnboardingPlan.start_date, TIMESTAMP),
+            )
+            / 86400
+        )
+
+        query = (
+            select(
+                Department.name.label("department_name"),
+                func.count(OnboardingPlan.id.distinct()).label("total_plans"),
+                func.avg(days_expr).label("avg_completion_days"),
+            )
+            .join(last_approval, OnboardingPlan.id == last_approval.c.plan_id)
+            .join(User, OnboardingPlan.user_id == User.id)
+            .join(Department, User.department_id == Department.id)
+        )
+
+        if start_date:
+            query = query.where(OnboardingPlan.start_date >= start_date)
+        if end_date:
+            query = query.where(OnboardingPlan.start_date <= end_date)
+
+        query = query.group_by(Department.name).order_by(Department.name)
+        result = await db.execute(query)
+        return [dict(row._mapping) for row in result.all()]
+
+    async def get_task_completion_rates(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[dict]:
+        done_statuses = [OnboardingPlanTaskStatus.COMPLETED, OnboardingPlanTaskStatus.APPROVED]
+        done_case = case(
+            (OnboardingPlanTask.status.in_(done_statuses), 1),
+            else_=0,
+        )
+
+        query = (
+            select(
+                OnboardingTemplate.name.label("template_name"),
+                func.count(OnboardingPlanTask.id).label("total_tasks"),
+                func.sum(done_case).label("completed_tasks"),
+            )
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+            .join(OnboardingTemplate, OnboardingPlan.template_id == OnboardingTemplate.id)
+        )
+
+        if start_date:
+            query = query.where(OnboardingPlan.start_date >= start_date)
+        if end_date:
+            query = query.where(OnboardingPlan.start_date <= end_date)
+
+        query = query.group_by(OnboardingTemplate.name).order_by(OnboardingTemplate.name)
+        result = await db.execute(query)
+        return [dict(row._mapping) for row in result.all()]
+
+    async def get_bottlenecks(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[dict]:
+        today = date.today()
+
+        returned_case = case(
+            (OnboardingPlanTask.status == OnboardingPlanTaskStatus.RETURNED, 1),
+            else_=0,
+        )
+        overdue_case = case(
+            (
+                and_(
+                    OnboardingPlanTask.deadline < today,
+                    OnboardingPlanTask.status.notin_(_TERMINAL),
+                ),
+                1,
+            ),
+            else_=0,
+        )
+
+        total_expr = func.sum(returned_case) + func.sum(overdue_case)
+
+        query = (
+            select(
+                OnboardingPlanTask.title.label("task_title"),
+                func.sum(returned_case).label("returned_count"),
+                func.sum(overdue_case).label("overdue_count"),
+            )
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+        )
+
+        if start_date:
+            query = query.where(OnboardingPlan.start_date >= start_date)
+        if end_date:
+            query = query.where(OnboardingPlan.start_date <= end_date)
+
+        query = (
+            query.group_by(OnboardingPlanTask.title)
+            .having(total_expr > 0)
+            .order_by(total_expr.desc())
+            .limit(20)
+        )
+
+        result = await db.execute(query)
+        return [dict(row._mapping) for row in result.all()]

--- a/apps/backend/app/schemas/reports.py
+++ b/apps/backend/app/schemas/reports.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, computed_field
+
+
+class DepartmentCompletionRow(BaseModel):
+    department_name: str
+    total_plans: int
+    avg_completion_days: float | None
+
+    @computed_field
+    @property
+    def avg_completion_days_rounded(self) -> float | None:
+        if self.avg_completion_days is None:
+            return None
+        return round(self.avg_completion_days, 1)
+
+
+class TemplateCompletionRow(BaseModel):
+    template_name: str
+    total_tasks: int
+    completed_tasks: int
+
+    @computed_field
+    @property
+    def completion_rate(self) -> float:
+        if self.total_tasks == 0:
+            return 0.0
+        return round(self.completed_tasks / self.total_tasks * 100, 1)
+
+
+class BottleneckRow(BaseModel):
+    task_title: str
+    returned_count: int
+    overdue_count: int

--- a/apps/backend/app/services/reports_service.py
+++ b/apps/backend/app/services/reports_service.py
@@ -1,0 +1,49 @@
+import csv
+import io
+from datetime import date
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.reports_repository import ReportsRepository
+from app.schemas.reports import DepartmentCompletionRow, TemplateCompletionRow, BottleneckRow
+
+reports_repository = ReportsRepository()
+
+
+class ReportsService:
+
+    async def get_completion_time(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[DepartmentCompletionRow]:
+        rows = await reports_repository.get_completion_time_by_department(
+            db, start_date, end_date
+        )
+        return [DepartmentCompletionRow(**r) for r in rows]
+
+    async def get_task_completion_rates(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[TemplateCompletionRow]:
+        rows = await reports_repository.get_task_completion_rates(db, start_date, end_date)
+        return [TemplateCompletionRow(**r) for r in rows]
+
+    async def get_bottlenecks(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[BottleneckRow]:
+        rows = await reports_repository.get_bottlenecks(db, start_date, end_date)
+        return [BottleneckRow(**r) for r in rows]
+
+    def to_csv(self, headers: list[str], rows: list[dict]) -> str:
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=headers, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+        return buf.getvalue()

--- a/apps/backend/scripts/seed.py
+++ b/apps/backend/scripts/seed.py
@@ -11,281 +11,533 @@ from sqlalchemy.orm import sessionmaker
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import app.models  # noqa — ensures all models are registered with Base
+
+from app.models.audit_log import AuditLog
 from app.models.department import Department
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
 from app.models.onboarding_template import OnboardingTemplate
 from app.models.template_task import TemplateTask
 from app.models.user import User
-from app.models.onboarding_plan import OnboardingPlan
-from app.models.onboarding_plan_task import OnboardingPlanTask
 from app.enums.user_role import UserRole
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 
 DATABASE_URL = os.environ["DATABASE_URL"]
-
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+TODAY = date.today()
+
+# ─── Fixed IDs ────────────────────────────────────────────────────────────────
+
+ADMIN_ID     = uuid.UUID("00000000-0000-0000-0000-000000000001")
+MANAGER_ID   = uuid.UUID("00000000-0000-0000-0000-000000000002")
+EMPLOYEE_ID  = uuid.UUID("00000000-0000-0000-0000-000000000003")
+ALICE_ID     = uuid.UUID("00000000-0000-0000-0000-000000000004")
+BOB_ID       = uuid.UUID("00000000-0000-0000-0000-000000000005")
+MANAGER2_ID  = uuid.UUID("00000000-0000-0000-0000-000000000006")
+
+DEPT_ENG_ID  = uuid.UUID("00000000-0000-0000-0000-000000000101")
+DEPT_HR_ID   = uuid.UUID("00000000-0000-0000-0000-000000000102")
+DEPT_PROD_ID = uuid.UUID("00000000-0000-0000-0000-000000000103")
+
+TMPL_ENG_ID  = uuid.UUID("00000000-0000-0000-0001-000000000001")
+TMPL_HR_ID   = uuid.UUID("00000000-0000-0000-0001-000000000002")
+TMPL_PROD_ID = uuid.UUID("00000000-0000-0000-0001-000000000003")
+
+PLAN_EMP_ID   = uuid.UUID("00000000-0000-0000-0003-000000000001")
+PLAN_ALICE_ID = uuid.UUID("00000000-0000-0000-0003-000000000002")
+PLAN_BOB_ID   = uuid.UUID("00000000-0000-0000-0003-000000000003")
+
+# ─── Departments ──────────────────────────────────────────────────────────────
+
 SEED_DEPARTMENTS = [
-    {"id": uuid.UUID("00000000-0000-0000-0000-000000000101"), "name": "Engineering"},
-    {"id": uuid.UUID("00000000-0000-0000-0000-000000000102"), "name": "Human Resources"},
-    {"id": uuid.UUID("00000000-0000-0000-0000-000000000103"), "name": "Product"},
+    {"id": DEPT_ENG_ID,  "name": "Engineering"},
+    {"id": DEPT_HR_ID,   "name": "Human Resources"},
+    {"id": DEPT_PROD_ID, "name": "Product"},
 ]
 
-SEED_TEMPLATES = [
-    {
-        "id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "name": "Engineering Onboarding",
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000101"),
-        "is_active": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "name": "HR Onboarding",
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000102"),
-        "is_active": False,
-    },
-]
-
-SEED_TASKS = [
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000001"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Set up development environment",
-        "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
-        "order": 1,
-        "deadline_days": 1,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000002"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Complete security and compliance training",
-        "description": "Finish the mandatory security awareness course on the learning portal.",
-        "order": 2,
-        "deadline_days": 3,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000003"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Review architecture documentation",
-        "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
-        "order": 3,
-        "deadline_days": 5,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000004"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Submit first pull request",
-        "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
-        "order": 4,
-        "deadline_days": 14,
-        "is_required": False,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000005"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "title": "Review HR policies and handbook",
-        "description": "Read the company handbook and sign the policy acknowledgement form.",
-        "order": 1,
-        "deadline_days": 2,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000006"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "title": "Shadow a payroll processing session",
-        "description": "Sit in on the monthly payroll run with a senior HR specialist.",
-        "order": 2,
-        "deadline_days": 7,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000007"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "title": "Complete HRIS system training",
-        "description": "Finish self-paced training modules for the HR information system.",
-        "order": 3,
-        "deadline_days": 10,
-        "is_required": False,
-    },
-]
+# ─── Users ────────────────────────────────────────────────────────────────────
 
 SEED_USERS = [
     {
-        "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
-        "email": "admin@stepup.com",
-        "password": "Admin1234!",
-        "first_name": "HR",
-        "last_name": "Admin",
-        "role": UserRole.HR_ADMIN,
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000102"),
+        "id": ADMIN_ID, "email": "admin@stepup.com", "password": "Admin1234!",
+        "first_name": "HR", "last_name": "Admin",
+        "role": UserRole.HR_ADMIN, "department_id": DEPT_HR_ID,
     },
     {
-        "id": uuid.UUID("00000000-0000-0000-0000-000000000002"),
-        "email": "manager@stepup.com",
-        "password": "Manager1234!",
-        "first_name": "Manager",
-        "last_name": "User",
-        "role": UserRole.MANAGER,
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000101"),
+        "id": MANAGER_ID, "email": "manager@stepup.com", "password": "Manager1234!",
+        "first_name": "Alex", "last_name": "Manager",
+        "role": UserRole.MANAGER, "department_id": DEPT_ENG_ID,
     },
     {
-        "id": uuid.UUID("00000000-0000-0000-0000-000000000003"),
-        "email": "employee@stepup.com",
-        "password": "Employee1234!",
-        "first_name": "Employee",
-        "last_name": "User",
-        "role": UserRole.EMPLOYEE,
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000101"),
+        "id": MANAGER2_ID, "email": "manager2@stepup.com", "password": "Manager1234!",
+        "first_name": "Sam", "last_name": "Lead",
+        "role": UserRole.MANAGER, "department_id": DEPT_PROD_ID,
+    },
+    {
+        "id": EMPLOYEE_ID, "email": "employee@stepup.com", "password": "Employee1234!",
+        "first_name": "John", "last_name": "Doe",
+        "role": UserRole.EMPLOYEE, "department_id": DEPT_ENG_ID,
+    },
+    {
+        "id": ALICE_ID, "email": "alice@stepup.com", "password": "Employee1234!",
+        "first_name": "Alice", "last_name": "Chen",
+        "role": UserRole.EMPLOYEE, "department_id": DEPT_ENG_ID,
+    },
+    {
+        "id": BOB_ID, "email": "bob@stepup.com", "password": "Employee1234!",
+        "first_name": "Bob", "last_name": "Marley",
+        "role": UserRole.EMPLOYEE, "department_id": DEPT_PROD_ID,
+    },
+]
+
+# ─── Templates ────────────────────────────────────────────────────────────────
+
+SEED_TEMPLATES = [
+    {"id": TMPL_ENG_ID,  "name": "Engineering Onboarding", "department_id": DEPT_ENG_ID,  "is_active": True},
+    {"id": TMPL_HR_ID,   "name": "HR Onboarding",          "department_id": DEPT_HR_ID,   "is_active": False},
+    {"id": TMPL_PROD_ID, "name": "Product Onboarding",     "department_id": DEPT_PROD_ID, "is_active": True},
+]
+
+# ─── Template Tasks ───────────────────────────────────────────────────────────
+
+SEED_TEMPLATE_TASKS = [
+    # Engineering Onboarding
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000001"),
+        "template_id": TMPL_ENG_ID, "order": 1, "deadline_days": 1, "is_required": True,
+        "title": "Set up development environment",
+        "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000002"),
+        "template_id": TMPL_ENG_ID, "order": 2, "deadline_days": 3, "is_required": True,
+        "title": "Complete security and compliance training",
+        "description": "Finish the mandatory security awareness course on the learning portal.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000003"),
+        "template_id": TMPL_ENG_ID, "order": 3, "deadline_days": 5, "is_required": True,
+        "title": "Review architecture documentation",
+        "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000004"),
+        "template_id": TMPL_ENG_ID, "order": 4, "deadline_days": 14, "is_required": False,
+        "title": "Submit first pull request",
+        "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
+    },
+    # HR Onboarding
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000005"),
+        "template_id": TMPL_HR_ID, "order": 1, "deadline_days": 2, "is_required": True,
+        "title": "Review HR policies and handbook",
+        "description": "Read the company handbook and sign the policy acknowledgement form.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000006"),
+        "template_id": TMPL_HR_ID, "order": 2, "deadline_days": 7, "is_required": True,
+        "title": "Shadow a payroll processing session",
+        "description": "Sit in on the monthly payroll run with a senior HR specialist.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000007"),
+        "template_id": TMPL_HR_ID, "order": 3, "deadline_days": 10, "is_required": False,
+        "title": "Complete HRIS system training",
+        "description": "Finish self-paced training modules for the HR information system.",
+    },
+    # Product Onboarding
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000008"),
+        "template_id": TMPL_PROD_ID, "order": 1, "deadline_days": 2, "is_required": True,
+        "title": "Meet the product team",
+        "description": "Schedule 1:1s with each product team member and your PM lead.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000009"),
+        "template_id": TMPL_PROD_ID, "order": 2, "deadline_days": 5, "is_required": True,
+        "title": "Review product roadmap",
+        "description": "Go through the current and upcoming quarter roadmap with your PM lead.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000010"),
+        "template_id": TMPL_PROD_ID, "order": 3, "deadline_days": 14, "is_required": False,
+        "title": "Shadow a customer call",
+        "description": "Join a live customer demo or support call to understand user pain points.",
+    },
+]
+
+# ─── Plans ────────────────────────────────────────────────────────────────────
+#
+# Plan 1 — employee@stepup.com (Engineering, in-progress)
+#   Task 1 APPROVED, Task 2 RETURNED (returned by manager), Task 3 IN_PROGRESS, Task 4 NOT_STARTED + overdue
+#   → Shows in task completion rates. Task 2 shows in bottlenecks.
+#
+# Plan 2 — alice@stepup.com (Engineering, completed)
+#   All tasks APPROVED. start_date = 40 days ago.
+#   → Shows in completion time report (Engineering, ~40 days avg).
+#   → Shows in task completion rates (100% for Engineering Onboarding).
+#
+# Plan 3 — bob@stepup.com (Product, stuck)
+#   Task 1 RETURNED, Task 2 RETURNED, Task 3 NOT_STARTED + overdue.
+#   → Shows in bottlenecks report for Product Onboarding.
+
+SEED_PLANS = [
+    {
+        "id": PLAN_EMP_ID,
+        "user_id": EMPLOYEE_ID,
+        "template_id": TMPL_ENG_ID,
+        "manager_id": MANAGER_ID,
+        "start_date": TODAY - timedelta(days=20),
+        "tasks": [
+            {
+                "title": "Set up development environment",
+                "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
+                "deadline": TODAY - timedelta(days=19),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 1,
+            },
+            {
+                "title": "Complete security and compliance training",
+                "description": "Finish the mandatory security awareness course on the learning portal.",
+                "deadline": TODAY - timedelta(days=17),
+                "status": OnboardingPlanTaskStatus.RETURNED,
+                "is_required": True, "order": 2,
+            },
+            {
+                "title": "Review architecture documentation",
+                "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
+                "deadline": TODAY + timedelta(days=2),
+                "status": OnboardingPlanTaskStatus.IN_PROGRESS,
+                "is_required": True, "order": 3,
+            },
+            {
+                "title": "Submit first pull request",
+                "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
+                "deadline": TODAY - timedelta(days=6),
+                "status": OnboardingPlanTaskStatus.NOT_STARTED,
+                "is_required": False, "order": 4,
+            },
+        ],
+    },
+    {
+        "id": PLAN_ALICE_ID,
+        "user_id": ALICE_ID,
+        "template_id": TMPL_ENG_ID,
+        "manager_id": MANAGER_ID,
+        "start_date": TODAY - timedelta(days=40),
+        "tasks": [
+            {
+                "title": "Set up development environment",
+                "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
+                "deadline": TODAY - timedelta(days=39),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 1,
+            },
+            {
+                "title": "Complete security and compliance training",
+                "description": "Finish the mandatory security awareness course on the learning portal.",
+                "deadline": TODAY - timedelta(days=37),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 2,
+            },
+            {
+                "title": "Review architecture documentation",
+                "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
+                "deadline": TODAY - timedelta(days=35),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 3,
+            },
+            {
+                "title": "Submit first pull request",
+                "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
+                "deadline": TODAY - timedelta(days=26),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": False, "order": 4,
+            },
+        ],
+    },
+    {
+        "id": PLAN_BOB_ID,
+        "user_id": BOB_ID,
+        "template_id": TMPL_PROD_ID,
+        "manager_id": MANAGER2_ID,
+        "start_date": TODAY - timedelta(days=15),
+        "tasks": [
+            {
+                "title": "Meet the product team",
+                "description": "Schedule 1:1s with each product team member and your PM lead.",
+                "deadline": TODAY - timedelta(days=13),
+                "status": OnboardingPlanTaskStatus.RETURNED,
+                "is_required": True, "order": 1,
+            },
+            {
+                "title": "Review product roadmap",
+                "description": "Go through the current and upcoming quarter roadmap with your PM lead.",
+                "deadline": TODAY - timedelta(days=10),
+                "status": OnboardingPlanTaskStatus.RETURNED,
+                "is_required": True, "order": 2,
+            },
+            {
+                "title": "Shadow a customer call",
+                "description": "Join a live customer demo or support call to understand user pain points.",
+                "deadline": TODAY - timedelta(days=1),
+                "status": OnboardingPlanTaskStatus.NOT_STARTED,
+                "is_required": False, "order": 3,
+            },
+        ],
+    },
+]
+
+# ─── Audit Logs ───────────────────────────────────────────────────────────────
+
+SEED_AUDIT_LOGS = [
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000001"),
+        "actor_id": ADMIN_ID, "action": "user.invited",
+        "entity_type": "invitation", "entity_id": uuid.UUID("00000000-0000-0000-0088-000000000001"),
+        "detail": "alice@stepup.com invited as employee",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000002"),
+        "actor_id": ADMIN_ID, "action": "user.invited",
+        "entity_type": "invitation", "entity_id": uuid.UUID("00000000-0000-0000-0088-000000000002"),
+        "detail": "bob@stepup.com invited as employee",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000003"),
+        "actor_id": ALICE_ID, "action": "user.registered",
+        "entity_type": "user", "entity_id": ALICE_ID,
+        "detail": "Alice Chen completed registration",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000004"),
+        "actor_id": BOB_ID, "action": "user.registered",
+        "entity_type": "user", "entity_id": BOB_ID,
+        "detail": "Bob Marley completed registration",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000005"),
+        "actor_id": ADMIN_ID, "action": "plan.created",
+        "entity_type": "onboarding_plan", "entity_id": PLAN_EMP_ID,
+        "detail": "Plan created for employee@stepup.com",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000006"),
+        "actor_id": ADMIN_ID, "action": "plan.created",
+        "entity_type": "onboarding_plan", "entity_id": PLAN_ALICE_ID,
+        "detail": "Plan created for alice@stepup.com",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000007"),
+        "actor_id": ADMIN_ID, "action": "plan.created",
+        "entity_type": "onboarding_plan", "entity_id": PLAN_BOB_ID,
+        "detail": "Plan created for bob@stepup.com",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000008"),
+        "actor_id": ALICE_ID, "action": "task.started",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000001"),
+        "detail": "Set up development environment",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000009"),
+        "actor_id": ALICE_ID, "action": "task.completed",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000001"),
+        "detail": "Set up development environment",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000010"),
+        "actor_id": MANAGER_ID, "action": "task.approved",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000001"),
+        "detail": "Set up development environment",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000011"),
+        "actor_id": EMPLOYEE_ID, "action": "task.started",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000002"),
+        "detail": "Complete security and compliance training",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000012"),
+        "actor_id": EMPLOYEE_ID, "action": "task.completed",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000002"),
+        "detail": "Complete security and compliance training",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000013"),
+        "actor_id": MANAGER_ID, "action": "task.returned",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000002"),
+        "detail": "Complete security and compliance training — certificate screenshot missing",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000014"),
+        "actor_id": BOB_ID, "action": "task.started",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000003"),
+        "detail": "Meet the product team",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000015"),
+        "actor_id": BOB_ID, "action": "task.completed",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000003"),
+        "detail": "Meet the product team",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000016"),
+        "actor_id": MANAGER2_ID, "action": "task.returned",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000003"),
+        "detail": "Meet the product team — needs documented meeting notes",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000017"),
+        "actor_id": ADMIN_ID, "action": "user.updated",
+        "entity_type": "user", "entity_id": EMPLOYEE_ID,
+        "detail": "Department updated",
     },
 ]
 
 
-async def seed():
+# ─── Seed helpers ─────────────────────────────────────────────────────────────
+
+async def seed_departments(session: AsyncSession) -> None:
+    for d in SEED_DEPARTMENTS:
+        exists = (await session.execute(select(Department).where(Department.id == d["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip dept: {d['name']}")
+            continue
+        session.add(Department(id=d["id"], name=d["name"]))
+        print(f"  + dept: {d['name']}")
+    await session.commit()
+
+
+async def seed_users(session: AsyncSession) -> None:
+    for u in SEED_USERS:
+        exists = (await session.execute(select(User).where(User.email == u["email"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip user: {u['email']}")
+            continue
+        session.add(User(
+            id=u["id"],
+            email=u["email"],
+            password_hash=pwd_context.hash(u["password"]),
+            first_name=u["first_name"],
+            last_name=u["last_name"],
+            role=u["role"],
+            department_id=u["department_id"],
+        ))
+        print(f"  + user: {u['email']} / {u['password']}")
+    await session.commit()
+
+
+async def seed_templates(session: AsyncSession) -> None:
+    for t in SEED_TEMPLATES:
+        exists = (await session.execute(select(OnboardingTemplate).where(OnboardingTemplate.id == t["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip template: {t['name']}")
+            continue
+        session.add(OnboardingTemplate(id=t["id"], name=t["name"], department_id=t["department_id"], is_active=t["is_active"]))
+        print(f"  + template: {t['name']}")
+    await session.commit()
+
+
+async def seed_template_tasks(session: AsyncSession) -> None:
+    for t in SEED_TEMPLATE_TASKS:
+        exists = (await session.execute(select(TemplateTask).where(TemplateTask.id == t["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip template task: {t['title']}")
+            continue
+        session.add(TemplateTask(
+            id=t["id"],
+            template_id=t["template_id"],
+            title=t["title"],
+            description=t["description"],
+            order=t["order"],
+            deadline_days=t["deadline_days"],
+            is_required=t["is_required"],
+        ))
+        print(f"  + template task: {t['title']}")
+    await session.commit()
+
+
+async def seed_plans(session: AsyncSession) -> None:
+    for p in SEED_PLANS:
+        exists = (await session.execute(select(OnboardingPlan).where(OnboardingPlan.id == p["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip plan: {p['id']}")
+            continue
+        plan = OnboardingPlan(
+            id=p["id"],
+            user_id=p["user_id"],
+            template_id=p["template_id"],
+            manager_id=p["manager_id"],
+            start_date=p["start_date"],
+            is_active=True,
+        )
+        session.add(plan)
+        await session.flush()
+
+        for t in p["tasks"]:
+            session.add(OnboardingPlanTask(
+                plan_id=plan.id,
+                title=t["title"],
+                description=t["description"],
+                deadline=t["deadline"],
+                status=t["status"],
+                is_required=t["is_required"],
+                order=t["order"],
+            ))
+            print(f"  + plan task: {t['title']} ({t['status'].value})")
+
+        await session.commit()
+        print(f"  + plan: {p['id']}")
+
+
+async def seed_audit_logs(session: AsyncSession) -> None:
+    for a in SEED_AUDIT_LOGS:
+        exists = (await session.execute(select(AuditLog).where(AuditLog.id == a["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip audit: {a['action']}")
+            continue
+        session.add(AuditLog(
+            id=a["id"],
+            actor_id=a["actor_id"],
+            action=a["action"],
+            entity_type=a["entity_type"],
+            entity_id=a["entity_id"],
+            detail=a["detail"],
+        ))
+        print(f"  + audit: {a['action']} — {a['detail']}")
+    await session.commit()
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+async def seed() -> None:
     engine = create_async_engine(DATABASE_URL)
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as session:
-        for seed_dept in SEED_DEPARTMENTS:
-            result = await session.execute(
-                select(Department).where(Department.id == seed_dept["id"])
-            )
-            existing = result.scalar_one_or_none()
+        print("\n[Departments]")
+        await seed_departments(session)
 
-            if existing:
-                print(f"Seed department already exists: {seed_dept['name']}")
-                continue
+        print("\n[Users]")
+        await seed_users(session)
 
-            dept = Department(id=seed_dept["id"], name=seed_dept["name"])
-            session.add(dept)
-            print(f"Seed department created: {seed_dept['name']}")
+        print("\n[Templates]")
+        await seed_templates(session)
 
-        await session.commit()
+        print("\n[Template Tasks]")
+        await seed_template_tasks(session)
 
-        for seed_user in SEED_USERS:
-            result = await session.execute(
-                select(User).where(User.email == seed_user["email"])
-            )
-            existing = result.scalar_one_or_none()
+        print("\n[Plans]")
+        await seed_plans(session)
 
-            if existing:
-                print(f"Seed user already exists: {seed_user['email']}")
-                continue
-
-            user = User(
-                id=seed_user["id"],
-                email=seed_user["email"],
-                password_hash=pwd_context.hash(seed_user["password"]),
-                first_name=seed_user["first_name"],
-                last_name=seed_user["last_name"],
-                role=seed_user["role"],
-                department_id=seed_user["department_id"],
-            )
-            session.add(user)
-            print(f"Seed user created: {seed_user['email']} / {seed_user['password']}")
-
-        await session.commit()
-
-        for seed_tmpl in SEED_TEMPLATES:
-            result = await session.execute(
-                select(OnboardingTemplate).where(OnboardingTemplate.id == seed_tmpl["id"])
-            )
-            existing = result.scalar_one_or_none()
-
-            if existing:
-                print(f"Seed template already exists: {seed_tmpl['name']}")
-                continue
-
-            tmpl = OnboardingTemplate(
-                id=seed_tmpl["id"],
-                name=seed_tmpl["name"],
-                department_id=seed_tmpl["department_id"],
-                is_active=seed_tmpl["is_active"],
-            )
-            session.add(tmpl)
-            print(f"Seed template created: {seed_tmpl['name']}")
-
-        await session.commit()
-
-        for seed_task in SEED_TASKS:
-            result = await session.execute(
-                select(TemplateTask).where(TemplateTask.id == seed_task["id"])
-            )
-            existing = result.scalar_one_or_none()
-
-            if existing:
-                print(f"Seed task already exists: {seed_task['title']}")
-                continue
-
-            task = TemplateTask(
-                id=seed_task["id"],
-                template_id=seed_task["template_id"],
-                title=seed_task["title"],
-                description=seed_task["description"],
-                order=seed_task["order"],
-                deadline_days=seed_task["deadline_days"],
-                is_required=seed_task["is_required"],
-            )
-            session.add(task)
-            print(f"Seed task created: {seed_task['title']}")
-
-        await session.commit()
-
-        result = await session.execute(
-            select(OnboardingPlan).where(
-                OnboardingPlan.user_id == uuid.UUID("00000000-0000-0000-0000-000000000003")
-            )
-        )
-        existing_plan = result.scalar_one_or_none()
-
-        if existing_plan:
-            print("Seed plan already exists")
-        else:
-            plan = OnboardingPlan(
-                id=uuid.UUID("00000000-0000-0000-0003-000000000001"),
-                user_id=uuid.UUID("00000000-0000-0000-0000-000000000003"),
-                template_id=uuid.UUID("00000000-0000-0000-0001-000000000001"),
-                manager_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
-                start_date=date(2026, 5, 1),
-                is_active=True,
-            )
-            session.add(plan)
-            await session.flush()
-
-            task_statuses = [
-                OnboardingPlanTaskStatus.CANCELLED,
-                OnboardingPlanTaskStatus.NOT_STARTED,
-                OnboardingPlanTaskStatus.NOT_STARTED,
-                OnboardingPlanTaskStatus.NOT_STARTED,
-            ]
-            template_tasks_result = await session.execute(
-                select(TemplateTask).where(
-                    TemplateTask.template_id == uuid.UUID("00000000-0000-0000-0001-000000000001"),
-                    TemplateTask.deleted_at.is_(None),
-                ).order_by(TemplateTask.order)
-            )
-            template_tasks = list(template_tasks_result.scalars().all())
-
-            for i, task in enumerate(template_tasks):
-                task_status = task_statuses[i] if i < len(task_statuses) else OnboardingPlanTaskStatus.NOT_STARTED
-                plan_task = OnboardingPlanTask(
-                    plan_id=plan.id,
-                    template_task_id=task.id,
-                    title=task.title,
-                    description=task.description,
-                    deadline=date(2026, 5, 1) + timedelta(days=task.deadline_days),
-                    status=task_status,
-                    is_required=task.is_required,
-                    order=task.order,
-                )
-                session.add(plan_task)
-                print(f"Seed plan task created: {task.title} ({task_status.value})")
-
-            await session.commit()
-            print("Seed plan created for employee")
+        print("\n[Audit Logs]")
+        await seed_audit_logs(session)
 
     await engine.dispose()
+    print("\nSeed complete.")
 
 
 if __name__ == "__main__":

--- a/apps/backend/tests/integration/api/test_reports_endpoints.py
+++ b/apps/backend/tests/integration/api/test_reports_endpoints.py
@@ -1,0 +1,185 @@
+import pytest
+from datetime import date, timedelta
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.enums.user_role import UserRole
+from app.models.department import Department
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
+from app.models.onboarding_template import OnboardingTemplate
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.fixture
+async def department(db_session):
+    dept = Department(name="Engineering")
+    db_session.add(dept)
+    await db_session.flush()
+    return dept
+
+
+@pytest.fixture
+async def template(db_session, department):
+    tmpl = OnboardingTemplate(
+        name="Dev Onboarding",
+        department_id=department.id,
+        is_active=True,
+    )
+    db_session.add(tmpl)
+    await db_session.flush()
+    return tmpl
+
+
+@pytest.fixture
+async def employee(db_session, department):
+    user = User(
+        email="report_employee@test.com",
+        role=UserRole.EMPLOYEE,
+        first_name="Report",
+        last_name="Employee",
+        password_hash="placeholder",
+        is_active=True,
+        department_id=department.id,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.fixture
+async def manager(db_session):
+    user = User(
+        email="report_manager@test.com",
+        role=UserRole.MANAGER,
+        first_name="Report",
+        last_name="Manager",
+        password_hash="placeholder",
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.fixture
+async def approved_plan(db_session, employee, manager, template):
+    plan = OnboardingPlan(
+        user_id=employee.id,
+        manager_id=manager.id,
+        template_id=template.id,
+        start_date=date.today() - timedelta(days=10),
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    task = OnboardingPlanTask(
+        plan_id=plan.id,
+        title="Read Docs",
+        deadline=date.today() + timedelta(days=7),
+        status=OnboardingPlanTaskStatus.APPROVED,
+        is_required=True,
+        order=1,
+    )
+    db_session.add(task)
+    await db_session.flush()
+    return plan
+
+
+@pytest.fixture
+async def plan_with_returned_task(db_session, employee, manager, template):
+    plan = OnboardingPlan(
+        user_id=employee.id,
+        manager_id=manager.id,
+        template_id=template.id,
+        start_date=date.today() - timedelta(days=5),
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    task = OnboardingPlanTask(
+        plan_id=plan.id,
+        title="Write Tests",
+        deadline=date.today() - timedelta(days=1),
+        status=OnboardingPlanTaskStatus.RETURNED,
+        is_required=True,
+        order=1,
+    )
+    db_session.add(task)
+    await db_session.flush()
+    return plan
+
+
+class TestCompletionTimeEndpoint:
+
+    async def test_returns_department_rows(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/completion-time")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert any(row["department_name"] == "Engineering" for row in data)
+
+    async def test_returns_csv(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/completion-time?format=csv")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "department_name" in resp.text
+
+    async def test_date_filter_excludes_old_plans(self, authenticated_client, approved_plan):
+        future = (date.today() + timedelta(days=30)).isoformat()
+        resp = await authenticated_client.get(f"/api/v1/reports/completion-time?start_date={future}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert not any(row["department_name"] == "Engineering" for row in data)
+
+
+class TestTaskCompletionRatesEndpoint:
+
+    async def test_returns_template_rows(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/task-completion-rates")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert any(row["template_name"] == "Dev Onboarding" for row in data)
+
+    async def test_completion_rate_calculation(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/task-completion-rates")
+        row = next(r for r in resp.json() if r["template_name"] == "Dev Onboarding")
+        assert row["total_tasks"] >= 1
+        assert row["completion_rate"] > 0
+
+    async def test_returns_csv(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/task-completion-rates?format=csv")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "template_name" in resp.text
+
+
+class TestBottlenecksEndpoint:
+
+    async def test_returns_returned_tasks(self, authenticated_client, plan_with_returned_task):
+        resp = await authenticated_client.get("/api/v1/reports/bottlenecks")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(row["task_title"] == "Write Tests" for row in data)
+
+    async def test_returned_count_correct(self, authenticated_client, plan_with_returned_task):
+        resp = await authenticated_client.get("/api/v1/reports/bottlenecks")
+        row = next(r for r in resp.json() if r["task_title"] == "Write Tests")
+        assert row["returned_count"] >= 1
+
+    async def test_returns_csv(self, authenticated_client, plan_with_returned_task):
+        resp = await authenticated_client.get("/api/v1/reports/bottlenecks?format=csv")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "task_title" in resp.text
+
+
+class TestReportsAuthorization:
+
+    async def test_unauthenticated_rejected(self, client):
+        resp = await client.get("/api/v1/reports/completion-time")
+        assert resp.status_code == 401

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -23,6 +23,7 @@ import EmployeePlanPage from '@/features/plan/pages/EmployeePlanPage'
 import ManagerApprovalsPage from '@/features/plan/pages/ManagerApprovalsPage'
 import ManagerTaskReviewPage from '@/features/plan/pages/ManagerTaskReviewPage'
 import AuditLogPage from '@/features/audit/pages/AuditLogPage'
+import ReportsPage from '@/features/reports/pages/ReportsPage'
 
 
 export default function App() {
@@ -46,6 +47,7 @@ export default function App() {
           <Route path={ROUTES.HR_PLAN_NEW} element={<CreatePlanPage />} />
           <Route path="/hr/plans/:id" element={<PlanDetailPage />} />
           <Route path={ROUTES.HR_AUDIT} element={<AuditLogPage />} />
+          <Route path={ROUTES.HR_REPORTS} element={<ReportsPage />} />
         </Route>
       </Route>
 

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -52,6 +52,11 @@ export const API = {
     MANAGER: '/api/v1/dashboard/manager',
     EMPLOYEE: '/api/v1/dashboard/employee',
   },
+  REPORTS: {
+    COMPLETION_TIME: '/api/v1/reports/completion-time',
+    TASK_COMPLETION_RATES: '/api/v1/reports/task-completion-rates',
+    BOTTLENECKS: '/api/v1/reports/bottlenecks',
+  },
   TEMPLATES: {
     LIST: '/api/v1/templates/',
     CREATE: '/api/v1/templates/',

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
   MANAGER_APPROVALS: '/manager/approvals',
   MANAGER_TASK_REVIEW: (id: string) => `/manager/tasks/${id}`,
   HR_AUDIT: '/hr/audit',
+  HR_REPORTS: '/hr/reports',
 }
 
 export const ERROR_ROUTES = {

--- a/apps/frontend/src/features/reports/hooks/useReports.ts
+++ b/apps/frontend/src/features/reports/hooks/useReports.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  getCompletionTime,
+  getTaskCompletionRates,
+  getBottlenecks,
+  type DepartmentCompletionRow,
+  type TemplateCompletionRow,
+  type BottleneckRow,
+  type ReportFilters,
+} from '@/features/reports/services/reportsService'
+
+export function useReports(filters: ReportFilters) {
+  const [completionTime, setCompletionTime] = useState<DepartmentCompletionRow[]>([])
+  const [taskRates, setTaskRates] = useState<TemplateCompletionRow[]>([])
+  const [bottlenecks, setBottlenecks] = useState<BottleneckRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    const [ct, tr, bn] = await Promise.all([
+      getCompletionTime(filters),
+      getTaskCompletionRates(filters),
+      getBottlenecks(filters),
+    ])
+    setCompletionTime(ct)
+    setTaskRates(tr)
+    setBottlenecks(bn)
+    setLoading(false)
+  }, [filters.start_date, filters.end_date])
+
+  useEffect(() => { load() }, [load])
+
+  return { completionTime, taskRates, bottlenecks, loading, reload: load }
+}

--- a/apps/frontend/src/features/reports/pages/ReportsPage.test.tsx
+++ b/apps/frontend/src/features/reports/pages/ReportsPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import ReportsPage from './ReportsPage'
+import * as reportsService from '@/features/reports/services/reportsService'
+
+vi.mock('@/features/reports/services/reportsService')
+
+const mockCompletionTime = [
+  { department_name: 'Engineering', total_plans: 3, avg_completion_days: 12.5, avg_completion_days_rounded: 12.5 },
+]
+const mockTaskRates = [
+  { template_name: 'Dev Onboarding', total_tasks: 10, completed_tasks: 8, completion_rate: 80 },
+]
+const mockBottlenecks = [
+  { task_title: 'Write Tests', returned_count: 3, overdue_count: 1 },
+]
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <ReportsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ReportsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(reportsService.getCompletionTime).mockResolvedValue(mockCompletionTime)
+    vi.mocked(reportsService.getTaskCompletionRates).mockResolvedValue(mockTaskRates)
+    vi.mocked(reportsService.getBottlenecks).mockResolvedValue(mockBottlenecks)
+  })
+
+  it('renders section headings', async () => {
+    renderPage()
+    expect(await screen.findByText(/average completion time by department/i)).toBeInTheDocument()
+    expect(screen.getByText(/task completion rates by template/i)).toBeInTheDocument()
+    expect(screen.getByText(/bottlenecks/i)).toBeInTheDocument()
+  })
+
+  it('renders completion time data', async () => {
+    renderPage()
+    expect(await screen.findByText('Engineering')).toBeInTheDocument()
+    expect(screen.getByText('12.5 days')).toBeInTheDocument()
+  })
+
+  it('renders task completion rate data', async () => {
+    renderPage()
+    expect(await screen.findByText('Dev Onboarding')).toBeInTheDocument()
+    expect(screen.getByText('80%')).toBeInTheDocument()
+  })
+
+  it('renders bottleneck data', async () => {
+    renderPage()
+    expect(await screen.findByText('Write Tests')).toBeInTheDocument()
+  })
+
+  it('renders three export CSV buttons', async () => {
+    renderPage()
+    const buttons = await screen.findAllByText(/export csv/i)
+    expect(buttons).toHaveLength(3)
+  })
+})

--- a/apps/frontend/src/features/reports/pages/ReportsPage.tsx
+++ b/apps/frontend/src/features/reports/pages/ReportsPage.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react'
+import { useReports } from '@/features/reports/hooks/useReports'
+import { downloadCsv } from '@/features/reports/services/reportsService'
+import { API } from '@/constants/apiEndpoints'
+
+export default function ReportsPage() {
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+
+  const filters = {
+    start_date: startDate || undefined,
+    end_date: endDate || undefined,
+  }
+
+  const { completionTime, taskRates, bottlenecks, loading } = useReports(filters)
+
+  function handleExport(endpoint: string, filename: string) {
+    downloadCsv(endpoint, filename, filters)
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Reports</h2>
+          <p className="text-sm text-gray-500 mt-0.5">Onboarding activity analysis and export.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-0.5">
+            <label className="text-xs text-gray-500">From</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <label className="text-xs text-gray-500">To</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-gray-400">Loading...</p>
+      ) : (
+        <>
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-700">Average Completion Time by Department</h3>
+              <button
+                onClick={() => handleExport(API.REPORTS.COMPLETION_TIME, 'completion-time.csv')}
+                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+              >
+                Export CSV
+              </button>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+              {completionTime.length === 0 ? (
+                <p className="text-sm text-gray-400 px-5 py-4">No completed plans found.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100">
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Department</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completed Plans</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Avg. Days to Complete</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {completionTime.map((row) => (
+                      <tr key={row.department_name} className="hover:bg-gray-50">
+                        <td className="px-5 py-3 font-medium text-gray-800">{row.department_name}</td>
+                        <td className="px-5 py-3 text-gray-600">{row.total_plans}</td>
+                        <td className="px-5 py-3 text-gray-600">
+                          {row.avg_completion_days_rounded != null ? `${row.avg_completion_days_rounded} days` : '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-700">Task Completion Rates by Template</h3>
+              <button
+                onClick={() => handleExport(API.REPORTS.TASK_COMPLETION_RATES, 'task-completion-rates.csv')}
+                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+              >
+                Export CSV
+              </button>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+              {taskRates.length === 0 ? (
+                <p className="text-sm text-gray-400 px-5 py-4">No data found.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100">
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Template</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Total Tasks</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completed</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completion Rate</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {taskRates.map((row) => (
+                      <tr key={row.template_name} className="hover:bg-gray-50">
+                        <td className="px-5 py-3 font-medium text-gray-800">{row.template_name}</td>
+                        <td className="px-5 py-3 text-gray-600">{row.total_tasks}</td>
+                        <td className="px-5 py-3 text-gray-600">{row.completed_tasks}</td>
+                        <td className="px-5 py-3">
+                          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                            row.completion_rate >= 75
+                              ? 'text-green-700 bg-green-50'
+                              : row.completion_rate >= 40
+                              ? 'text-yellow-700 bg-yellow-50'
+                              : 'text-red-600 bg-red-50'
+                          }`}>
+                            {row.completion_rate}%
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-700">Bottlenecks — Most Returned & Overdue Tasks</h3>
+              <button
+                onClick={() => handleExport(API.REPORTS.BOTTLENECKS, 'bottlenecks.csv')}
+                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+              >
+                Export CSV
+              </button>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+              {bottlenecks.length === 0 ? (
+                <p className="text-sm text-gray-400 px-5 py-4">No bottlenecks found.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100">
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Task</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Times Returned</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Times Overdue</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {bottlenecks.map((row) => (
+                      <tr key={row.task_title} className="hover:bg-gray-50">
+                        <td className="px-5 py-3 font-medium text-gray-800">{row.task_title}</td>
+                        <td className="px-5 py-3">
+                          {row.returned_count > 0 ? (
+                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-orange-600 bg-orange-50">
+                              {row.returned_count}
+                            </span>
+                          ) : (
+                            <span className="text-gray-400">0</span>
+                          )}
+                        </td>
+                        <td className="px-5 py-3">
+                          {row.overdue_count > 0 ? (
+                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-red-600 bg-red-50">
+                              {row.overdue_count}
+                            </span>
+                          ) : (
+                            <span className="text-gray-400">0</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/features/reports/services/reportsService.ts
+++ b/apps/frontend/src/features/reports/services/reportsService.ts
@@ -1,0 +1,55 @@
+import apiClient from '@/lib/apiClient'
+import { API } from '@/constants/apiEndpoints'
+
+export interface DepartmentCompletionRow {
+  department_name: string
+  total_plans: number
+  avg_completion_days: number | null
+  avg_completion_days_rounded: number | null
+}
+
+export interface TemplateCompletionRow {
+  template_name: string
+  total_tasks: number
+  completed_tasks: number
+  completion_rate: number
+}
+
+export interface BottleneckRow {
+  task_title: string
+  returned_count: number
+  overdue_count: number
+}
+
+export interface ReportFilters {
+  start_date?: string
+  end_date?: string
+}
+
+export async function getCompletionTime(filters: ReportFilters): Promise<DepartmentCompletionRow[]> {
+  const res = await apiClient.get(API.REPORTS.COMPLETION_TIME, { params: filters })
+  return res.data
+}
+
+export async function getTaskCompletionRates(filters: ReportFilters): Promise<TemplateCompletionRow[]> {
+  const res = await apiClient.get(API.REPORTS.TASK_COMPLETION_RATES, { params: filters })
+  return res.data
+}
+
+export async function getBottlenecks(filters: ReportFilters): Promise<BottleneckRow[]> {
+  const res = await apiClient.get(API.REPORTS.BOTTLENECKS, { params: filters })
+  return res.data
+}
+
+export async function downloadCsv(endpoint: string, filename: string, filters: ReportFilters): Promise<void> {
+  const res = await apiClient.get(endpoint, {
+    params: { ...filters, format: 'csv' },
+    responseType: 'blob',
+  })
+  const url = URL.createObjectURL(new Blob([res.data], { type: 'text/csv' }))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -132,6 +132,16 @@ export default function HRDashboardLayout() {
             >
               Audit Trail
             </NavLink>
+            <NavLink
+              to={ROUTES.HR_REPORTS}
+              className={({ isActive }) =>
+                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                }`
+              }
+            >
+              Reports
+            </NavLink>
           </nav>
         </aside>
 


### PR DESCRIPTION
## Summary

- Adds 3 report endpoints: average completion time by department, task completion rates by template, and bottleneck identification (most returned/overdue tasks)
- Each endpoint supports `?format=csv` for CSV export with `Content-Disposition: attachment` response
- Adds `ReportsPage` at `/hr/reports` with date range filter, 3 data sections, and per-section Export CSV buttons
- Fixes broken `audit_logs` migration chain (`a3f1c8e2d047` was missing — repointed to `14e90742db5f`) and inline index duplication bug
- Adds comprehensive seed data: 3 users (alice, bob, manager2), Product Onboarding template, 3 plans with realistic task statuses, 17 audit log entries

## Test plan

- [x] 10 BE integration tests — all passing
- [x] 5 FE component tests — all passing
- [ ] Visit `/hr/reports` as HR Admin — verify 3 sections load with data
- [ ] Set date range filter — verify tables update
- [ ] Click Export CSV on each section — verify file downloads

Closes #135

