### PR TITLE
feat: US-017 Automated Scheduler — overdue tasks and deadline reminders

### DIFF
--- a/apps/backend/alembic/versions/e1b2c3d4e5f6_add_overdue_task_status.py
+++ b/apps/backend/alembic/versions/e1b2c3d4e5f6_add_overdue_task_status.py
@@ -1,0 +1,24 @@
+"""add_overdue_task_status
+
+Revision ID: e1b2c3d4e5f6
+Revises: c9a4b2e1f8d3
+Create Date: 2026-05-14 18:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'e1b2c3d4e5f6'
+down_revision: Union[str, None] = 'c9a4b2e1f8d3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE onboarding_plan_task_status ADD VALUE IF NOT EXISTS 'overdue'")
+
+
+def downgrade() -> None:
+    pass

--- a/apps/backend/app/enums/onboarding_plan_task_status.py
+++ b/apps/backend/app/enums/onboarding_plan_task_status.py
@@ -7,4 +7,5 @@ class OnboardingPlanTaskStatus(str, enum.Enum):
     COMPLETED = "completed"
     APPROVED = "approved"
     RETURNED = "returned"
+    OVERDUE = "overdue"
     CANCELLED = "cancelled"

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,3 +1,6 @@
+from contextlib import asynccontextmanager
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import _rate_limit_exceeded_handler
@@ -5,8 +8,25 @@ from slowapi.errors import RateLimitExceeded
 
 from app.api.router import api_router
 from app.core.config import settings
+from app.core.database import AsyncSessionLocal
 from app.core.limiter import limiter
 from app.errors.handlers import register_error_handlers
+from app.services.scheduler_service import mark_overdue_tasks, send_deadline_reminders
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler = AsyncIOScheduler(timezone="UTC")
+    scheduler.add_job(
+        send_deadline_reminders, "cron", hour=0, minute=0, args=[AsyncSessionLocal]
+    )
+    scheduler.add_job(
+        mark_overdue_tasks, "cron", hour=0, minute=5, args=[AsyncSessionLocal]
+    )
+    scheduler.start()
+    yield
+    scheduler.shutdown()
+
 
 app = FastAPI(
     title="StepUp API",
@@ -14,6 +34,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
 
 app.state.limiter = limiter
@@ -35,4 +56,3 @@ app.include_router(api_router, prefix="/api/v1")
 @app.get("/health")
 async def health_check():
     return {"status": "ok", "service": "stepup-backend"}
-

--- a/apps/backend/app/services/email_service.py
+++ b/apps/backend/app/services/email_service.py
@@ -68,6 +68,55 @@ class EmailService:
         client = SendGridAPIClient(settings.SENDGRID_API_KEY)
         client.send(message)
 
+    async def send_task_overdue_email(self, to_email: str, first_name: str, task_title: str, deadline: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Task overdue: {task_title}",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>The following task has passed its deadline and is now marked as overdue:</p>
+                <p><strong>{task_title}</strong> — was due on {deadline}</p>
+                <p>Please complete it as soon as possible.</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_overdue_manager_email(self, to_email: str, manager_first_name: str, employee_name: str, task_title: str, deadline: str) -> None:
+        approvals_url = f"{settings.FRONTEND_URL}/manager/approvals"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Overdue task: {task_title} — {employee_name}",
+            html_content=f"""
+                <p>Hi {manager_first_name},</p>
+                <p><strong>{employee_name}</strong> has an overdue task:</p>
+                <p><strong>{task_title}</strong> — was due on {deadline}</p>
+                <p><a href="{approvals_url}">View team tasks</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_deadline_reminder_email(self, to_email: str, first_name: str, task_title: str, deadline: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Reminder: '{task_title}' is due in 2 days",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>This is a reminder that the following task is due in 2 days:</p>
+                <p><strong>{task_title}</strong> — due on {deadline}</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
     async def send_task_returned_email(self, to_email: str, first_name: str, task_title: str, comment: str) -> None:
         plan_url = f"{settings.FRONTEND_URL}/employee/plan"
         message = Mail(

--- a/apps/backend/app/services/scheduler_service.py
+++ b/apps/backend/app/services/scheduler_service.py
@@ -1,0 +1,152 @@
+import logging
+from datetime import date, timedelta
+
+from sqlalchemy import select, and_
+from sqlalchemy.orm import sessionmaker, selectinload
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
+from app.models.user import User
+from app.services.email_service import EmailService
+
+logger = logging.getLogger(__name__)
+email_service = EmailService()
+
+_OVERDUEABLE = [OnboardingPlanTaskStatus.NOT_STARTED, OnboardingPlanTaskStatus.IN_PROGRESS]
+_REMINDABLE = [
+    OnboardingPlanTaskStatus.NOT_STARTED,
+    OnboardingPlanTaskStatus.IN_PROGRESS,
+    OnboardingPlanTaskStatus.OVERDUE,
+]
+
+
+async def mark_overdue_tasks(session_factory: sessionmaker) -> None:
+    today = date.today()
+    processed = 0
+    emails_sent = 0
+    errors = 0
+
+    async with session_factory() as db:
+        try:
+            result = await db.execute(
+                select(OnboardingPlanTask)
+                .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+                .where(
+                    and_(
+                        OnboardingPlanTask.deadline < today,
+                        OnboardingPlanTask.status.in_(_OVERDUEABLE),
+                        OnboardingPlanTask.deleted_at.is_(None),
+                        OnboardingPlan.is_active.is_(True),
+                        OnboardingPlan.deleted_at.is_(None),
+                    )
+                )
+                .options(selectinload(OnboardingPlanTask.plan))
+            )
+            tasks = list(result.scalars().unique().all())
+
+            for task in tasks:
+                try:
+                    task.status = OnboardingPlanTaskStatus.OVERDUE
+                    processed += 1
+                    plan = task.plan
+
+                    emp_row = await db.execute(select(User).where(User.id == plan.user_id))
+                    employee = emp_row.scalar_one_or_none()
+
+                    mgr_row = await db.execute(select(User).where(User.id == plan.manager_id))
+                    manager = mgr_row.scalar_one_or_none()
+
+                    deadline_str = task.deadline.isoformat()
+
+                    if employee:
+                        try:
+                            await email_service.send_task_overdue_email(
+                                to_email=employee.email,
+                                first_name=employee.first_name,
+                                task_title=task.title,
+                                deadline=deadline_str,
+                            )
+                            emails_sent += 1
+                        except Exception as e:
+                            logger.error(f"Overdue email to employee failed: {e}")
+                            errors += 1
+
+                    if manager and employee:
+                        try:
+                            await email_service.send_task_overdue_manager_email(
+                                to_email=manager.email,
+                                manager_first_name=manager.first_name,
+                                employee_name=f"{employee.first_name} {employee.last_name}",
+                                task_title=task.title,
+                                deadline=deadline_str,
+                            )
+                            emails_sent += 1
+                        except Exception as e:
+                            logger.error(f"Overdue email to manager failed: {e}")
+                            errors += 1
+
+                except Exception as e:
+                    logger.error(f"Failed processing task {task.id}: {e}")
+                    errors += 1
+
+            await db.commit()
+
+        except Exception as e:
+            logger.error(f"mark_overdue_tasks job failed: {e}")
+            await db.rollback()
+            return
+
+    logger.info(
+        f"mark_overdue_tasks — tasks_marked={processed}, emails_sent={emails_sent}, errors={errors}"
+    )
+
+
+async def send_deadline_reminders(session_factory: sessionmaker) -> None:
+    reminder_date = date.today() + timedelta(days=2)
+    emails_sent = 0
+    errors = 0
+
+    async with session_factory() as db:
+        try:
+            result = await db.execute(
+                select(OnboardingPlanTask)
+                .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+                .where(
+                    and_(
+                        OnboardingPlanTask.deadline == reminder_date,
+                        OnboardingPlanTask.status.in_(_REMINDABLE),
+                        OnboardingPlanTask.deleted_at.is_(None),
+                        OnboardingPlan.is_active.is_(True),
+                        OnboardingPlan.deleted_at.is_(None),
+                    )
+                )
+                .options(selectinload(OnboardingPlanTask.plan))
+            )
+            tasks = list(result.scalars().unique().all())
+
+            for task in tasks:
+                try:
+                    plan = task.plan
+                    emp_row = await db.execute(select(User).where(User.id == plan.user_id))
+                    employee = emp_row.scalar_one_or_none()
+
+                    if employee:
+                        await email_service.send_deadline_reminder_email(
+                            to_email=employee.email,
+                            first_name=employee.first_name,
+                            task_title=task.title,
+                            deadline=task.deadline.isoformat(),
+                        )
+                        emails_sent += 1
+
+                except Exception as e:
+                    logger.error(f"Reminder email failed for task {task.id}: {e}")
+                    errors += 1
+
+        except Exception as e:
+            logger.error(f"send_deadline_reminders job failed: {e}")
+            return
+
+    logger.info(f"send_deadline_reminders — emails_sent={emails_sent}, errors={errors}")

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -25,9 +25,10 @@ user_repository = UserRepository()
 audit_service = AuditService()
 email_service = EmailService()
 
-VALID_TRANSITIONS = {
-    OnboardingPlanTaskStatus.NOT_STARTED: OnboardingPlanTaskStatus.IN_PROGRESS,
-    OnboardingPlanTaskStatus.IN_PROGRESS: OnboardingPlanTaskStatus.COMPLETED,
+VALID_TRANSITIONS: dict[OnboardingPlanTaskStatus, set[OnboardingPlanTaskStatus]] = {
+    OnboardingPlanTaskStatus.NOT_STARTED: {OnboardingPlanTaskStatus.IN_PROGRESS},
+    OnboardingPlanTaskStatus.IN_PROGRESS: {OnboardingPlanTaskStatus.COMPLETED},
+    OnboardingPlanTaskStatus.OVERDUE: {OnboardingPlanTaskStatus.IN_PROGRESS, OnboardingPlanTaskStatus.COMPLETED},
 }
 
 
@@ -178,5 +179,5 @@ class TaskWorkflowService:
     def _assert_transition(
         self, task: OnboardingPlanTask, target: OnboardingPlanTaskStatus
     ) -> None:
-        if VALID_TRANSITIONS.get(task.status) != target:
+        if target not in VALID_TRANSITIONS.get(task.status, set()):
             raise ValidationError(*messages.INVALID_TASK_TRANSITION)

--- a/apps/backend/tests/unit/services/test_scheduler_service.py
+++ b/apps/backend/tests/unit/services/test_scheduler_service.py
@@ -1,0 +1,176 @@
+import pytest
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch, call
+import uuid
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.services.scheduler_service import mark_overdue_tasks, send_deadline_reminders
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _make_task(status, deadline, plan_user_id=None, plan_manager_id=None):
+    task = MagicMock()
+    task.id = uuid.uuid4()
+    task.title = "Test Task"
+    task.status = status
+    task.deadline = deadline
+    task.deleted_at = None
+    plan = MagicMock()
+    plan.user_id = plan_user_id or uuid.uuid4()
+    plan.manager_id = plan_manager_id or uuid.uuid4()
+    task.plan = plan
+    return task
+
+
+def _make_session_factory(tasks):
+    session = AsyncMock()
+
+    execute_result = MagicMock()
+    execute_result.scalars.return_value.unique.return_value.all.return_value = tasks
+
+    user = MagicMock()
+    user.email = "test@example.com"
+    user.first_name = "Test"
+    user.last_name = "User"
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+
+    session.execute = AsyncMock(side_effect=[execute_result, user_result, user_result] * (len(tasks) + 1))
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return factory, session
+
+
+class TestMarkOverdueTasks:
+
+    async def test_marks_not_started_task_as_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.NOT_STARTED, yesterday)
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_task_overdue_email = AsyncMock()
+            mock_email.send_task_overdue_manager_email = AsyncMock()
+            await mark_overdue_tasks(factory)
+
+        assert task.status == OnboardingPlanTaskStatus.OVERDUE
+
+    async def test_marks_in_progress_task_as_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.IN_PROGRESS, yesterday)
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_task_overdue_email = AsyncMock()
+            mock_email.send_task_overdue_manager_email = AsyncMock()
+            await mark_overdue_tasks(factory)
+
+        assert task.status == OnboardingPlanTaskStatus.OVERDUE
+
+    async def test_does_not_mark_completed_task_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.COMPLETED, yesterday)
+
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await mark_overdue_tasks(factory)
+        assert task.status == OnboardingPlanTaskStatus.COMPLETED
+
+    async def test_does_not_mark_approved_task_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.APPROVED, yesterday)
+
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await mark_overdue_tasks(factory)
+        assert task.status == OnboardingPlanTaskStatus.APPROVED
+
+    async def test_commits_after_marking(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.NOT_STARTED, yesterday)
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_task_overdue_email = AsyncMock()
+            mock_email.send_task_overdue_manager_email = AsyncMock()
+            await mark_overdue_tasks(factory)
+
+        session.commit.assert_called_once()
+
+    async def test_no_tasks_still_commits(self):
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await mark_overdue_tasks(factory)
+        session.commit.assert_called_once()
+
+
+class TestSendDeadlineReminders:
+
+    async def test_sends_reminder_for_task_due_in_two_days(self):
+        in_two_days = date.today() + timedelta(days=2)
+        task = _make_task(OnboardingPlanTaskStatus.NOT_STARTED, in_two_days)
+        task.deadline = in_two_days
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_deadline_reminder_email = AsyncMock()
+            await send_deadline_reminders(factory)
+
+        mock_email.send_deadline_reminder_email.assert_called_once()
+
+    async def test_sends_reminder_for_overdue_task_due_in_two_days(self):
+        in_two_days = date.today() + timedelta(days=2)
+        task = _make_task(OnboardingPlanTaskStatus.OVERDUE, in_two_days)
+        task.deadline = in_two_days
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_deadline_reminder_email = AsyncMock()
+            await send_deadline_reminders(factory)
+
+        mock_email.send_deadline_reminder_email.assert_called_once()
+
+    async def test_no_tasks_no_emails_sent(self):
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_deadline_reminder_email = AsyncMock()
+            await send_deadline_reminders(factory)
+
+        mock_email.send_deadline_reminder_email.assert_not_called()

--- a/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
+++ b/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
@@ -9,6 +9,7 @@ const STATUS_LABELS: Record<OnboardingPlanTaskStatus, string> = {
   completed: 'Completed',
   approved: 'Approved',
   returned: 'Returned',
+  overdue: 'Overdue',
   cancelled: 'Cancelled',
 }
 
@@ -18,6 +19,7 @@ const STATUS_STYLES: Record<OnboardingPlanTaskStatus, string> = {
   completed: 'bg-green-50 text-green-700 border-green-100',
   approved: 'bg-green-100 text-green-800 border-green-200',
   returned: 'bg-red-50 text-red-700 border-red-100',
+  overdue: 'bg-red-100 text-red-800 border-red-200',
   cancelled: 'bg-gray-100 text-gray-400 border-gray-200',
 }
 
@@ -73,7 +75,7 @@ export default function EmployeePlanPage() {
                 </div>
 
                 <div className="shrink-0">
-                  {task.status === 'not_started' && (
+                  {(task.status === 'not_started' || task.status === 'overdue') && (
                     <button
                       onClick={() => handleStartTask(task.id)}
                       className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
@@ -81,7 +83,7 @@ export default function EmployeePlanPage() {
                       Start
                     </button>
                   )}
-                  {task.status === 'in_progress' && (
+                  {(task.status === 'in_progress' || task.status === 'overdue') && (
                     <button
                       onClick={() => handleCompleteTask(task.id)}
                       className="text-xs bg-green-700 hover:bg-green-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -753,7 +753,7 @@ export interface components {
          * OnboardingPlanTaskStatus
          * @enum {string}
          */
-        OnboardingPlanTaskStatus: "not_started" | "in_progress" | "completed" | "approved" | "returned" | "cancelled";
+        OnboardingPlanTaskStatus: "not_started" | "in_progress" | "completed" | "approved" | "returned" | "overdue" | "cancelled";
         /** OnboardingPlanTaskUpdate */
         OnboardingPlanTaskUpdate: {
             /**

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -754,11 +754,19 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ✅ Audit trail: all key actions logged (user invited/registered/deactivated, plan created, task started/completed/approved/returned), HR Admin filter page
 - ✅ Bug fixes: deactivated user login rejection, login form error display, return_comment persistence, playwright baseURL env var
 
-### Sprint 8 — Notifications, Scheduler & Reports
+### Sprint 8 — Notifications ✅ Done
 - ✅ Email notifications via SendGrid — plan started (employee), task completed (manager), task approved/returned (employee)
-- ⬜ APScheduler: daily overdue detection + deadline reminders (US-017)
-- ⬜ Admin reports (completion rates, avg time per department) (US-020)
-- ⬜ File upload (US-014b, GCS integration)
+
+### Sprint 9 — Scheduler, Reports & Seed ✅ Done
+- ✅ APScheduler wired into FastAPI lifespan — `mark_overdue_tasks` (00:05 UTC) and `send_deadline_reminders` (00:00 UTC) run daily
+- ✅ `OVERDUE` task status added — tasks past deadline auto-marked; employee and manager emailed; overdue tasks remain actionable
+- ✅ Admin reports — 3 endpoints (completion time by dept, task rates by template, bottlenecks) + CSV export + `ReportsPage` with date range filter
+- ✅ Comprehensive seed data — 6 users, 3 templates, 10 template tasks, 3 plans with realistic task statuses, 17 audit log entries
+- ✅ Fixed broken `audit_logs` migration chain
+
+### Sprint 10 — File Upload & Quality
+- ⬜ File upload per task (US-014b, GCS integration)
+- ⬜ Technical quality & polish (US-021)
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
@@ -832,6 +840,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.4 | 2026-05-14 | Sprint 5 done, Sprint 6 done; task workflow and manager review complete; department added to invitation; US-014b deferred to Sprint 8; sprint numbering adjusted |
 | 1.5 | 2026-05-14 | Sprint 7 done; role-based dashboards (US-018) and audit trail (US-019) complete; bug fixes (auth is_active, login error display, return_comment, playwright config); Sprint 8 scope updated |
 | 1.6 | 2026-05-14 | US-016 email notifications done; plan started, task completed/approved/returned emails added via SendGrid |
+| 1.7 | 2026-05-14 | Sprint 9 done; US-017 scheduler (OVERDUE status + APScheduler lifespan + 2 daily jobs), US-020 reports (3 endpoints + CSV + ReportsPage), comprehensive seed data, audit_log migration fix; Sprint 8 closed, Sprint 9 added, Sprint 10 scoped |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/scrum/review/sprint-9.md
+++ b/docs/scrum/review/sprint-9.md
@@ -1,0 +1,61 @@
+# Sprint 9 — Review
+
+## Sprint Goal
+APScheduler marks overdue tasks daily and sends deadline reminders. HR Admin reports are live. Seed data covers all features end-to-end.
+
+## Sprint Goal Achieved?
+Yes — US-017, US-020, and seed data fully delivered.
+
+## Completed User Stories
+
+| US | Title | Status | Notes |
+|----|-------|--------|-------|
+| US-017 | Automated Scheduler | Done | APScheduler lifespan, 2 daily jobs, OVERDUE enum + migration, 3 email templates, 9 unit tests |
+| US-020 | Admin Reports & Export | Done | 3 report endpoints, CSV export per endpoint, ReportsPage with date range filter, 10 BE + 5 FE tests |
+| Seed | Comprehensive seed data | Done | 6 users, 3 templates, 3 plans with varied statuses, 17 audit logs, migration chain fixed |
+
+## Incomplete / Deferred User Stories
+
+| US | Title | Reason | Moved to |
+|----|-------|--------|----------|
+| US-014b | File Upload & Comments | GCS infrastructure required | Sprint 10 |
+| US-021 | Technical Quality & Polish | Natural last sprint | Sprint 10 |
+
+## Metrics
+- USs planned: 2 (US-017, US-020)
+- USs completed: 2
+- PRs merged: 2 (#192 Reports, #193 Scheduler)
+
+## Key Decisions Made This Sprint
+
+### APScheduler wired into FastAPI lifespan (not a separate process)
+APScheduler runs inside the FastAPI process via `lifespan`. This is the simplest approach for Cloud Run (single process, no worker dyno). If job load grows, the scheduler can be extracted to a dedicated Cloud Run job triggered by Cloud Scheduler.
+
+### OVERDUE tasks remain actionable via two transitions
+`VALID_TRANSITIONS` updated to `dict[status, set[status]]`. OVERDUE → IN_PROGRESS (start) and OVERDUE → COMPLETED (complete directly). This handles both cases: task was NOT_STARTED when marked overdue, and task was IN_PROGRESS when marked overdue.
+
+### Reports use direct SQL aggregations — no dedicated analytics layer
+All three report queries run direct SQLAlchemy aggregations against `onboarding_plan_tasks` and `onboarding_plans`. No materialized views or separate analytics tables. Acceptable for current scale; can be optimized if report query time exceeds 1s in production.
+
+### CSV export via `?format=csv` query param — no separate endpoint
+Each report endpoint returns JSON by default and CSV when `?format=csv`. The FE uses `apiClient` with `responseType: blob` + `URL.createObjectURL` for download — avoids CORS issues since cookies are sent automatically.
+
+### Seed is fully idempotent — skip if exists by fixed ID
+All seed entities use fixed UUIDs. Each section checks for existence before inserting. Running the seed twice is safe. New entities are added by extending the constants, not by modifying logic.
+
+### audit_logs migration chain was broken — fixed
+`c9a4b2e1f8d3` referenced a lost parent `a3f1c8e2d047`. Fixed by repointing to `14e90742db5f` (the actual head). An inline `index=True` on the `action` column conflicted with the explicit `op.create_index` call — fixed by removing `index=True` from the column definition.
+
+## Emails Added This Sprint
+
+| Method | To | When |
+|--------|----|------|
+| `send_task_overdue_email` | Employee | Task deadline passed, marked OVERDUE |
+| `send_task_overdue_manager_email` | Manager | Employee's task marked OVERDUE |
+| `send_deadline_reminder_email` | Employee | Task deadline is in exactly 2 days |
+
+## Notes
+- `mark_overdue_tasks` runs at 00:05 UTC daily (after reminders) to avoid race conditions
+- Scheduler jobs log summary: `tasks_marked=N, emails_sent=N, errors=N`
+- Email failures inside jobs are caught per-task and logged — one failure does not abort the entire job run
+- OVERDUE status displayed as red badge in `EmployeePlanPage`; Start and Complete buttons both visible on OVERDUE tasks

--- a/docs/scrum/sprint-goals.md
+++ b/docs/scrum/sprint-goals.md
@@ -25,9 +25,18 @@ All three roles have a dedicated dashboard with real system stats. Every key act
 Email notifications are sent at every key workflow stage. APScheduler automatically marks overdue tasks daily and sends deadline reminders. HR Admins have access to basic onboarding reports. Employees can upload documents to tasks stored in GCP Cloud Storage.
 
 - ✅ US-016 Email Notifications
-- ⬜ US-017 Automated Scheduler
-- ⬜ US-020 Admin Reports
-- ⬜ US-014b File Upload
+- ⬜ US-017 Automated Scheduler (deferred to Sprint 9)
+- ⬜ US-020 Admin Reports (deferred to Sprint 9)
+- ⬜ US-014b File Upload (deferred to Sprint 9)
 
-## Sprint 9 — Quality & Polish
-All list endpoints are paginated. Seed data creates a realistic demo dataset. Full E2E regression suite passes in CI pipeline. README and Swagger polished for demo.
+## Sprint 9 — Scheduler, Reports & Quality
+APScheduler marks overdue tasks daily and sends deadline reminders. HR Admin reports are live. Seed data covers all features. Quality polish and remaining US-021 work.
+
+- ✅ US-017 Automated Scheduler (APScheduler lifespan, mark_overdue_tasks, send_deadline_reminders, OVERDUE enum)
+- ✅ US-020 Admin Reports & Export (3 endpoints, CSV export, ReportsPage with date filter)
+- ✅ Comprehensive seed data (alice, bob, manager2, Product template, 3 plans, 17 audit logs)
+- ⬜ US-014b File Upload
+- ⬜ US-021 Technical Quality & Polish
+
+## Sprint 10 — Final Polish & File Upload
+All list endpoints are paginated. File upload via GCS. Full E2E regression suite passes in CI. README and Swagger polished for demo.


### PR DESCRIPTION
## Summary

- APScheduler wired into FastAPI lifespan — starts on app boot, shuts down cleanly
- Job 1: `send_deadline_reminders` — runs daily at 00:00 UTC, emails employees whose tasks are due in exactly 2 days
- Job 2: `mark_overdue_tasks` — runs daily at 00:05 UTC, marks NOT_STARTED/IN_PROGRESS tasks past deadline as OVERDUE, emails employee and manager
- New `OVERDUE` enum value added to `OnboardingPlanTaskStatus` with migration
- `VALID_TRANSITIONS` updated: OVERDUE tasks can transition to IN_PROGRESS or COMPLETED (employee remains unblocked)
- 3 new email templates: overdue (employee), overdue (manager), deadline reminder
- FE: `overdue` status badge (red) and Start/Complete buttons shown on OVERDUE tasks

## Test plan

- [x] 9 unit tests for scheduler jobs — all passing
- [x] EmployeePlanPage FE tests — all passing (5/5)
- [ ] Verify scheduler starts on `docker compose up` (check logs for APScheduler init)
- [ ] Manually call `mark_overdue_tasks` in a Python shell to verify tasks are marked

Closes #132
