### PR TITLE
fix: plan flow bugs — return_comment, attachments, UI consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,9 @@ apps/frontend/test-results/
 apps/frontend/.pnpm-store/
 
 apps/frontend/.firebase/
+
+# GCP service account keys
+*.json
+!package.json
+!tsconfig*.json
+!turbo.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Employee onboarding management platform
 
-StepUp streamlines the process of onboarding new employees — structured task assignment, transparent progress tracking, and manager approval workflows, all in one place.
+StepUp replaces email chains and spreadsheets with a structured onboarding workflow — task assignment, progress tracking, manager approvals, file uploads, automated reminders, and analytics in one place.
 
 ---
 
@@ -18,8 +18,44 @@ StepUp streamlines the process of onboarding new employees — structured task a
 | Role | Email | Password |
 |---|---|---|
 | HR Admin | admin@stepup.com | Admin1234! |
-| Manager | manager@stepup.com | Manager1234! |
-| Employee | employee@stepup.com | Employee1234! |
+| Manager (Engineering) | manager@stepup.com | Manager1234! |
+| Manager (Product) | manager2@stepup.com | Manager1234! |
+| Employee (Engineering, in progress) | employee@stepup.com | Employee1234! |
+| Employee (Engineering, completed) | alice@stepup.com | Employee1234! |
+| Employee (Product, stuck) | bob@stepup.com | Employee1234! |
+
+---
+
+## Features
+
+### HR Admin
+- Invite users by email with role and department pre-assigned
+- Manage departments and user accounts (deactivate, reactivate)
+- Create and manage onboarding templates per department (tasks, deadlines, required/optional)
+- Clone templates between departments
+- Create onboarding plans for employees from active templates
+- Adjust plans after creation (deadlines, cancel tasks, add tasks)
+- Role-based dashboard with org-wide stats
+- Audit trail — full history of all system actions, filterable
+- Reports — avg completion time by department, task rates by template, bottleneck analysis — all exportable to CSV
+
+### Manager
+- Dashboard with team onboarding status and pending approval count
+- Review completed tasks — approve or return with mandatory feedback
+- Notifications when employees complete tasks
+
+### Employee
+- View assigned onboarding plan and task list
+- Start and complete tasks (state machine enforced)
+- Upload files per task (PDF, DOCX, PNG, JPEG — max 10 MB) stored in GCP Cloud Storage
+- Add comments to tasks
+- View manager feedback on returned tasks
+- Notifications on plan start, task approved/returned, deadline reminders
+
+### System (automated)
+- APScheduler marks tasks as Overdue daily when deadline passes
+- Deadline reminder emails sent 2 days before due date
+- Overdue tasks remain actionable — employee and manager notified
 
 ---
 
@@ -27,16 +63,16 @@ StepUp streamlines the process of onboarding new employees — structured task a
 
 | Sprint | Theme | Status |
 |---|---|---|
-| Sprint 1 | Infrastructure | ✅ Complete |
+| Sprint 1 | Infrastructure & CI/CD | ✅ Complete |
 | Sprint 2 | Authentication & Authorization | ✅ Complete |
-| Sprint 3 | User & Department Management | — |
-| Sprint 4 | Onboarding Template Management | — |
-| Sprint 5 | Onboarding Plan & Task Workflow | — |
-| Sprint 6 | Notifications & Email | — |
-| Sprint 7 | Dashboards | — |
-| Sprint 8 | Attachments | — |
-| Sprint 9 | Audit Trail & Reports | — |
-| Sprint 10 | Quality & Polish | — |
+| Sprint 3 | User & Department Management | ✅ Complete |
+| Sprint 4 | Onboarding Template Management | ✅ Complete |
+| Sprint 5 | Plan Creation & Task Workflow | ✅ Complete |
+| Sprint 6 | Manager Review & UI Polish | ✅ Complete |
+| Sprint 7 | Role-Based Dashboards & Audit Trail | ✅ Complete |
+| Sprint 8 | Email Notifications | ✅ Complete |
+| Sprint 9 | Scheduler, Reports, File Upload & Seed | ✅ Complete |
+| Sprint 10 | Quality & Polish (US-021) | 🔶 In Progress |
 
 Sprint progress is tracked on the [StepUp Board](https://github.com/users/aykutcihan/projects/5).
 
@@ -46,12 +82,20 @@ Sprint progress is tracked on the [StepUp Board](https://github.com/users/aykutc
 
 | Layer | Technology |
 |---|---|
-| **Backend** | Python 3.11, FastAPI, SQLAlchemy 2.0, Alembic |
+| **Backend** | Python 3.11, FastAPI, SQLAlchemy 2.0 (async), Alembic |
 | **Database** | PostgreSQL 15 |
-| **Frontend** | React 18, TypeScript, Tailwind CSS |
-| **Infrastructure** | Docker, GCP Cloud Run, GCP Cloud SQL, GCP Secret Manager |
+| **Auth** | JWT (HttpOnly cookies), bcrypt, refresh token rotation |
+| **Email** | SendGrid |
+| **File Storage** | GCP Cloud Storage (signed URLs) |
+| **Scheduler** | APScheduler (runs inside FastAPI lifespan) |
+| **Rate Limiting** | slowapi |
+| **Frontend** | React 18, TypeScript, Tailwind CSS, Zustand, Axios |
+| **Testing (BE)** | pytest, httpx (unit + integration) |
+| **Testing (FE)** | Vitest, React Testing Library |
+| **Testing (E2E)** | Playwright |
+| **Infrastructure** | Docker, GCP Cloud Run, GCP Cloud SQL, GCP Cloud Storage, GCP Secret Manager |
 | **CI/CD** | GitHub Actions |
-| **Package Manager** | pnpm (monorepo with Turborepo) |
+| **Monorepo** | Turborepo + pnpm |
 
 ---
 
@@ -62,31 +106,35 @@ stepup/
   apps/
     backend/          # FastAPI application
       app/
-        api/          # Route handlers
-        core/         # Config, database, limiter
+        api/          # Route handlers (v1/)
+        core/         # Config, database, dependencies, limiter
+        enums/        # Shared enum types
+        errors/       # Exception classes, messages, handlers
         models/       # SQLAlchemy models
-        services/     # Business logic
         repositories/ # Database queries
-        schemas/      # Pydantic schemas
+        schemas/      # Pydantic request/response schemas
+        services/     # Business logic
       alembic/        # Database migrations
-      scripts/        # Seed and utility scripts
-      tests/          # Unit and integration tests
-    frontend/         # React 18 + TypeScript application
+      scripts/        # Seed script
+      tests/
+        unit/         # Unit tests (services)
+        integration/  # API endpoint tests
+    frontend/         # React 18 + TypeScript
       src/
         app/          # App entry, routing
         components/   # Shared UI components
-        constants/    # Routes, API endpoints, messages
-        features/     # Feature-based modules (auth, invitation, users)
-        lib/          # API client
-        stores/       # Zustand stores
-        types/        # Generated API types
-      tests/
-        e2e/          # Playwright E2E tests
+        constants/    # Routes, API endpoints, error codes, roles
+        features/     # Feature modules (auth, plan, template, audit, reports…)
+        layouts/      # Dashboard layouts per role
+        lib/          # Axios client + interceptor
+        stores/       # Zustand auth store
+        types/        # api.ts (OpenAPI-aligned type definitions)
+      tests/e2e/      # Playwright E2E tests
   docs/
     adr/              # Architecture Decision Records
+    guides/           # Technical guides (FastAPI, Alembic, Docker, testing…)
     postmortems/      # Debug and incident records
-    guides/           # Technical guides
-    scrum/            # Sprint planning and retrospectives
+    scrum/            # Sprint goals, reviews, retrospectives
   docker-compose.yml
   turbo.json
 ```
@@ -103,8 +151,6 @@ stepup/
 
 ### First-time setup
 
-Run these once after cloning the repository.
-
 ```bash
 # 1. Install frontend dependencies
 pnpm install
@@ -119,14 +165,14 @@ docker-compose build
 docker-compose run --rm backend alembic upgrade head
 
 # 5. Seed the database
-docker-compose run --rm backend python scripts/seed.py
+docker-compose run --rm seeder
 ```
 
-Steps 4 and 5 automatically start the database container if it is not already running.
+> **File upload (optional):** To test file upload locally, place a GCP service account key at `gcs-key.json` in the project root and set `GCS_BUCKET_NAME` in `.env`. Without this, the app works fully except for the file upload feature.
 
 ### Scenario 1 — Full Docker
 
-Everything runs in Docker. Use this when you want a quick start or a clean environment.
+Everything runs in Docker.
 
 ```bash
 docker-compose up db backend frontend
@@ -141,7 +187,7 @@ docker-compose up db backend frontend
 
 ### Scenario 2 — Frontend Local
 
-Database and backend run in Docker. Frontend runs locally for faster hot reload.
+Database and backend in Docker, frontend runs locally for faster hot reload.
 
 **Terminal 1:**
 ```bash
@@ -158,58 +204,63 @@ pnpm --filter frontend dev
 | Frontend | http://localhost:5173 |
 | Backend API | http://localhost:8000 |
 | Swagger UI | http://localhost:8000/docs |
-| Database | localhost:5433 |
 
-> Port 5433 is used instead of the default 5432 to avoid conflicts with a locally installed PostgreSQL.
+> Port 5433 is used instead of 5432 to avoid conflicts with a locally installed PostgreSQL.
 
-### Test users
+### Seed data
 
-| Email | Password | Role |
-|---|---|---|
-| admin@stepup.com | Admin1234! | HR Admin |
-| manager@stepup.com | Manager1234! | Manager |
-| employee@stepup.com | Employee1234! | Employee |
+The seeder creates a realistic dataset covering all task states and features:
+
+| User | Role | Department | Plan state |
+|---|---|---|---|
+| admin@stepup.com | HR Admin | Human Resources | — |
+| manager@stepup.com | Manager | Engineering | — |
+| manager2@stepup.com | Manager | Product | — |
+| employee@stepup.com | Employee | Engineering | In progress (mix of statuses) |
+| alice@stepup.com | Employee | Engineering | Completed (all approved) |
+| bob@stepup.com | Employee | Product | Stuck (returned + overdue tasks) |
 
 ---
 
-## E2E Tests
+## Running Tests
 
-### Docker (CI / pre-push)
-
-Runs in an isolated container — same environment as CI. Slower due to Vite cold start (~5 min for full suite).
+### Backend
 
 ```bash
-# Run all E2E tests
-docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
+# Unit tests
+docker-compose run --rm backend pytest tests/unit/ -v
 
-# Run a specific test file
-docker-compose run --rm playwright sh -c "pnpm install && pnpm exec playwright test tests/e2e/login.spec.ts"
+# Integration tests (requires running db)
+docker-compose run --rm backend pytest tests/integration/ -v
+
+# All tests
+docker-compose run --rm backend pytest --tb=short -q
 ```
 
-The `seeder` service runs automatically as part of the Playwright dependency chain.
-
-### Local (during development)
-
-Runs against the local Vite dev server. Much faster (~1-2 min) since Vite is already warm.
-
-**Prerequisite:** Scenario 2 must be running (db, backend, and `pnpm --filter frontend dev`).
+### Frontend
 
 ```bash
-# First-time only: install browser binary
-pnpm --filter frontend exec playwright install chromium
+# Unit + component tests
+pnpm --filter frontend test
 
-# Run all E2E tests
+# Watch mode
+pnpm --filter frontend test:watch
+```
+
+### E2E (Playwright)
+
+```bash
+# Docker (CI / pre-push) — full isolated run
+docker-compose run --rm playwright sh -c "pnpm install && pnpm e2e"
+
+# Local (faster, requires Scenario 2 running)
+pnpm --filter frontend exec playwright install chromium   # first time only
 pnpm --filter frontend e2e:local
-
-# Run a specific test file
-pnpm --filter frontend exec playwright test --config apps/frontend/playwright.config.local.ts tests/e2e/login.spec.ts
 ```
 
 | | Docker | Local |
 |---|---|---|
 | Speed | ~5 min | ~1-2 min |
-| Workers | 1 | 2 |
-| Test timeout | 120s | 30s |
 | Use when | CI, pre-push | Active development |
 
 ---
@@ -219,9 +270,6 @@ pnpm --filter frontend exec playwright test --config apps/frontend/playwright.co
 ```bash
 # Run database migrations
 docker-compose run --rm backend alembic upgrade head
-
-# Seed the database
-docker-compose run --rm backend python scripts/seed.py
 
 # Create a new migration after model changes
 docker-compose run --rm backend alembic revision --autogenerate -m "description"
@@ -235,9 +283,6 @@ docker-compose logs -f backend
 # Rebuild backend image (after requirements.txt changes)
 docker-compose build backend
 
-# Run backend tests
-docker-compose run --rm backend pytest --tb=short -q
-
 # Run frontend unit tests
 pnpm --filter frontend test
 ```
@@ -248,27 +293,22 @@ pnpm --filter frontend test
 
 | Document | Description |
 |---|---|
-| [`docs/product-vision.md`](./docs/product-vision.md) | Full product specification, user roles, workflows |
+| [`docs/product-vision.md`](./docs/product-vision.md) | Product specification, user roles, workflow, roadmap |
 | [`docs/adr/`](./docs/adr/) | Architecture Decision Records |
+| [`docs/guides/`](./docs/guides/) | Technical guides (FastAPI, Alembic, Docker, testing, conventions) |
+| [`docs/scrum/`](./docs/scrum/) | Sprint goals, reviews, retrospectives |
 | [`docs/postmortems/`](./docs/postmortems/) | Debug and incident records |
-| [`docs/guides/`](./docs/guides/) | Technical guides (FastAPI, Docker, Git, Alembic, etc.) |
-| [`docs/scrum/`](./docs/scrum/) | Sprint goals, refinement notes, reviews, retrospectives |
 
 ---
 
 ## Branch Strategy
 
 ```
-main           → production (stable, merged at sprint end)
-develop        → integration branch
-feature/be-    → backend feature work  (feature/be-us-004-department)
-feature/fe-    → frontend feature work (feature/fe-us-004-department)
-fix/           → bug fixes
-test/be-       → backend tests  (test/be-us-001-invitation-service)
-test/fe-       → frontend tests (test/fe-us-001-invite-form)
+main       → production (stable, merged at sprint end)
+develop    → integration branch (all PRs target this)
+feature/   → feature work  (feature/us-020-admin-reports)
+fix/       → bug fixes
 ```
 
-BE and FE are developed on separate branches per user story, allowing independent PRs and reviews.
-
-All changes go through Pull Requests into `develop`.
+All changes go through Pull Requests into `develop`.  
 `develop` is merged into `main` at the end of each sprint.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,8 @@ StepUp replaces email chains and spreadsheets with a structured onboarding workf
 | Role | Email | Password |
 |---|---|---|
 | HR Admin | admin@stepup.com | Admin1234! |
-| Manager (Engineering) | manager@stepup.com | Manager1234! |
-| Manager (Product) | manager2@stepup.com | Manager1234! |
-| Employee (Engineering, in progress) | employee@stepup.com | Employee1234! |
-| Employee (Engineering, completed) | alice@stepup.com | Employee1234! |
-| Employee (Product, stuck) | bob@stepup.com | Employee1234! |
+| Manager | manager@stepup.com | Manager1234! |
+| Employee | employee@stepup.com | Employee1234! |
 
 ---
 

--- a/apps/backend/alembic/versions/a1b2c3d4e5f6_add_return_comment_to_plan_tasks.py
+++ b/apps/backend/alembic/versions/a1b2c3d4e5f6_add_return_comment_to_plan_tasks.py
@@ -1,0 +1,28 @@
+"""add_return_comment_to_plan_tasks
+
+Revision ID: a1b2c3d4e5f6
+Revises: f2a3b4c5d6e7
+Create Date: 2026-05-15 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = 'f2a3b4c5d6e7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'onboarding_plan_tasks',
+        sa.Column('return_comment', sa.Text, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('onboarding_plan_tasks', 'return_comment')

--- a/apps/backend/alembic/versions/c9a4b2e1f8d3_add_audit_log_table.py
+++ b/apps/backend/alembic/versions/c9a4b2e1f8d3_add_audit_log_table.py
@@ -1,0 +1,39 @@
+"""add_audit_log_table
+
+Revision ID: c9a4b2e1f8d3
+Revises: a3f1c8e2d047
+Create Date: 2026-05-14 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision: str = 'c9a4b2e1f8d3'
+down_revision: Union[str, None] = 'a3f1c8e2d047'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'audit_logs',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True),
+        sa.Column('actor_id', UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('action', sa.String(64), nullable=False, index=True),
+        sa.Column('entity_type', sa.String(64), nullable=False),
+        sa.Column('entity_id', UUID(as_uuid=True), nullable=False),
+        sa.Column('detail', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index('ix_audit_logs_action', 'audit_logs', ['action'])
+    op.create_index('ix_audit_logs_created_at', 'audit_logs', ['created_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_audit_logs_created_at', 'audit_logs')
+    op.drop_index('ix_audit_logs_action', 'audit_logs')
+    op.drop_table('audit_logs')

--- a/apps/backend/alembic/versions/c9a4b2e1f8d3_add_audit_log_table.py
+++ b/apps/backend/alembic/versions/c9a4b2e1f8d3_add_audit_log_table.py
@@ -1,7 +1,7 @@
 """add_audit_log_table
 
 Revision ID: c9a4b2e1f8d3
-Revises: a3f1c8e2d047
+Revises: 14e90742db5f
 Create Date: 2026-05-14 12:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 
 revision: str = 'c9a4b2e1f8d3'
-down_revision: Union[str, None] = 'a3f1c8e2d047'
+down_revision: Union[str, None] = '14e90742db5f'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -23,7 +23,7 @@ def upgrade() -> None:
         'audit_logs',
         sa.Column('id', UUID(as_uuid=True), primary_key=True),
         sa.Column('actor_id', UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
-        sa.Column('action', sa.String(64), nullable=False, index=True),
+        sa.Column('action', sa.String(64), nullable=False),
         sa.Column('entity_type', sa.String(64), nullable=False),
         sa.Column('entity_id', UUID(as_uuid=True), nullable=False),
         sa.Column('detail', sa.Text(), nullable=True),

--- a/apps/backend/alembic/versions/e1b2c3d4e5f6_add_overdue_task_status.py
+++ b/apps/backend/alembic/versions/e1b2c3d4e5f6_add_overdue_task_status.py
@@ -1,0 +1,24 @@
+"""add_overdue_task_status
+
+Revision ID: e1b2c3d4e5f6
+Revises: c9a4b2e1f8d3
+Create Date: 2026-05-14 18:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'e1b2c3d4e5f6'
+down_revision: Union[str, None] = 'c9a4b2e1f8d3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE onboarding_plan_task_status ADD VALUE IF NOT EXISTS 'overdue'")
+
+
+def downgrade() -> None:
+    pass

--- a/apps/backend/alembic/versions/f2a3b4c5d6e7_create_task_attachments_and_comments.py
+++ b/apps/backend/alembic/versions/f2a3b4c5d6e7_create_task_attachments_and_comments.py
@@ -1,0 +1,54 @@
+"""create_task_attachments_and_comments
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1b2c3d4e5f6
+Create Date: 2026-05-14 20:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision: str = 'f2a3b4c5d6e7'
+down_revision: Union[str, None] = 'e1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'task_attachments',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True),
+        sa.Column('plan_task_id', UUID(as_uuid=True), sa.ForeignKey('onboarding_plan_tasks.id'), nullable=False),
+        sa.Column('uploaded_by', UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('file_name', sa.String(255), nullable=False),
+        sa.Column('object_name', sa.String(512), nullable=False),
+        sa.Column('file_type', sa.String(128), nullable=False),
+        sa.Column('file_size', sa.Integer, nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index('ix_task_attachments_plan_task_id', 'task_attachments', ['plan_task_id'])
+
+    op.create_table(
+        'task_comments',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True),
+        sa.Column('plan_task_id', UUID(as_uuid=True), sa.ForeignKey('onboarding_plan_tasks.id'), nullable=False),
+        sa.Column('user_id', UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('content', sa.Text, nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index('ix_task_comments_plan_task_id', 'task_comments', ['plan_task_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_task_comments_plan_task_id', 'task_comments')
+    op.drop_table('task_comments')
+    op.drop_index('ix_task_attachments_plan_task_id', 'task_attachments')
+    op.drop_table('task_attachments')

--- a/apps/backend/app/api/router.py
+++ b/apps/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard, audit
+from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard, audit, reports
 
 
 api_router = APIRouter()
@@ -16,3 +16,4 @@ api_router.include_router(task_workflow.tasks_router, prefix="/tasks", tags=["em
 api_router.include_router(task_workflow.manager_router, prefix="/manager", tags=["manager-tasks"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 api_router.include_router(audit.router, prefix="/audit", tags=["audit"])
+api_router.include_router(reports.router, prefix="/reports", tags=["reports"])

--- a/apps/backend/app/api/router.py
+++ b/apps/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow
+from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard
 
 
 api_router = APIRouter()
@@ -14,3 +14,4 @@ api_router.include_router(task_workflow.plans_router, prefix="/plans", tags=["em
 api_router.include_router(onboarding_plan.router, prefix="/plans", tags=["plans"])
 api_router.include_router(task_workflow.tasks_router, prefix="/tasks", tags=["employee-tasks"])
 api_router.include_router(task_workflow.manager_router, prefix="/manager", tags=["manager-tasks"])
+api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])

--- a/apps/backend/app/api/router.py
+++ b/apps/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard
+from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard, audit
 
 
 api_router = APIRouter()
@@ -15,3 +15,4 @@ api_router.include_router(onboarding_plan.router, prefix="/plans", tags=["plans"
 api_router.include_router(task_workflow.tasks_router, prefix="/tasks", tags=["employee-tasks"])
 api_router.include_router(task_workflow.manager_router, prefix="/manager", tags=["manager-tasks"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
+api_router.include_router(audit.router, prefix="/audit", tags=["audit"])

--- a/apps/backend/app/api/router.py
+++ b/apps/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard, audit, reports
+from app.api.v1 import auth, invitation, user, department, template, onboarding_plan, task_workflow, dashboard, audit, reports, attachments
 
 
 api_router = APIRouter()
@@ -17,3 +17,4 @@ api_router.include_router(task_workflow.manager_router, prefix="/manager", tags=
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 api_router.include_router(audit.router, prefix="/audit", tags=["audit"])
 api_router.include_router(reports.router, prefix="/reports", tags=["reports"])
+api_router.include_router(attachments.router, prefix="/tasks", tags=["attachments"])

--- a/apps/backend/app/api/v1/attachments.py
+++ b/apps/backend/app/api/v1/attachments.py
@@ -1,0 +1,54 @@
+import uuid
+
+from fastapi import APIRouter, Depends, UploadFile, File, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.models.user import User
+from app.schemas.attachment import TaskAttachmentResponse, TaskCommentCreate, TaskCommentResponse
+from app.services.attachment_service import AttachmentService
+
+router = APIRouter()
+attachment_service = AttachmentService()
+
+
+@router.post(
+    "/{task_id}/attachments",
+    response_model=TaskAttachmentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_attachment(
+    task_id: uuid.UUID,
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> TaskAttachmentResponse:
+    return await attachment_service.upload_attachment(db, task_id, file, current_user)
+
+
+@router.delete(
+    "/{task_id}/attachments/{attachment_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_attachment(
+    task_id: uuid.UUID,
+    attachment_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    await attachment_service.delete_attachment(db, task_id, attachment_id, current_user)
+
+
+@router.post(
+    "/{task_id}/comments",
+    response_model=TaskCommentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_comment(
+    task_id: uuid.UUID,
+    data: TaskCommentCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> TaskCommentResponse:
+    return await attachment_service.add_comment(db, task_id, data, current_user)

--- a/apps/backend/app/api/v1/audit.py
+++ b/apps/backend/app/api/v1/audit.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import require_role
+from app.enums.user_role import UserRole
+from app.models.user import User
+from app.schemas.audit_log import AuditLogResponse
+from app.services.audit_service import AuditService
+
+router = APIRouter()
+audit_service = AuditService()
+
+
+@router.get("/", response_model=list[AuditLogResponse])
+async def get_audit_logs(
+    action: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> list[AuditLogResponse]:
+    logs = await audit_service.get_logs(db=db, action=action, limit=limit, offset=offset)
+    return [AuditLogResponse.model_validate(log) for log in logs]

--- a/apps/backend/app/api/v1/dashboard.py
+++ b/apps/backend/app/api/v1/dashboard.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import require_role
+from app.enums.user_role import UserRole
+from app.models.user import User
+from app.schemas.dashboard import EmployeeDashboardResponse, HRDashboardResponse, ManagerDashboardResponse
+from app.services.dashboard_service import DashboardService
+
+router = APIRouter()
+dashboard_service = DashboardService()
+
+
+@router.get("/hr", response_model=HRDashboardResponse)
+async def get_hr_dashboard(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> HRDashboardResponse:
+    return await dashboard_service.get_hr_stats(db=db)
+
+
+@router.get("/manager", response_model=ManagerDashboardResponse)
+async def get_manager_dashboard(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.MANAGER)),
+) -> ManagerDashboardResponse:
+    return await dashboard_service.get_manager_stats(db=db, manager_id=current_user.id)
+
+
+@router.get("/employee", response_model=EmployeeDashboardResponse)
+async def get_employee_dashboard(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.EMPLOYEE)),
+) -> EmployeeDashboardResponse:
+    return await dashboard_service.get_employee_stats(db=db, user_id=current_user.id)

--- a/apps/backend/app/api/v1/onboarding_plan.py
+++ b/apps/backend/app/api/v1/onboarding_plan.py
@@ -26,7 +26,7 @@ async def create_plan(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
 ) -> OnboardingPlanResponse:
-    plan = await onboarding_plan_service.create_plan(db=db, data=data)
+    plan = await onboarding_plan_service.create_plan(db=db, data=data, actor_id=current_user.id)
     return OnboardingPlanResponse.model_validate(plan)
 
 
@@ -81,5 +81,5 @@ async def cancel_task(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
 ) -> OnboardingPlanTaskResponse:
-    task = await onboarding_plan_service.cancel_task(db=db, plan_id=plan_id, task_id=task_id)
+    task = await onboarding_plan_service.cancel_task(db=db, plan_id=plan_id, task_id=task_id, actor_id=current_user.id)
     return OnboardingPlanTaskResponse.model_validate(task)

--- a/apps/backend/app/api/v1/reports.py
+++ b/apps/backend/app/api/v1/reports.py
@@ -1,0 +1,75 @@
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import require_role
+from app.enums.user_role import UserRole
+from app.models.user import User
+from app.schemas.reports import DepartmentCompletionRow, TemplateCompletionRow, BottleneckRow
+from app.services.reports_service import ReportsService
+
+router = APIRouter()
+reports_service = ReportsService()
+
+
+@router.get("/completion-time", response_model=list[DepartmentCompletionRow])
+async def get_completion_time(
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
+    format: str = Query("json", pattern="^(json|csv)$"),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> list[DepartmentCompletionRow] | StreamingResponse:
+    rows = await reports_service.get_completion_time(db, start_date, end_date)
+    if format == "csv":
+        headers = ["department_name", "total_plans", "avg_completion_days"]
+        csv_data = reports_service.to_csv(headers, [r.model_dump() for r in rows])
+        return StreamingResponse(
+            iter([csv_data]),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=completion-time.csv"},
+        )
+    return rows
+
+
+@router.get("/task-completion-rates", response_model=list[TemplateCompletionRow])
+async def get_task_completion_rates(
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
+    format: str = Query("json", pattern="^(json|csv)$"),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> list[TemplateCompletionRow] | StreamingResponse:
+    rows = await reports_service.get_task_completion_rates(db, start_date, end_date)
+    if format == "csv":
+        headers = ["template_name", "total_tasks", "completed_tasks", "completion_rate"]
+        csv_data = reports_service.to_csv(headers, [r.model_dump() for r in rows])
+        return StreamingResponse(
+            iter([csv_data]),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=task-completion-rates.csv"},
+        )
+    return rows
+
+
+@router.get("/bottlenecks", response_model=list[BottleneckRow])
+async def get_bottlenecks(
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
+    format: str = Query("json", pattern="^(json|csv)$"),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.HR_ADMIN)),
+) -> list[BottleneckRow] | StreamingResponse:
+    rows = await reports_service.get_bottlenecks(db, start_date, end_date)
+    if format == "csv":
+        headers = ["task_title", "returned_count", "overdue_count"]
+        csv_data = reports_service.to_csv(headers, [r.model_dump() for r in rows])
+        return StreamingResponse(
+            iter([csv_data]),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=bottlenecks.csv"},
+        )
+    return rows

--- a/apps/backend/app/api/v1/user.py
+++ b/apps/backend/app/api/v1/user.py
@@ -51,7 +51,7 @@ async def update_user(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
 ) -> UserResponse:
-    user = await user_service.update_user(db=db, user_id=user_id, data=data)
+    user = await user_service.update_user(db=db, user_id=user_id, data=data, actor_id=current_user.id)
     return UserResponse.model_validate(user)
 
 
@@ -74,5 +74,5 @@ async def reactivate_user(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
 ) -> UserResponse:
-    user = await user_service.reactivate_user(db=db, user_id=user_id)
+    user = await user_service.reactivate_user(db=db, user_id=user_id, actor_id=current_user.id)
     return UserResponse.model_validate(user)

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     FRONTEND_URL: str = ""
     SENDGRID_API_KEY: str = ""
     SENDGRID_FROM_EMAIL: str = ""
+    GCS_BUCKET_NAME: str = ""
     COOKIE_SECURE: bool = False
 
     JWT_SECRET_KEY: str

--- a/apps/backend/app/enums/onboarding_plan_task_status.py
+++ b/apps/backend/app/enums/onboarding_plan_task_status.py
@@ -7,4 +7,5 @@ class OnboardingPlanTaskStatus(str, enum.Enum):
     COMPLETED = "completed"
     APPROVED = "approved"
     RETURNED = "returned"
+    OVERDUE = "overdue"
     CANCELLED = "cancelled"

--- a/apps/backend/app/errors/messages.py
+++ b/apps/backend/app/errors/messages.py
@@ -40,3 +40,9 @@ TASK_ALREADY_TERMINAL = ("TASK_ALREADY_TERMINAL", "This task is already in a ter
 INVALID_TASK_TRANSITION = ("INVALID_TASK_TRANSITION", "This task cannot transition from its current status")
 TASK_NOT_APPROVABLE = ("TASK_NOT_APPROVABLE", "Only completed tasks can be approved or returned")
 RETURN_COMMENT_REQUIRED = ("RETURN_COMMENT_REQUIRED", "Feedback comment is required when returning a task")
+
+# Attachments
+ATTACHMENT_NOT_FOUND = ("ATTACHMENT_NOT_FOUND", "Attachment not found")
+ATTACHMENT_LOCKED = ("ATTACHMENT_LOCKED", "Attachment cannot be deleted after task is approved")
+INVALID_FILE_TYPE = ("INVALID_FILE_TYPE", "Only PDF, DOCX, PNG and JPEG files are allowed")
+FILE_TOO_LARGE = ("FILE_TOO_LARGE", "File size must not exceed 10 MB")

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,3 +1,6 @@
+from contextlib import asynccontextmanager
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import _rate_limit_exceeded_handler
@@ -5,8 +8,25 @@ from slowapi.errors import RateLimitExceeded
 
 from app.api.router import api_router
 from app.core.config import settings
+from app.core.database import AsyncSessionLocal
 from app.core.limiter import limiter
 from app.errors.handlers import register_error_handlers
+from app.services.scheduler_service import mark_overdue_tasks, send_deadline_reminders
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler = AsyncIOScheduler(timezone="UTC")
+    scheduler.add_job(
+        send_deadline_reminders, "cron", hour=0, minute=0, args=[AsyncSessionLocal]
+    )
+    scheduler.add_job(
+        mark_overdue_tasks, "cron", hour=0, minute=5, args=[AsyncSessionLocal]
+    )
+    scheduler.start()
+    yield
+    scheduler.shutdown()
+
 
 app = FastAPI(
     title="StepUp API",
@@ -14,6 +34,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
 
 app.state.limiter = limiter
@@ -35,4 +56,3 @@ app.include_router(api_router, prefix="/api/v1")
 @app.get("/health")
 async def health_check():
     return {"status": "ok", "service": "stepup-backend"}
-

--- a/apps/backend/app/models/__init__.py
+++ b/apps/backend/app/models/__init__.py
@@ -6,3 +6,5 @@ from app.models.onboarding_template import OnboardingTemplate  # noqa: F401
 from app.models.template_task import TemplateTask  # noqa: F401
 from app.models.onboarding_plan import OnboardingPlan  # noqa: F401
 from app.models.onboarding_plan_task import OnboardingPlanTask  # noqa: F401
+from app.models.task_attachment import TaskAttachment  # noqa: F401
+from app.models.task_comment import TaskComment  # noqa: F401

--- a/apps/backend/app/models/audit_log.py
+++ b/apps/backend/app/models/audit_log.py
@@ -1,0 +1,22 @@
+import uuid
+from datetime import datetime
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    actor_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    action: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    entity_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/apps/backend/app/models/onboarding_plan_task.py
+++ b/apps/backend/app/models/onboarding_plan_task.py
@@ -43,6 +43,7 @@ class OnboardingPlanTask(Base, TimestampMixin):
     )
     is_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     order: Mapped[int] = mapped_column(Integer, nullable=False)
+    return_comment: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     plan: Mapped["OnboardingPlan"] = relationship("OnboardingPlan", back_populates="tasks")
     attachments: Mapped[list["TaskAttachment"]] = relationship("TaskAttachment", back_populates="task", order_by="TaskAttachment.created_at")

--- a/apps/backend/app/models/onboarding_plan_task.py
+++ b/apps/backend/app/models/onboarding_plan_task.py
@@ -13,6 +13,8 @@ from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 
 if TYPE_CHECKING:
     from app.models.onboarding_plan import OnboardingPlan
+    from app.models.task_attachment import TaskAttachment
+    from app.models.task_comment import TaskComment
 
 
 class OnboardingPlanTask(Base, TimestampMixin):
@@ -43,3 +45,5 @@ class OnboardingPlanTask(Base, TimestampMixin):
     order: Mapped[int] = mapped_column(Integer, nullable=False)
 
     plan: Mapped["OnboardingPlan"] = relationship("OnboardingPlan", back_populates="tasks")
+    attachments: Mapped[list["TaskAttachment"]] = relationship("TaskAttachment", back_populates="task", order_by="TaskAttachment.created_at")
+    comments: Mapped[list["TaskComment"]] = relationship("TaskComment", back_populates="task", order_by="TaskComment.created_at")

--- a/apps/backend/app/models/task_attachment.py
+++ b/apps/backend/app/models/task_attachment.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+from sqlalchemy import ForeignKey, String, Integer
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.onboarding_plan_task import OnboardingPlanTask
+    from app.models.user import User
+
+
+class TaskAttachment(Base, TimestampMixin):
+    __tablename__ = "task_attachments"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    plan_task_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("onboarding_plan_tasks.id"), nullable=False)
+    uploaded_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    file_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    object_name: Mapped[str] = mapped_column(String(512), nullable=False)
+    file_type: Mapped[str] = mapped_column(String(128), nullable=False)
+    file_size: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    task: Mapped["OnboardingPlanTask"] = relationship("OnboardingPlanTask", back_populates="attachments")
+    uploader: Mapped["User"] = relationship("User", foreign_keys=[uploaded_by])

--- a/apps/backend/app/models/task_comment.py
+++ b/apps/backend/app/models/task_comment.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+from sqlalchemy import ForeignKey, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.onboarding_plan_task import OnboardingPlanTask
+    from app.models.user import User
+
+
+class TaskComment(Base, TimestampMixin):
+    __tablename__ = "task_comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    plan_task_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("onboarding_plan_tasks.id"), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    task: Mapped["OnboardingPlanTask"] = relationship("OnboardingPlanTask", back_populates="comments")
+    author: Mapped["User"] = relationship("User", foreign_keys=[user_id])

--- a/apps/backend/app/repositories/audit_log_repository.py
+++ b/apps/backend/app/repositories/audit_log_repository.py
@@ -1,0 +1,25 @@
+import uuid
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_log import AuditLog
+
+
+class AuditLogRepository:
+
+    async def create(self, db: AsyncSession, log: AuditLog) -> None:
+        db.add(log)
+
+    async def get_all(
+        self,
+        db: AsyncSession,
+        action: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AuditLog]:
+        query = select(AuditLog).order_by(AuditLog.created_at.desc())
+        if action:
+            query = query.where(AuditLog.action == action)
+        query = query.limit(limit).offset(offset)
+        result = await db.execute(query)
+        return list(result.scalars().all())

--- a/apps/backend/app/repositories/department_repository.py
+++ b/apps/backend/app/repositories/department_repository.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.department import Department
@@ -27,3 +27,12 @@ class DepartmentRepository:
     async def create(self, db: AsyncSession, department: Department) -> Department:
         db.add(department)
         return department
+
+    async def count_active(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count()).where(
+                Department.is_active.is_(True),
+                Department.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()

--- a/apps/backend/app/repositories/onboarding_plan_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_repository.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -45,3 +45,12 @@ class OnboardingPlanRepository:
             )
         )
         return result.scalar_one_or_none()
+
+    async def count_active(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count()).where(
+                OnboardingPlan.is_active.is_(True),
+                OnboardingPlan.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()

--- a/apps/backend/app/repositories/onboarding_plan_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
 
 
 class OnboardingPlanRepository:
@@ -11,10 +12,16 @@ class OnboardingPlanRepository:
         db.add(plan)
         return plan
 
+    def _task_options(self):
+        return selectinload(OnboardingPlan.tasks).options(
+            selectinload(OnboardingPlanTask.attachments),
+            selectinload(OnboardingPlanTask.comments),
+        )
+
     async def get_by_id(self, db: AsyncSession, plan_id: uuid.UUID) -> OnboardingPlan | None:
         result = await db.execute(
             select(OnboardingPlan)
-            .options(selectinload(OnboardingPlan.tasks))
+            .options(self._task_options())
             .where(
                 OnboardingPlan.id == plan_id,
                 OnboardingPlan.deleted_at.is_(None),
@@ -25,7 +32,7 @@ class OnboardingPlanRepository:
     async def get_all_by_manager(self, db: AsyncSession, manager_id: uuid.UUID) -> list[OnboardingPlan]:
         result = await db.execute(
             select(OnboardingPlan)
-            .options(selectinload(OnboardingPlan.tasks), selectinload(OnboardingPlan.employee))
+            .options(self._task_options(), selectinload(OnboardingPlan.employee))
             .where(
                 OnboardingPlan.manager_id == manager_id,
                 OnboardingPlan.is_active.is_(True),
@@ -37,7 +44,7 @@ class OnboardingPlanRepository:
     async def get_active_by_user(self, db: AsyncSession, user_id: uuid.UUID) -> OnboardingPlan | None:
         result = await db.execute(
             select(OnboardingPlan)
-            .options(selectinload(OnboardingPlan.tasks))
+            .options(self._task_options())
             .where(
                 OnboardingPlan.user_id == user_id,
                 OnboardingPlan.is_active.is_(True),

--- a/apps/backend/app/repositories/onboarding_plan_task_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_task_repository.py
@@ -2,6 +2,8 @@ import uuid
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.models.onboarding_plan import OnboardingPlan
 from app.models.onboarding_plan_task import OnboardingPlanTask
 
 
@@ -27,3 +29,30 @@ class OnboardingPlanTaskRepository:
             )
         )
         return result.scalar_one() or 0
+
+    async def count_completed_across_active_plans(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count())
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+            .where(
+                OnboardingPlanTask.status == OnboardingPlanTaskStatus.COMPLETED,
+                OnboardingPlanTask.deleted_at.is_(None),
+                OnboardingPlan.is_active.is_(True),
+                OnboardingPlan.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()
+
+    async def count_completed_by_manager(self, db: AsyncSession, manager_id: uuid.UUID) -> int:
+        result = await db.execute(
+            select(func.count())
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+            .where(
+                OnboardingPlanTask.status == OnboardingPlanTaskStatus.COMPLETED,
+                OnboardingPlanTask.deleted_at.is_(None),
+                OnboardingPlan.manager_id == manager_id,
+                OnboardingPlan.is_active.is_(True),
+                OnboardingPlan.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()

--- a/apps/backend/app/repositories/onboarding_plan_task_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_task_repository.py
@@ -1,6 +1,7 @@
 import uuid
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 from app.models.onboarding_plan import OnboardingPlan
@@ -14,7 +15,12 @@ class OnboardingPlanTaskRepository:
 
     async def get_by_id(self, db: AsyncSession, task_id: uuid.UUID) -> OnboardingPlanTask | None:
         result = await db.execute(
-            select(OnboardingPlanTask).where(
+            select(OnboardingPlanTask)
+            .options(
+                selectinload(OnboardingPlanTask.attachments),
+                selectinload(OnboardingPlanTask.comments),
+            )
+            .where(
                 OnboardingPlanTask.id == task_id,
                 OnboardingPlanTask.deleted_at.is_(None),
             )

--- a/apps/backend/app/repositories/reports_repository.py
+++ b/apps/backend/app/repositories/reports_repository.py
@@ -1,0 +1,146 @@
+from datetime import date
+from sqlalchemy import func, case, and_, cast
+from sqlalchemy.dialects.postgresql import TIMESTAMP
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.models.department import Department
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
+from app.models.onboarding_template import OnboardingTemplate
+from app.models.user import User
+
+_TERMINAL = [
+    OnboardingPlanTaskStatus.COMPLETED,
+    OnboardingPlanTaskStatus.APPROVED,
+    OnboardingPlanTaskStatus.CANCELLED,
+]
+
+
+class ReportsRepository:
+
+    async def get_completion_time_by_department(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[dict]:
+        # Subquery: last approval timestamp per plan (= plan completion moment)
+        last_approval = (
+            select(
+                OnboardingPlanTask.plan_id,
+                func.max(OnboardingPlanTask.updated_at).label("completed_at"),
+            )
+            .where(OnboardingPlanTask.status == OnboardingPlanTaskStatus.APPROVED)
+            .group_by(OnboardingPlanTask.plan_id)
+            .subquery()
+        )
+
+        days_expr = (
+            func.extract(
+                "epoch",
+                last_approval.c.completed_at - cast(OnboardingPlan.start_date, TIMESTAMP),
+            )
+            / 86400
+        )
+
+        query = (
+            select(
+                Department.name.label("department_name"),
+                func.count(OnboardingPlan.id.distinct()).label("total_plans"),
+                func.avg(days_expr).label("avg_completion_days"),
+            )
+            .join(last_approval, OnboardingPlan.id == last_approval.c.plan_id)
+            .join(User, OnboardingPlan.user_id == User.id)
+            .join(Department, User.department_id == Department.id)
+        )
+
+        if start_date:
+            query = query.where(OnboardingPlan.start_date >= start_date)
+        if end_date:
+            query = query.where(OnboardingPlan.start_date <= end_date)
+
+        query = query.group_by(Department.name).order_by(Department.name)
+        result = await db.execute(query)
+        return [dict(row._mapping) for row in result.all()]
+
+    async def get_task_completion_rates(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[dict]:
+        done_statuses = [OnboardingPlanTaskStatus.COMPLETED, OnboardingPlanTaskStatus.APPROVED]
+        done_case = case(
+            (OnboardingPlanTask.status.in_(done_statuses), 1),
+            else_=0,
+        )
+
+        query = (
+            select(
+                OnboardingTemplate.name.label("template_name"),
+                func.count(OnboardingPlanTask.id).label("total_tasks"),
+                func.sum(done_case).label("completed_tasks"),
+            )
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+            .join(OnboardingTemplate, OnboardingPlan.template_id == OnboardingTemplate.id)
+        )
+
+        if start_date:
+            query = query.where(OnboardingPlan.start_date >= start_date)
+        if end_date:
+            query = query.where(OnboardingPlan.start_date <= end_date)
+
+        query = query.group_by(OnboardingTemplate.name).order_by(OnboardingTemplate.name)
+        result = await db.execute(query)
+        return [dict(row._mapping) for row in result.all()]
+
+    async def get_bottlenecks(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[dict]:
+        today = date.today()
+
+        returned_case = case(
+            (OnboardingPlanTask.status == OnboardingPlanTaskStatus.RETURNED, 1),
+            else_=0,
+        )
+        overdue_case = case(
+            (
+                and_(
+                    OnboardingPlanTask.deadline < today,
+                    OnboardingPlanTask.status.notin_(_TERMINAL),
+                ),
+                1,
+            ),
+            else_=0,
+        )
+
+        total_expr = func.sum(returned_case) + func.sum(overdue_case)
+
+        query = (
+            select(
+                OnboardingPlanTask.title.label("task_title"),
+                func.sum(returned_case).label("returned_count"),
+                func.sum(overdue_case).label("overdue_count"),
+            )
+            .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+        )
+
+        if start_date:
+            query = query.where(OnboardingPlan.start_date >= start_date)
+        if end_date:
+            query = query.where(OnboardingPlan.start_date <= end_date)
+
+        query = (
+            query.group_by(OnboardingPlanTask.title)
+            .having(total_expr > 0)
+            .order_by(total_expr.desc())
+            .limit(20)
+        )
+
+        result = await db.execute(query)
+        return [dict(row._mapping) for row in result.all()]

--- a/apps/backend/app/repositories/task_attachment_repository.py
+++ b/apps/backend/app/repositories/task_attachment_repository.py
@@ -1,0 +1,30 @@
+import uuid
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.task_attachment import TaskAttachment
+
+
+class TaskAttachmentRepository:
+
+    async def create(self, db: AsyncSession, attachment: TaskAttachment) -> TaskAttachment:
+        db.add(attachment)
+        return attachment
+
+    async def get_by_id(self, db: AsyncSession, attachment_id: uuid.UUID) -> TaskAttachment | None:
+        result = await db.execute(
+            select(TaskAttachment).where(
+                TaskAttachment.id == attachment_id,
+                TaskAttachment.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_task(self, db: AsyncSession, plan_task_id: uuid.UUID) -> list[TaskAttachment]:
+        result = await db.execute(
+            select(TaskAttachment).where(
+                TaskAttachment.plan_task_id == plan_task_id,
+                TaskAttachment.deleted_at.is_(None),
+            ).order_by(TaskAttachment.created_at)
+        )
+        return list(result.scalars().all())

--- a/apps/backend/app/repositories/task_comment_repository.py
+++ b/apps/backend/app/repositories/task_comment_repository.py
@@ -1,0 +1,21 @@
+import uuid
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.task_comment import TaskComment
+
+
+class TaskCommentRepository:
+
+    async def create(self, db: AsyncSession, comment: TaskComment) -> TaskComment:
+        db.add(comment)
+        return comment
+
+    async def get_by_task(self, db: AsyncSession, plan_task_id: uuid.UUID) -> list[TaskComment]:
+        result = await db.execute(
+            select(TaskComment).where(
+                TaskComment.plan_task_id == plan_task_id,
+                TaskComment.deleted_at.is_(None),
+            ).order_by(TaskComment.created_at)
+        )
+        return list(result.scalars().all())

--- a/apps/backend/app/repositories/user_repository.py
+++ b/apps/backend/app/repositories/user_repository.py
@@ -36,6 +36,15 @@ class UserRepository:
         )
         return result.scalar_one()
 
+    async def count_active(self, db: AsyncSession) -> int:
+        result = await db.execute(
+            select(func.count()).where(
+                User.is_active.is_(True),
+                User.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one()
+
     async def get_all(
         self,
         db: AsyncSession,

--- a/apps/backend/app/schemas/attachment.py
+++ b/apps/backend/app/schemas/attachment.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+
+class TaskAttachmentResponse(BaseModel):
+    id: uuid.UUID
+    plan_task_id: uuid.UUID
+    uploaded_by: uuid.UUID
+    file_name: str
+    file_type: str
+    file_size: int
+    download_url: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskCommentCreate(BaseModel):
+    content: str
+
+
+class TaskCommentResponse(BaseModel):
+    id: uuid.UUID
+    plan_task_id: uuid.UUID
+    user_id: uuid.UUID
+    content: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/app/schemas/attachment.py
+++ b/apps/backend/app/schemas/attachment.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class TaskAttachmentResponse(BaseModel):
@@ -14,6 +14,24 @@ class TaskAttachmentResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def compute_download_url(cls, v):
+        if isinstance(v, dict):
+            return v
+        from app.services.storage_service import StorageService
+        storage = StorageService()
+        return {
+            'id': v.id,
+            'plan_task_id': v.plan_task_id,
+            'uploaded_by': v.uploaded_by,
+            'file_name': v.file_name,
+            'file_type': v.file_type,
+            'file_size': v.file_size,
+            'download_url': storage.signed_url(v.object_name),
+            'created_at': v.created_at,
+        }
 
 
 class TaskCommentCreate(BaseModel):

--- a/apps/backend/app/schemas/audit_log.py
+++ b/apps/backend/app/schemas/audit_log.py
@@ -1,0 +1,15 @@
+import uuid
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+
+class AuditLogResponse(BaseModel):
+    id: uuid.UUID
+    actor_id: uuid.UUID
+    action: str
+    entity_type: str
+    entity_id: uuid.UUID
+    detail: str | None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/app/schemas/dashboard.py
+++ b/apps/backend/app/schemas/dashboard.py
@@ -1,0 +1,23 @@
+from datetime import date
+from pydantic import BaseModel
+
+
+class HRDashboardResponse(BaseModel):
+    active_users: int
+    active_plans: int
+    active_departments: int
+    pending_approvals: int
+
+
+class ManagerDashboardResponse(BaseModel):
+    active_plans: int
+    pending_approvals: int
+    total_employees: int
+
+
+class EmployeeDashboardResponse(BaseModel):
+    total_tasks: int
+    approved_tasks: int
+    completed_tasks: int
+    in_progress_tasks: int
+    next_deadline: date | None

--- a/apps/backend/app/schemas/onboarding_plan.py
+++ b/apps/backend/app/schemas/onboarding_plan.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict
 
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.schemas.attachment import TaskAttachmentResponse, TaskCommentResponse
 
 
 class ReturnTask(BaseModel):
@@ -21,6 +22,8 @@ class ApprovalTaskResponse(BaseModel):
     created_at: datetime
     employee_name: str
     plan_start_date: date
+    return_comment: str | None = None
+    attachments: list[TaskAttachmentResponse] = []
 
 
 class OnboardingPlanCreate(BaseModel):
@@ -56,6 +59,9 @@ class OnboardingPlanTaskResponse(BaseModel):
     is_required: bool
     order: int
     created_at: datetime
+    return_comment: str | None = None
+    attachments: list[TaskAttachmentResponse] = []
+    comments: list[TaskCommentResponse] = []
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/backend/app/schemas/reports.py
+++ b/apps/backend/app/schemas/reports.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, computed_field
+
+
+class DepartmentCompletionRow(BaseModel):
+    department_name: str
+    total_plans: int
+    avg_completion_days: float | None
+
+    @computed_field
+    @property
+    def avg_completion_days_rounded(self) -> float | None:
+        if self.avg_completion_days is None:
+            return None
+        return round(self.avg_completion_days, 1)
+
+
+class TemplateCompletionRow(BaseModel):
+    template_name: str
+    total_tasks: int
+    completed_tasks: int
+
+    @computed_field
+    @property
+    def completion_rate(self) -> float:
+        if self.total_tasks == 0:
+            return 0.0
+        return round(self.completed_tasks / self.total_tasks * 100, 1)
+
+
+class BottleneckRow(BaseModel):
+    task_title: str
+    returned_count: int
+    overdue_count: int

--- a/apps/backend/app/services/attachment_service.py
+++ b/apps/backend/app/services/attachment_service.py
@@ -1,0 +1,116 @@
+import uuid
+
+from fastapi import UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.errors import NotFoundError, ValidationError, PermissionError
+from app.errors import messages
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.models.task_attachment import TaskAttachment
+from app.models.task_comment import TaskComment
+from app.models.user import User
+from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
+from app.repositories.task_attachment_repository import TaskAttachmentRepository
+from app.repositories.task_comment_repository import TaskCommentRepository
+from app.schemas.attachment import TaskAttachmentResponse, TaskCommentCreate, TaskCommentResponse
+from app.services.storage_service import StorageService, ALLOWED_CONTENT_TYPES, MAX_FILE_SIZE
+
+plan_task_repository = OnboardingPlanTaskRepository()
+attachment_repository = TaskAttachmentRepository()
+comment_repository = TaskCommentRepository()
+storage_service = StorageService()
+
+
+class AttachmentService:
+
+    async def upload_attachment(
+        self,
+        db: AsyncSession,
+        task_id: uuid.UUID,
+        file: UploadFile,
+        current_user: User,
+    ) -> TaskAttachmentResponse:
+        task = await plan_task_repository.get_by_id(db, task_id)
+        if not task:
+            raise NotFoundError(*messages.PLAN_TASK_NOT_FOUND)
+
+        if file.content_type not in ALLOWED_CONTENT_TYPES:
+            raise ValidationError(*messages.INVALID_FILE_TYPE)
+
+        content = await file.read()
+        if len(content) > MAX_FILE_SIZE:
+            raise ValidationError(*messages.FILE_TOO_LARGE)
+
+        object_name = f"tasks/{task_id}/{uuid.uuid4()}_{file.filename}"
+        storage_service.upload(content, object_name, file.content_type)
+
+        attachment = TaskAttachment(
+            plan_task_id=task_id,
+            uploaded_by=current_user.id,
+            file_name=file.filename,
+            object_name=object_name,
+            file_type=file.content_type,
+            file_size=len(content),
+        )
+        await attachment_repository.create(db, attachment)
+        await db.commit()
+        await db.refresh(attachment)
+
+        return self._to_response(attachment)
+
+    async def delete_attachment(
+        self,
+        db: AsyncSession,
+        task_id: uuid.UUID,
+        attachment_id: uuid.UUID,
+        current_user: User,
+    ) -> None:
+        attachment = await attachment_repository.get_by_id(db, attachment_id)
+        if not attachment or attachment.plan_task_id != task_id:
+            raise NotFoundError(*messages.ATTACHMENT_NOT_FOUND)
+
+        if attachment.uploaded_by != current_user.id:
+            raise PermissionError(*messages.PERMISSION_DENIED)
+
+        task = await plan_task_repository.get_by_id(db, task_id)
+        if task and task.status == OnboardingPlanTaskStatus.APPROVED:
+            raise ValidationError(*messages.ATTACHMENT_LOCKED)
+
+        storage_service.delete(attachment.object_name)
+        await db.delete(attachment)
+        await db.commit()
+
+    async def add_comment(
+        self,
+        db: AsyncSession,
+        task_id: uuid.UUID,
+        data: TaskCommentCreate,
+        current_user: User,
+    ) -> TaskCommentResponse:
+        task = await plan_task_repository.get_by_id(db, task_id)
+        if not task:
+            raise NotFoundError(*messages.PLAN_TASK_NOT_FOUND)
+
+        comment = TaskComment(
+            plan_task_id=task_id,
+            user_id=current_user.id,
+            content=data.content,
+        )
+        await comment_repository.create(db, comment)
+        await db.commit()
+        await db.refresh(comment)
+
+        return TaskCommentResponse.model_validate(comment)
+
+    def _to_response(self, attachment: TaskAttachment) -> TaskAttachmentResponse:
+        download_url = storage_service.signed_url(attachment.object_name)
+        return TaskAttachmentResponse(
+            id=attachment.id,
+            plan_task_id=attachment.plan_task_id,
+            uploaded_by=attachment.uploaded_by,
+            file_name=attachment.file_name,
+            file_type=attachment.file_type,
+            file_size=attachment.file_size,
+            download_url=download_url,
+            created_at=attachment.created_at,
+        )

--- a/apps/backend/app/services/audit_service.py
+++ b/apps/backend/app/services/audit_service.py
@@ -1,0 +1,38 @@
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_log import AuditLog
+from app.repositories.audit_log_repository import AuditLogRepository
+
+audit_log_repository = AuditLogRepository()
+
+
+class AuditService:
+
+    async def log(
+        self,
+        db: AsyncSession,
+        actor_id: uuid.UUID,
+        action: str,
+        entity_type: str,
+        entity_id: uuid.UUID,
+        detail: str | None = None,
+    ) -> None:
+        entry = AuditLog(
+            actor_id=actor_id,
+            action=action,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            detail=detail,
+        )
+        await audit_log_repository.create(db, entry)
+
+    async def get_logs(
+        self,
+        db: AsyncSession,
+        action: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AuditLog]:
+        return await audit_log_repository.get_all(db, action=action, limit=limit, offset=offset)

--- a/apps/backend/app/services/dashboard_service.py
+++ b/apps/backend/app/services/dashboard_service.py
@@ -1,0 +1,74 @@
+import uuid
+from datetime import date
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.repositories.department_repository import DepartmentRepository
+from app.repositories.onboarding_plan_repository import OnboardingPlanRepository
+from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
+from app.repositories.user_repository import UserRepository
+from app.schemas.dashboard import EmployeeDashboardResponse, HRDashboardResponse, ManagerDashboardResponse
+
+user_repository = UserRepository()
+plan_repository = OnboardingPlanRepository()
+plan_task_repository = OnboardingPlanTaskRepository()
+department_repository = DepartmentRepository()
+
+
+class DashboardService:
+
+    async def get_hr_stats(self, db: AsyncSession) -> HRDashboardResponse:
+        active_users = await user_repository.count_active(db)
+        active_plans = await plan_repository.count_active(db)
+        active_departments = await department_repository.count_active(db)
+        pending_approvals = await plan_task_repository.count_completed_across_active_plans(db)
+
+        return HRDashboardResponse(
+            active_users=active_users,
+            active_plans=active_plans,
+            active_departments=active_departments,
+            pending_approvals=pending_approvals,
+        )
+
+    async def get_manager_stats(self, db: AsyncSession, manager_id: uuid.UUID) -> ManagerDashboardResponse:
+        plans = await plan_repository.get_all_by_manager(db, manager_id)
+        pending_approvals = await plan_task_repository.count_completed_by_manager(db, manager_id)
+
+        return ManagerDashboardResponse(
+            active_plans=len(plans),
+            pending_approvals=pending_approvals,
+            total_employees=len({p.user_id for p in plans}),
+        )
+
+    async def get_employee_stats(self, db: AsyncSession, user_id: uuid.UUID) -> EmployeeDashboardResponse:
+        plan = await plan_repository.get_active_by_user(db, user_id)
+
+        if not plan:
+            return EmployeeDashboardResponse(
+                total_tasks=0,
+                approved_tasks=0,
+                completed_tasks=0,
+                in_progress_tasks=0,
+                next_deadline=None,
+            )
+
+        active_tasks = [t for t in plan.tasks if t.deleted_at is None]
+
+        approved = sum(1 for t in active_tasks if t.status == OnboardingPlanTaskStatus.APPROVED)
+        completed = sum(1 for t in active_tasks if t.status == OnboardingPlanTaskStatus.COMPLETED)
+        in_progress = sum(1 for t in active_tasks if t.status == OnboardingPlanTaskStatus.IN_PROGRESS)
+
+        pending_deadlines: list[date] = [
+            t.deadline for t in active_tasks
+            if t.status not in (OnboardingPlanTaskStatus.APPROVED, OnboardingPlanTaskStatus.CANCELLED)
+        ]
+        next_deadline = min(pending_deadlines) if pending_deadlines else None
+
+        return EmployeeDashboardResponse(
+            total_tasks=len(active_tasks),
+            approved_tasks=approved,
+            completed_tasks=completed,
+            in_progress_tasks=in_progress,
+            next_deadline=next_deadline,
+        )

--- a/apps/backend/app/services/email_service.py
+++ b/apps/backend/app/services/email_service.py
@@ -6,14 +6,8 @@ from app.core.config import settings
 
 class EmailService:
 
-    async def send_invitation_email(
-        self,
-        to_email: str,
-        token: str,
-        role: str,
-    ) -> None:
+    async def send_invitation_email(self, to_email: str, token: str, role: str) -> None:
         registration_url = f"{settings.FRONTEND_URL}/register?token={token}"
-
         message = Mail(
             from_email=settings.SENDGRID_FROM_EMAIL,
             to_emails=to_email,
@@ -24,6 +18,69 @@ class EmailService:
                 <p>This link expires in 7 days.</p>
             """,
         )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
 
+    async def send_plan_started_email(self, to_email: str, first_name: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject="Your onboarding plan is ready",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>Your onboarding plan has been created. You can now view your tasks and get started.</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_completed_email(self, to_email: str, manager_first_name: str, employee_name: str, task_title: str) -> None:
+        approvals_url = f"{settings.FRONTEND_URL}/manager/approvals"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"{employee_name} completed a task — review required",
+            html_content=f"""
+                <p>Hi {manager_first_name},</p>
+                <p><strong>{employee_name}</strong> has marked the following task as complete and it is awaiting your review:</p>
+                <p><strong>{task_title}</strong></p>
+                <p><a href="{approvals_url}">Go to pending approvals</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_approved_email(self, to_email: str, first_name: str, task_title: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Task approved: {task_title}",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>Your task has been approved by your manager:</p>
+                <p><strong>{task_title}</strong></p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_returned_email(self, to_email: str, first_name: str, task_title: str, comment: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Task returned for revision: {task_title}",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>Your manager has returned the following task for revision:</p>
+                <p><strong>{task_title}</strong></p>
+                <p><strong>Feedback:</strong> {comment}</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
         client = SendGridAPIClient(settings.SENDGRID_API_KEY)
         client.send(message)

--- a/apps/backend/app/services/email_service.py
+++ b/apps/backend/app/services/email_service.py
@@ -68,6 +68,55 @@ class EmailService:
         client = SendGridAPIClient(settings.SENDGRID_API_KEY)
         client.send(message)
 
+    async def send_task_overdue_email(self, to_email: str, first_name: str, task_title: str, deadline: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Task overdue: {task_title}",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>The following task has passed its deadline and is now marked as overdue:</p>
+                <p><strong>{task_title}</strong> — was due on {deadline}</p>
+                <p>Please complete it as soon as possible.</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_task_overdue_manager_email(self, to_email: str, manager_first_name: str, employee_name: str, task_title: str, deadline: str) -> None:
+        approvals_url = f"{settings.FRONTEND_URL}/manager/approvals"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Overdue task: {task_title} — {employee_name}",
+            html_content=f"""
+                <p>Hi {manager_first_name},</p>
+                <p><strong>{employee_name}</strong> has an overdue task:</p>
+                <p><strong>{task_title}</strong> — was due on {deadline}</p>
+                <p><a href="{approvals_url}">View team tasks</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
+    async def send_deadline_reminder_email(self, to_email: str, first_name: str, task_title: str, deadline: str) -> None:
+        plan_url = f"{settings.FRONTEND_URL}/employee/plan"
+        message = Mail(
+            from_email=settings.SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=f"Reminder: '{task_title}' is due in 2 days",
+            html_content=f"""
+                <p>Hi {first_name},</p>
+                <p>This is a reminder that the following task is due in 2 days:</p>
+                <p><strong>{task_title}</strong> — due on {deadline}</p>
+                <p><a href="{plan_url}">View my onboarding plan</a></p>
+            """,
+        )
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        client.send(message)
+
     async def send_task_returned_email(self, to_email: str, first_name: str, task_title: str, comment: str) -> None:
         plan_url = f"{settings.FRONTEND_URL}/employee/plan"
         message = Mail(

--- a/apps/backend/app/services/invitation_service.py
+++ b/apps/backend/app/services/invitation_service.py
@@ -12,6 +12,7 @@ from app.models.invitation import Invitation
 from app.models.user import User
 from app.repositories.invitation_repository import InvitationRepository
 from app.repositories.user_repository import UserRepository
+from app.services.audit_service import AuditService
 from app.services.email_service import EmailService
 
 import logging
@@ -23,6 +24,7 @@ INVITATION_EXPIRY_DAYS = 7
 invitation_repository = InvitationRepository()
 user_repository = UserRepository()
 email_service = EmailService()
+audit_service = AuditService()
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
@@ -51,6 +53,8 @@ class InvitationService:
         await invitation_repository.create(db, invitation)
         await db.commit()
         await db.refresh(invitation)
+        await audit_service.log(db, actor_id=invited_by, action="user.invited", entity_type="invitation", entity_id=invitation.id, detail=email)
+        await db.commit()
 
         try:
             await email_service.send_invitation_email(
@@ -104,8 +108,11 @@ class InvitationService:
         )
         db.add(user)
         invitation.used_at = datetime.now(timezone.utc)
+        await db.flush()
         await db.commit()
         await db.refresh(user)
+        await audit_service.log(db, actor_id=user.id, action="user.registered", entity_type="user", entity_id=user.id)
+        await db.commit()
         return user
     
     async def get_invitations(self, db: AsyncSession) -> list[Invitation]:

--- a/apps/backend/app/services/onboarding_plan_service.py
+++ b/apps/backend/app/services/onboarding_plan_service.py
@@ -18,11 +18,19 @@ from app.schemas.onboarding_plan import (
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 from app.errors import NotFoundError, ValidationError
 from app.errors import messages
+from app.repositories.user_repository import UserRepository
 from app.services.audit_service import AuditService
+from app.services.email_service import EmailService
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 audit_service = AuditService()
+email_service = EmailService()
 
 plan_repository = OnboardingPlanRepository()
+user_repository = UserRepository()
 plan_task_repository = OnboardingPlanTaskRepository()
 template_repository = TemplateRepository()
 template_task_repository = TemplateTaskRepository()
@@ -69,6 +77,15 @@ class OnboardingPlanService:
         if actor_id:
             await audit_service.log(db, actor_id=actor_id, action="plan.created", entity_type="plan", entity_id=plan.id)
             await db.commit()
+        try:
+            employee = await user_repository.get_by_id(db, data.user_id)
+            if employee:
+                await email_service.send_plan_started_email(
+                    to_email=employee.email,
+                    first_name=employee.first_name,
+                )
+        except Exception as e:
+            logger.error(f"Failed to send plan_started email: {e}")
         return await plan_repository.get_by_id(db, plan.id)
 
     async def get_plan(self, db: AsyncSession, plan_id: uuid.UUID) -> OnboardingPlan:

--- a/apps/backend/app/services/onboarding_plan_service.py
+++ b/apps/backend/app/services/onboarding_plan_service.py
@@ -18,6 +18,9 @@ from app.schemas.onboarding_plan import (
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 from app.errors import NotFoundError, ValidationError
 from app.errors import messages
+from app.services.audit_service import AuditService
+
+audit_service = AuditService()
 
 plan_repository = OnboardingPlanRepository()
 plan_task_repository = OnboardingPlanTaskRepository()
@@ -28,7 +31,7 @@ TERMINAL_STATUSES = {OnboardingPlanTaskStatus.CANCELLED}
 
 
 class OnboardingPlanService:
-    async def create_plan(self, db: AsyncSession, data: OnboardingPlanCreate) -> OnboardingPlan:
+    async def create_plan(self, db: AsyncSession, data: OnboardingPlanCreate, actor_id: uuid.UUID | None = None) -> OnboardingPlan:
         existing = await plan_repository.get_active_by_user(db, data.user_id)
         if existing:
             raise ValidationError(*messages.EMPLOYEE_ALREADY_HAS_ACTIVE_PLAN)
@@ -63,6 +66,9 @@ class OnboardingPlanService:
             ))
 
         await db.commit()
+        if actor_id:
+            await audit_service.log(db, actor_id=actor_id, action="plan.created", entity_type="plan", entity_id=plan.id)
+            await db.commit()
         return await plan_repository.get_by_id(db, plan.id)
 
     async def get_plan(self, db: AsyncSession, plan_id: uuid.UUID) -> OnboardingPlan:
@@ -119,7 +125,7 @@ class OnboardingPlanService:
         await db.refresh(task)
         return task
 
-    async def cancel_task(self, db: AsyncSession, plan_id: uuid.UUID, task_id: uuid.UUID) -> OnboardingPlanTask:
+    async def cancel_task(self, db: AsyncSession, plan_id: uuid.UUID, task_id: uuid.UUID, actor_id: uuid.UUID | None = None) -> OnboardingPlanTask:
         plan = await plan_repository.get_by_id(db, plan_id)
         if not plan:
             raise NotFoundError(*messages.PLAN_NOT_FOUND)
@@ -134,4 +140,7 @@ class OnboardingPlanService:
         task.status = OnboardingPlanTaskStatus.CANCELLED
         await db.commit()
         await db.refresh(task)
+        if actor_id:
+            await audit_service.log(db, actor_id=actor_id, action="plan.task_cancelled", entity_type="task", entity_id=task.id)
+            await db.commit()
         return task

--- a/apps/backend/app/services/onboarding_plan_service.py
+++ b/apps/backend/app/services/onboarding_plan_service.py
@@ -118,7 +118,7 @@ class OnboardingPlanService:
 
         task.deadline = data.deadline
         await db.commit()
-        await db.refresh(task)
+        task = await plan_task_repository.get_by_id(db, task_id)
         return task
 
     async def add_task(self, db: AsyncSession, plan_id: uuid.UUID, data: OnboardingPlanTaskAdd) -> OnboardingPlanTask:
@@ -139,7 +139,8 @@ class OnboardingPlanService:
         )
         await plan_task_repository.create(db, task)
         await db.commit()
-        await db.refresh(task)
+        await db.flush()
+        task = await plan_task_repository.get_by_id(db, task.id)
         return task
 
     async def cancel_task(self, db: AsyncSession, plan_id: uuid.UUID, task_id: uuid.UUID, actor_id: uuid.UUID | None = None) -> OnboardingPlanTask:
@@ -156,7 +157,7 @@ class OnboardingPlanService:
 
         task.status = OnboardingPlanTaskStatus.CANCELLED
         await db.commit()
-        await db.refresh(task)
+        task = await plan_task_repository.get_by_id(db, task_id)
         if actor_id:
             await audit_service.log(db, actor_id=actor_id, action="plan.task_cancelled", entity_type="task", entity_id=task.id)
             await db.commit()

--- a/apps/backend/app/services/reports_service.py
+++ b/apps/backend/app/services/reports_service.py
@@ -1,0 +1,49 @@
+import csv
+import io
+from datetime import date
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.reports_repository import ReportsRepository
+from app.schemas.reports import DepartmentCompletionRow, TemplateCompletionRow, BottleneckRow
+
+reports_repository = ReportsRepository()
+
+
+class ReportsService:
+
+    async def get_completion_time(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[DepartmentCompletionRow]:
+        rows = await reports_repository.get_completion_time_by_department(
+            db, start_date, end_date
+        )
+        return [DepartmentCompletionRow(**r) for r in rows]
+
+    async def get_task_completion_rates(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[TemplateCompletionRow]:
+        rows = await reports_repository.get_task_completion_rates(db, start_date, end_date)
+        return [TemplateCompletionRow(**r) for r in rows]
+
+    async def get_bottlenecks(
+        self,
+        db: AsyncSession,
+        start_date: date | None,
+        end_date: date | None,
+    ) -> list[BottleneckRow]:
+        rows = await reports_repository.get_bottlenecks(db, start_date, end_date)
+        return [BottleneckRow(**r) for r in rows]
+
+    def to_csv(self, headers: list[str], rows: list[dict]) -> str:
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=headers, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+        return buf.getvalue()

--- a/apps/backend/app/services/scheduler_service.py
+++ b/apps/backend/app/services/scheduler_service.py
@@ -1,0 +1,152 @@
+import logging
+from datetime import date, timedelta
+
+from sqlalchemy import select, and_
+from sqlalchemy.orm import sessionmaker, selectinload
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
+from app.models.user import User
+from app.services.email_service import EmailService
+
+logger = logging.getLogger(__name__)
+email_service = EmailService()
+
+_OVERDUEABLE = [OnboardingPlanTaskStatus.NOT_STARTED, OnboardingPlanTaskStatus.IN_PROGRESS]
+_REMINDABLE = [
+    OnboardingPlanTaskStatus.NOT_STARTED,
+    OnboardingPlanTaskStatus.IN_PROGRESS,
+    OnboardingPlanTaskStatus.OVERDUE,
+]
+
+
+async def mark_overdue_tasks(session_factory: sessionmaker) -> None:
+    today = date.today()
+    processed = 0
+    emails_sent = 0
+    errors = 0
+
+    async with session_factory() as db:
+        try:
+            result = await db.execute(
+                select(OnboardingPlanTask)
+                .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+                .where(
+                    and_(
+                        OnboardingPlanTask.deadline < today,
+                        OnboardingPlanTask.status.in_(_OVERDUEABLE),
+                        OnboardingPlanTask.deleted_at.is_(None),
+                        OnboardingPlan.is_active.is_(True),
+                        OnboardingPlan.deleted_at.is_(None),
+                    )
+                )
+                .options(selectinload(OnboardingPlanTask.plan))
+            )
+            tasks = list(result.scalars().unique().all())
+
+            for task in tasks:
+                try:
+                    task.status = OnboardingPlanTaskStatus.OVERDUE
+                    processed += 1
+                    plan = task.plan
+
+                    emp_row = await db.execute(select(User).where(User.id == plan.user_id))
+                    employee = emp_row.scalar_one_or_none()
+
+                    mgr_row = await db.execute(select(User).where(User.id == plan.manager_id))
+                    manager = mgr_row.scalar_one_or_none()
+
+                    deadline_str = task.deadline.isoformat()
+
+                    if employee:
+                        try:
+                            await email_service.send_task_overdue_email(
+                                to_email=employee.email,
+                                first_name=employee.first_name,
+                                task_title=task.title,
+                                deadline=deadline_str,
+                            )
+                            emails_sent += 1
+                        except Exception as e:
+                            logger.error(f"Overdue email to employee failed: {e}")
+                            errors += 1
+
+                    if manager and employee:
+                        try:
+                            await email_service.send_task_overdue_manager_email(
+                                to_email=manager.email,
+                                manager_first_name=manager.first_name,
+                                employee_name=f"{employee.first_name} {employee.last_name}",
+                                task_title=task.title,
+                                deadline=deadline_str,
+                            )
+                            emails_sent += 1
+                        except Exception as e:
+                            logger.error(f"Overdue email to manager failed: {e}")
+                            errors += 1
+
+                except Exception as e:
+                    logger.error(f"Failed processing task {task.id}: {e}")
+                    errors += 1
+
+            await db.commit()
+
+        except Exception as e:
+            logger.error(f"mark_overdue_tasks job failed: {e}")
+            await db.rollback()
+            return
+
+    logger.info(
+        f"mark_overdue_tasks — tasks_marked={processed}, emails_sent={emails_sent}, errors={errors}"
+    )
+
+
+async def send_deadline_reminders(session_factory: sessionmaker) -> None:
+    reminder_date = date.today() + timedelta(days=2)
+    emails_sent = 0
+    errors = 0
+
+    async with session_factory() as db:
+        try:
+            result = await db.execute(
+                select(OnboardingPlanTask)
+                .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
+                .where(
+                    and_(
+                        OnboardingPlanTask.deadline == reminder_date,
+                        OnboardingPlanTask.status.in_(_REMINDABLE),
+                        OnboardingPlanTask.deleted_at.is_(None),
+                        OnboardingPlan.is_active.is_(True),
+                        OnboardingPlan.deleted_at.is_(None),
+                    )
+                )
+                .options(selectinload(OnboardingPlanTask.plan))
+            )
+            tasks = list(result.scalars().unique().all())
+
+            for task in tasks:
+                try:
+                    plan = task.plan
+                    emp_row = await db.execute(select(User).where(User.id == plan.user_id))
+                    employee = emp_row.scalar_one_or_none()
+
+                    if employee:
+                        await email_service.send_deadline_reminder_email(
+                            to_email=employee.email,
+                            first_name=employee.first_name,
+                            task_title=task.title,
+                            deadline=task.deadline.isoformat(),
+                        )
+                        emails_sent += 1
+
+                except Exception as e:
+                    logger.error(f"Reminder email failed for task {task.id}: {e}")
+                    errors += 1
+
+        except Exception as e:
+            logger.error(f"send_deadline_reminders job failed: {e}")
+            return
+
+    logger.info(f"send_deadline_reminders — emails_sent={emails_sent}, errors={errors}")

--- a/apps/backend/app/services/storage_service.py
+++ b/apps/backend/app/services/storage_service.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+
+from google.cloud import storage
+
+from app.core.config import settings
+
+ALLOWED_CONTENT_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+class StorageService:
+
+    def __init__(self) -> None:
+        self._client: storage.Client | None = None
+
+    def _get_bucket(self) -> storage.Bucket:
+        if self._client is None:
+            self._client = storage.Client()
+        return self._client.bucket(settings.GCS_BUCKET_NAME)
+
+    def upload(self, content: bytes, object_name: str, content_type: str) -> str:
+        blob = self._get_bucket().blob(object_name)
+        blob.upload_from_string(content, content_type=content_type)
+        return object_name
+
+    def delete(self, object_name: str) -> None:
+        blob = self._get_bucket().blob(object_name)
+        if blob.exists():
+            blob.delete()
+
+    def signed_url(self, object_name: str, expiration_minutes: int = 60) -> str:
+        blob = self._get_bucket().blob(object_name)
+        return blob.generate_signed_url(
+            expiration=timedelta(minutes=expiration_minutes),
+            method="GET",
+            version="v4",
+        )

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -11,9 +11,11 @@ from app.models.user import User
 from app.repositories.onboarding_plan_repository import OnboardingPlanRepository
 from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
 from app.schemas.onboarding_plan import ApprovalTaskResponse, ReturnTask
+from app.services.audit_service import AuditService
 
 plan_repository = OnboardingPlanRepository()
 plan_task_repository = OnboardingPlanTaskRepository()
+audit_service = AuditService()
 
 VALID_TRANSITIONS = {
     OnboardingPlanTaskStatus.NOT_STARTED: OnboardingPlanTaskStatus.IN_PROGRESS,
@@ -36,6 +38,8 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.IN_PROGRESS
         await db.commit()
         await db.refresh(task)
+        await audit_service.log(db, actor_id=current_user.id, action="task.started", entity_type="task", entity_id=task.id)
+        await db.commit()
         return task
 
     async def complete_task(
@@ -46,6 +50,8 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.COMPLETED
         await db.commit()
         await db.refresh(task)
+        await audit_service.log(db, actor_id=current_user.id, action="task.completed", entity_type="task", entity_id=task.id)
+        await db.commit()
         return task
 
     async def get_pending_approvals(
@@ -80,6 +86,8 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.APPROVED
         await db.commit()
         await db.refresh(task)
+        await audit_service.log(db, actor_id=current_user.id, action="task.approved", entity_type="task", entity_id=task.id)
+        await db.commit()
         return task
 
     async def return_task(
@@ -91,8 +99,11 @@ class TaskWorkflowService:
         if not data.content or not data.content.strip():
             raise ValidationError(*messages.RETURN_COMMENT_REQUIRED)
         task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+        task.return_comment = data.content
         await db.commit()
         await db.refresh(task)
+        await audit_service.log(db, actor_id=current_user.id, action="task.returned", entity_type="task", entity_id=task.id, detail=data.content)
+        await db.commit()
         return task
 
     async def _get_task_for_manager(

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -11,6 +11,7 @@ from app.models.user import User
 from app.repositories.onboarding_plan_repository import OnboardingPlanRepository
 from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
 from app.repositories.user_repository import UserRepository
+from app.schemas.attachment import TaskAttachmentResponse
 from app.schemas.onboarding_plan import ApprovalTaskResponse, ReturnTask
 from app.services.audit_service import AuditService
 from app.services.email_service import EmailService
@@ -97,6 +98,8 @@ class TaskWorkflowService:
                         created_at=task.created_at,
                         employee_name=f"{plan.employee.first_name} {plan.employee.last_name}",
                         plan_start_date=plan.start_date,
+                        return_comment=task.return_comment,
+                        attachments=[TaskAttachmentResponse.model_validate(a) for a in task.attachments if a.deleted_at is None],
                     ))
         return result
 

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -25,9 +25,10 @@ user_repository = UserRepository()
 audit_service = AuditService()
 email_service = EmailService()
 
-VALID_TRANSITIONS = {
-    OnboardingPlanTaskStatus.NOT_STARTED: OnboardingPlanTaskStatus.IN_PROGRESS,
-    OnboardingPlanTaskStatus.IN_PROGRESS: OnboardingPlanTaskStatus.COMPLETED,
+VALID_TRANSITIONS: dict[OnboardingPlanTaskStatus, set[OnboardingPlanTaskStatus]] = {
+    OnboardingPlanTaskStatus.NOT_STARTED: {OnboardingPlanTaskStatus.IN_PROGRESS},
+    OnboardingPlanTaskStatus.IN_PROGRESS: {OnboardingPlanTaskStatus.COMPLETED},
+    OnboardingPlanTaskStatus.OVERDUE: {OnboardingPlanTaskStatus.IN_PROGRESS, OnboardingPlanTaskStatus.COMPLETED},
 }
 
 
@@ -178,5 +179,5 @@ class TaskWorkflowService:
     def _assert_transition(
         self, task: OnboardingPlanTask, target: OnboardingPlanTaskStatus
     ) -> None:
-        if VALID_TRANSITIONS.get(task.status) != target:
+        if target not in VALID_TRANSITIONS.get(task.status, set()):
             raise ValidationError(*messages.INVALID_TASK_TRANSITION)

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -47,7 +47,7 @@ class TaskWorkflowService:
         self._assert_transition(task, OnboardingPlanTaskStatus.IN_PROGRESS)
         task.status = OnboardingPlanTaskStatus.IN_PROGRESS
         await db.commit()
-        await db.refresh(task)
+        task = await plan_task_repository.get_by_id(db, task_id)
         await audit_service.log(db, actor_id=current_user.id, action="task.started", entity_type="task", entity_id=task.id)
         await db.commit()
         return task
@@ -59,7 +59,7 @@ class TaskWorkflowService:
         self._assert_transition(task, OnboardingPlanTaskStatus.COMPLETED)
         task.status = OnboardingPlanTaskStatus.COMPLETED
         await db.commit()
-        await db.refresh(task)
+        task = await plan_task_repository.get_by_id(db, task_id)
         await audit_service.log(db, actor_id=current_user.id, action="task.completed", entity_type="task", entity_id=task.id)
         await db.commit()
         try:
@@ -111,7 +111,7 @@ class TaskWorkflowService:
             raise ValidationError(*messages.TASK_NOT_APPROVABLE)
         task.status = OnboardingPlanTaskStatus.APPROVED
         await db.commit()
-        await db.refresh(task)
+        task = await plan_task_repository.get_by_id(db, task_id)
         await audit_service.log(db, actor_id=current_user.id, action="task.approved", entity_type="task", entity_id=task.id)
         await db.commit()
         try:
@@ -139,7 +139,7 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.IN_PROGRESS
         task.return_comment = data.content
         await db.commit()
-        await db.refresh(task)
+        task = await plan_task_repository.get_by_id(db, task_id)
         await audit_service.log(db, actor_id=current_user.id, action="task.returned", entity_type="task", entity_id=task.id, detail=data.content)
         await db.commit()
         try:

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -10,12 +10,20 @@ from app.models.onboarding_plan_task import OnboardingPlanTask
 from app.models.user import User
 from app.repositories.onboarding_plan_repository import OnboardingPlanRepository
 from app.repositories.onboarding_plan_task_repository import OnboardingPlanTaskRepository
+from app.repositories.user_repository import UserRepository
 from app.schemas.onboarding_plan import ApprovalTaskResponse, ReturnTask
 from app.services.audit_service import AuditService
+from app.services.email_service import EmailService
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 plan_repository = OnboardingPlanRepository()
 plan_task_repository = OnboardingPlanTaskRepository()
+user_repository = UserRepository()
 audit_service = AuditService()
+email_service = EmailService()
 
 VALID_TRANSITIONS = {
     OnboardingPlanTaskStatus.NOT_STARTED: OnboardingPlanTaskStatus.IN_PROGRESS,
@@ -52,6 +60,20 @@ class TaskWorkflowService:
         await db.refresh(task)
         await audit_service.log(db, actor_id=current_user.id, action="task.completed", entity_type="task", entity_id=task.id)
         await db.commit()
+        try:
+            plan = await plan_repository.get_by_id(db, task.plan_id)
+            if plan:
+                manager = await user_repository.get_by_id(db, plan.manager_id)
+                employee_name = f"{current_user.first_name} {current_user.last_name}"
+                if manager:
+                    await email_service.send_task_completed_email(
+                        to_email=manager.email,
+                        manager_first_name=manager.first_name,
+                        employee_name=employee_name,
+                        task_title=task.title,
+                    )
+        except Exception as e:
+            logger.error(f"Failed to send task_completed email: {e}")
         return task
 
     async def get_pending_approvals(
@@ -88,6 +110,18 @@ class TaskWorkflowService:
         await db.refresh(task)
         await audit_service.log(db, actor_id=current_user.id, action="task.approved", entity_type="task", entity_id=task.id)
         await db.commit()
+        try:
+            plan = await plan_repository.get_by_id(db, task.plan_id)
+            if plan:
+                employee = await user_repository.get_by_id(db, plan.user_id)
+                if employee:
+                    await email_service.send_task_approved_email(
+                        to_email=employee.email,
+                        first_name=employee.first_name,
+                        task_title=task.title,
+                    )
+        except Exception as e:
+            logger.error(f"Failed to send task_approved email: {e}")
         return task
 
     async def return_task(
@@ -104,6 +138,19 @@ class TaskWorkflowService:
         await db.refresh(task)
         await audit_service.log(db, actor_id=current_user.id, action="task.returned", entity_type="task", entity_id=task.id, detail=data.content)
         await db.commit()
+        try:
+            plan = await plan_repository.get_by_id(db, task.plan_id)
+            if plan:
+                employee = await user_repository.get_by_id(db, plan.user_id)
+                if employee:
+                    await email_service.send_task_returned_email(
+                        to_email=employee.email,
+                        first_name=employee.first_name,
+                        task_title=task.title,
+                        comment=data.content,
+                    )
+        except Exception as e:
+            logger.error(f"Failed to send task_returned email: {e}")
         return task
 
     async def _get_task_for_manager(

--- a/apps/backend/app/services/user_service.py
+++ b/apps/backend/app/services/user_service.py
@@ -9,9 +9,11 @@ from app.models.user import User
 from app.repositories.refresh_token_repository import RefreshTokenRepository
 from app.repositories.user_repository import UserRepository
 from app.schemas.user import UserUpdate, UserProfileUpdate
+from app.services.audit_service import AuditService
 
 user_repository = UserRepository()
 refresh_token_repository = RefreshTokenRepository()
+audit_service = AuditService()
 
 
 class UserService:
@@ -30,6 +32,7 @@ class UserService:
         db: AsyncSession,
         user_id: uuid.UUID,
         data: UserUpdate,
+        actor_id: uuid.UUID | None = None,
     ) -> User:
         user = await user_repository.get_by_id(db, user_id)
         if not user:
@@ -41,6 +44,9 @@ class UserService:
             user.role = data.role
 
         await db.commit()
+        if actor_id:
+            await audit_service.log(db, actor_id=actor_id, action="user.updated", entity_type="user", entity_id=user_id)
+            await db.commit()
         return await user_repository.get_by_id(db, user_id)
 
     async def update_my_profile(
@@ -73,11 +79,14 @@ class UserService:
         user.is_active = False
         await refresh_token_repository.delete_by_user_id(db, user_id)
         await db.commit()
+        await audit_service.log(db, actor_id=current_user_id, action="user.deactivated", entity_type="user", entity_id=user_id)
+        await db.commit()
 
     async def reactivate_user(
         self,
         db: AsyncSession,
         user_id: uuid.UUID,
+        actor_id: uuid.UUID | None = None,
     ) -> User:
         user = await user_repository.get_by_id(db, user_id)
         if not user:
@@ -85,4 +94,7 @@ class UserService:
 
         user.is_active = True
         await db.commit()
+        if actor_id:
+            await audit_service.log(db, actor_id=actor_id, action="user.reactivated", entity_type="user", entity_id=user_id)
+            await db.commit()
         return await user_repository.get_by_id(db, user_id)

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -11,6 +11,7 @@ bcrypt==4.0.1
 python-multipart==0.0.12
 slowapi==0.1.9
 google-cloud-secret-manager==2.21.0
+google-cloud-storage==2.18.2
 sendgrid==6.11.0
 apscheduler==3.10.4
 pytest==8.3.3

--- a/apps/backend/scripts/seed.py
+++ b/apps/backend/scripts/seed.py
@@ -11,281 +11,533 @@ from sqlalchemy.orm import sessionmaker
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import app.models  # noqa — ensures all models are registered with Base
+
+from app.models.audit_log import AuditLog
 from app.models.department import Department
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
 from app.models.onboarding_template import OnboardingTemplate
 from app.models.template_task import TemplateTask
 from app.models.user import User
-from app.models.onboarding_plan import OnboardingPlan
-from app.models.onboarding_plan_task import OnboardingPlanTask
 from app.enums.user_role import UserRole
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 
 DATABASE_URL = os.environ["DATABASE_URL"]
-
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+TODAY = date.today()
+
+# ─── Fixed IDs ────────────────────────────────────────────────────────────────
+
+ADMIN_ID     = uuid.UUID("00000000-0000-0000-0000-000000000001")
+MANAGER_ID   = uuid.UUID("00000000-0000-0000-0000-000000000002")
+EMPLOYEE_ID  = uuid.UUID("00000000-0000-0000-0000-000000000003")
+ALICE_ID     = uuid.UUID("00000000-0000-0000-0000-000000000004")
+BOB_ID       = uuid.UUID("00000000-0000-0000-0000-000000000005")
+MANAGER2_ID  = uuid.UUID("00000000-0000-0000-0000-000000000006")
+
+DEPT_ENG_ID  = uuid.UUID("00000000-0000-0000-0000-000000000101")
+DEPT_HR_ID   = uuid.UUID("00000000-0000-0000-0000-000000000102")
+DEPT_PROD_ID = uuid.UUID("00000000-0000-0000-0000-000000000103")
+
+TMPL_ENG_ID  = uuid.UUID("00000000-0000-0000-0001-000000000001")
+TMPL_HR_ID   = uuid.UUID("00000000-0000-0000-0001-000000000002")
+TMPL_PROD_ID = uuid.UUID("00000000-0000-0000-0001-000000000003")
+
+PLAN_EMP_ID   = uuid.UUID("00000000-0000-0000-0003-000000000001")
+PLAN_ALICE_ID = uuid.UUID("00000000-0000-0000-0003-000000000002")
+PLAN_BOB_ID   = uuid.UUID("00000000-0000-0000-0003-000000000003")
+
+# ─── Departments ──────────────────────────────────────────────────────────────
+
 SEED_DEPARTMENTS = [
-    {"id": uuid.UUID("00000000-0000-0000-0000-000000000101"), "name": "Engineering"},
-    {"id": uuid.UUID("00000000-0000-0000-0000-000000000102"), "name": "Human Resources"},
-    {"id": uuid.UUID("00000000-0000-0000-0000-000000000103"), "name": "Product"},
+    {"id": DEPT_ENG_ID,  "name": "Engineering"},
+    {"id": DEPT_HR_ID,   "name": "Human Resources"},
+    {"id": DEPT_PROD_ID, "name": "Product"},
 ]
 
-SEED_TEMPLATES = [
-    {
-        "id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "name": "Engineering Onboarding",
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000101"),
-        "is_active": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "name": "HR Onboarding",
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000102"),
-        "is_active": False,
-    },
-]
-
-SEED_TASKS = [
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000001"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Set up development environment",
-        "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
-        "order": 1,
-        "deadline_days": 1,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000002"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Complete security and compliance training",
-        "description": "Finish the mandatory security awareness course on the learning portal.",
-        "order": 2,
-        "deadline_days": 3,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000003"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Review architecture documentation",
-        "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
-        "order": 3,
-        "deadline_days": 5,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000004"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000001"),
-        "title": "Submit first pull request",
-        "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
-        "order": 4,
-        "deadline_days": 14,
-        "is_required": False,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000005"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "title": "Review HR policies and handbook",
-        "description": "Read the company handbook and sign the policy acknowledgement form.",
-        "order": 1,
-        "deadline_days": 2,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000006"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "title": "Shadow a payroll processing session",
-        "description": "Sit in on the monthly payroll run with a senior HR specialist.",
-        "order": 2,
-        "deadline_days": 7,
-        "is_required": True,
-    },
-    {
-        "id": uuid.UUID("00000000-0000-0000-0002-000000000007"),
-        "template_id": uuid.UUID("00000000-0000-0000-0001-000000000002"),
-        "title": "Complete HRIS system training",
-        "description": "Finish self-paced training modules for the HR information system.",
-        "order": 3,
-        "deadline_days": 10,
-        "is_required": False,
-    },
-]
+# ─── Users ────────────────────────────────────────────────────────────────────
 
 SEED_USERS = [
     {
-        "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
-        "email": "admin@stepup.com",
-        "password": "Admin1234!",
-        "first_name": "HR",
-        "last_name": "Admin",
-        "role": UserRole.HR_ADMIN,
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000102"),
+        "id": ADMIN_ID, "email": "admin@stepup.com", "password": "Admin1234!",
+        "first_name": "HR", "last_name": "Admin",
+        "role": UserRole.HR_ADMIN, "department_id": DEPT_HR_ID,
     },
     {
-        "id": uuid.UUID("00000000-0000-0000-0000-000000000002"),
-        "email": "manager@stepup.com",
-        "password": "Manager1234!",
-        "first_name": "Manager",
-        "last_name": "User",
-        "role": UserRole.MANAGER,
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000101"),
+        "id": MANAGER_ID, "email": "manager@stepup.com", "password": "Manager1234!",
+        "first_name": "Alex", "last_name": "Manager",
+        "role": UserRole.MANAGER, "department_id": DEPT_ENG_ID,
     },
     {
-        "id": uuid.UUID("00000000-0000-0000-0000-000000000003"),
-        "email": "employee@stepup.com",
-        "password": "Employee1234!",
-        "first_name": "Employee",
-        "last_name": "User",
-        "role": UserRole.EMPLOYEE,
-        "department_id": uuid.UUID("00000000-0000-0000-0000-000000000101"),
+        "id": MANAGER2_ID, "email": "manager2@stepup.com", "password": "Manager1234!",
+        "first_name": "Sam", "last_name": "Lead",
+        "role": UserRole.MANAGER, "department_id": DEPT_PROD_ID,
+    },
+    {
+        "id": EMPLOYEE_ID, "email": "employee@stepup.com", "password": "Employee1234!",
+        "first_name": "John", "last_name": "Doe",
+        "role": UserRole.EMPLOYEE, "department_id": DEPT_ENG_ID,
+    },
+    {
+        "id": ALICE_ID, "email": "alice@stepup.com", "password": "Employee1234!",
+        "first_name": "Alice", "last_name": "Chen",
+        "role": UserRole.EMPLOYEE, "department_id": DEPT_ENG_ID,
+    },
+    {
+        "id": BOB_ID, "email": "bob@stepup.com", "password": "Employee1234!",
+        "first_name": "Bob", "last_name": "Marley",
+        "role": UserRole.EMPLOYEE, "department_id": DEPT_PROD_ID,
+    },
+]
+
+# ─── Templates ────────────────────────────────────────────────────────────────
+
+SEED_TEMPLATES = [
+    {"id": TMPL_ENG_ID,  "name": "Engineering Onboarding", "department_id": DEPT_ENG_ID,  "is_active": True},
+    {"id": TMPL_HR_ID,   "name": "HR Onboarding",          "department_id": DEPT_HR_ID,   "is_active": False},
+    {"id": TMPL_PROD_ID, "name": "Product Onboarding",     "department_id": DEPT_PROD_ID, "is_active": True},
+]
+
+# ─── Template Tasks ───────────────────────────────────────────────────────────
+
+SEED_TEMPLATE_TASKS = [
+    # Engineering Onboarding
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000001"),
+        "template_id": TMPL_ENG_ID, "order": 1, "deadline_days": 1, "is_required": True,
+        "title": "Set up development environment",
+        "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000002"),
+        "template_id": TMPL_ENG_ID, "order": 2, "deadline_days": 3, "is_required": True,
+        "title": "Complete security and compliance training",
+        "description": "Finish the mandatory security awareness course on the learning portal.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000003"),
+        "template_id": TMPL_ENG_ID, "order": 3, "deadline_days": 5, "is_required": True,
+        "title": "Review architecture documentation",
+        "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000004"),
+        "template_id": TMPL_ENG_ID, "order": 4, "deadline_days": 14, "is_required": False,
+        "title": "Submit first pull request",
+        "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
+    },
+    # HR Onboarding
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000005"),
+        "template_id": TMPL_HR_ID, "order": 1, "deadline_days": 2, "is_required": True,
+        "title": "Review HR policies and handbook",
+        "description": "Read the company handbook and sign the policy acknowledgement form.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000006"),
+        "template_id": TMPL_HR_ID, "order": 2, "deadline_days": 7, "is_required": True,
+        "title": "Shadow a payroll processing session",
+        "description": "Sit in on the monthly payroll run with a senior HR specialist.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000007"),
+        "template_id": TMPL_HR_ID, "order": 3, "deadline_days": 10, "is_required": False,
+        "title": "Complete HRIS system training",
+        "description": "Finish self-paced training modules for the HR information system.",
+    },
+    # Product Onboarding
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000008"),
+        "template_id": TMPL_PROD_ID, "order": 1, "deadline_days": 2, "is_required": True,
+        "title": "Meet the product team",
+        "description": "Schedule 1:1s with each product team member and your PM lead.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000009"),
+        "template_id": TMPL_PROD_ID, "order": 2, "deadline_days": 5, "is_required": True,
+        "title": "Review product roadmap",
+        "description": "Go through the current and upcoming quarter roadmap with your PM lead.",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0002-000000000010"),
+        "template_id": TMPL_PROD_ID, "order": 3, "deadline_days": 14, "is_required": False,
+        "title": "Shadow a customer call",
+        "description": "Join a live customer demo or support call to understand user pain points.",
+    },
+]
+
+# ─── Plans ────────────────────────────────────────────────────────────────────
+#
+# Plan 1 — employee@stepup.com (Engineering, in-progress)
+#   Task 1 APPROVED, Task 2 RETURNED (returned by manager), Task 3 IN_PROGRESS, Task 4 NOT_STARTED + overdue
+#   → Shows in task completion rates. Task 2 shows in bottlenecks.
+#
+# Plan 2 — alice@stepup.com (Engineering, completed)
+#   All tasks APPROVED. start_date = 40 days ago.
+#   → Shows in completion time report (Engineering, ~40 days avg).
+#   → Shows in task completion rates (100% for Engineering Onboarding).
+#
+# Plan 3 — bob@stepup.com (Product, stuck)
+#   Task 1 RETURNED, Task 2 RETURNED, Task 3 NOT_STARTED + overdue.
+#   → Shows in bottlenecks report for Product Onboarding.
+
+SEED_PLANS = [
+    {
+        "id": PLAN_EMP_ID,
+        "user_id": EMPLOYEE_ID,
+        "template_id": TMPL_ENG_ID,
+        "manager_id": MANAGER_ID,
+        "start_date": TODAY - timedelta(days=20),
+        "tasks": [
+            {
+                "title": "Set up development environment",
+                "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
+                "deadline": TODAY - timedelta(days=19),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 1,
+            },
+            {
+                "title": "Complete security and compliance training",
+                "description": "Finish the mandatory security awareness course on the learning portal.",
+                "deadline": TODAY - timedelta(days=17),
+                "status": OnboardingPlanTaskStatus.RETURNED,
+                "is_required": True, "order": 2,
+            },
+            {
+                "title": "Review architecture documentation",
+                "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
+                "deadline": TODAY + timedelta(days=2),
+                "status": OnboardingPlanTaskStatus.IN_PROGRESS,
+                "is_required": True, "order": 3,
+            },
+            {
+                "title": "Submit first pull request",
+                "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
+                "deadline": TODAY - timedelta(days=6),
+                "status": OnboardingPlanTaskStatus.NOT_STARTED,
+                "is_required": False, "order": 4,
+            },
+        ],
+    },
+    {
+        "id": PLAN_ALICE_ID,
+        "user_id": ALICE_ID,
+        "template_id": TMPL_ENG_ID,
+        "manager_id": MANAGER_ID,
+        "start_date": TODAY - timedelta(days=40),
+        "tasks": [
+            {
+                "title": "Set up development environment",
+                "description": "Install required tools: Git, Docker, VS Code, and configure local environment variables.",
+                "deadline": TODAY - timedelta(days=39),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 1,
+            },
+            {
+                "title": "Complete security and compliance training",
+                "description": "Finish the mandatory security awareness course on the learning portal.",
+                "deadline": TODAY - timedelta(days=37),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 2,
+            },
+            {
+                "title": "Review architecture documentation",
+                "description": "Read system design docs and schedule a walkthrough session with the tech lead.",
+                "deadline": TODAY - timedelta(days=35),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": True, "order": 3,
+            },
+            {
+                "title": "Submit first pull request",
+                "description": "Pick a starter task from the backlog, implement it, and open a PR for review.",
+                "deadline": TODAY - timedelta(days=26),
+                "status": OnboardingPlanTaskStatus.APPROVED,
+                "is_required": False, "order": 4,
+            },
+        ],
+    },
+    {
+        "id": PLAN_BOB_ID,
+        "user_id": BOB_ID,
+        "template_id": TMPL_PROD_ID,
+        "manager_id": MANAGER2_ID,
+        "start_date": TODAY - timedelta(days=15),
+        "tasks": [
+            {
+                "title": "Meet the product team",
+                "description": "Schedule 1:1s with each product team member and your PM lead.",
+                "deadline": TODAY - timedelta(days=13),
+                "status": OnboardingPlanTaskStatus.RETURNED,
+                "is_required": True, "order": 1,
+            },
+            {
+                "title": "Review product roadmap",
+                "description": "Go through the current and upcoming quarter roadmap with your PM lead.",
+                "deadline": TODAY - timedelta(days=10),
+                "status": OnboardingPlanTaskStatus.RETURNED,
+                "is_required": True, "order": 2,
+            },
+            {
+                "title": "Shadow a customer call",
+                "description": "Join a live customer demo or support call to understand user pain points.",
+                "deadline": TODAY - timedelta(days=1),
+                "status": OnboardingPlanTaskStatus.NOT_STARTED,
+                "is_required": False, "order": 3,
+            },
+        ],
+    },
+]
+
+# ─── Audit Logs ───────────────────────────────────────────────────────────────
+
+SEED_AUDIT_LOGS = [
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000001"),
+        "actor_id": ADMIN_ID, "action": "user.invited",
+        "entity_type": "invitation", "entity_id": uuid.UUID("00000000-0000-0000-0088-000000000001"),
+        "detail": "alice@stepup.com invited as employee",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000002"),
+        "actor_id": ADMIN_ID, "action": "user.invited",
+        "entity_type": "invitation", "entity_id": uuid.UUID("00000000-0000-0000-0088-000000000002"),
+        "detail": "bob@stepup.com invited as employee",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000003"),
+        "actor_id": ALICE_ID, "action": "user.registered",
+        "entity_type": "user", "entity_id": ALICE_ID,
+        "detail": "Alice Chen completed registration",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000004"),
+        "actor_id": BOB_ID, "action": "user.registered",
+        "entity_type": "user", "entity_id": BOB_ID,
+        "detail": "Bob Marley completed registration",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000005"),
+        "actor_id": ADMIN_ID, "action": "plan.created",
+        "entity_type": "onboarding_plan", "entity_id": PLAN_EMP_ID,
+        "detail": "Plan created for employee@stepup.com",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000006"),
+        "actor_id": ADMIN_ID, "action": "plan.created",
+        "entity_type": "onboarding_plan", "entity_id": PLAN_ALICE_ID,
+        "detail": "Plan created for alice@stepup.com",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000007"),
+        "actor_id": ADMIN_ID, "action": "plan.created",
+        "entity_type": "onboarding_plan", "entity_id": PLAN_BOB_ID,
+        "detail": "Plan created for bob@stepup.com",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000008"),
+        "actor_id": ALICE_ID, "action": "task.started",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000001"),
+        "detail": "Set up development environment",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000009"),
+        "actor_id": ALICE_ID, "action": "task.completed",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000001"),
+        "detail": "Set up development environment",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000010"),
+        "actor_id": MANAGER_ID, "action": "task.approved",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000001"),
+        "detail": "Set up development environment",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000011"),
+        "actor_id": EMPLOYEE_ID, "action": "task.started",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000002"),
+        "detail": "Complete security and compliance training",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000012"),
+        "actor_id": EMPLOYEE_ID, "action": "task.completed",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000002"),
+        "detail": "Complete security and compliance training",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000013"),
+        "actor_id": MANAGER_ID, "action": "task.returned",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000002"),
+        "detail": "Complete security and compliance training — certificate screenshot missing",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000014"),
+        "actor_id": BOB_ID, "action": "task.started",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000003"),
+        "detail": "Meet the product team",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000015"),
+        "actor_id": BOB_ID, "action": "task.completed",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000003"),
+        "detail": "Meet the product team",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000016"),
+        "actor_id": MANAGER2_ID, "action": "task.returned",
+        "entity_type": "onboarding_plan_task", "entity_id": uuid.UUID("00000000-0000-0000-0077-000000000003"),
+        "detail": "Meet the product team — needs documented meeting notes",
+    },
+    {
+        "id": uuid.UUID("00000000-0000-0000-0099-000000000017"),
+        "actor_id": ADMIN_ID, "action": "user.updated",
+        "entity_type": "user", "entity_id": EMPLOYEE_ID,
+        "detail": "Department updated",
     },
 ]
 
 
-async def seed():
+# ─── Seed helpers ─────────────────────────────────────────────────────────────
+
+async def seed_departments(session: AsyncSession) -> None:
+    for d in SEED_DEPARTMENTS:
+        exists = (await session.execute(select(Department).where(Department.id == d["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip dept: {d['name']}")
+            continue
+        session.add(Department(id=d["id"], name=d["name"]))
+        print(f"  + dept: {d['name']}")
+    await session.commit()
+
+
+async def seed_users(session: AsyncSession) -> None:
+    for u in SEED_USERS:
+        exists = (await session.execute(select(User).where(User.email == u["email"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip user: {u['email']}")
+            continue
+        session.add(User(
+            id=u["id"],
+            email=u["email"],
+            password_hash=pwd_context.hash(u["password"]),
+            first_name=u["first_name"],
+            last_name=u["last_name"],
+            role=u["role"],
+            department_id=u["department_id"],
+        ))
+        print(f"  + user: {u['email']} / {u['password']}")
+    await session.commit()
+
+
+async def seed_templates(session: AsyncSession) -> None:
+    for t in SEED_TEMPLATES:
+        exists = (await session.execute(select(OnboardingTemplate).where(OnboardingTemplate.id == t["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip template: {t['name']}")
+            continue
+        session.add(OnboardingTemplate(id=t["id"], name=t["name"], department_id=t["department_id"], is_active=t["is_active"]))
+        print(f"  + template: {t['name']}")
+    await session.commit()
+
+
+async def seed_template_tasks(session: AsyncSession) -> None:
+    for t in SEED_TEMPLATE_TASKS:
+        exists = (await session.execute(select(TemplateTask).where(TemplateTask.id == t["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip template task: {t['title']}")
+            continue
+        session.add(TemplateTask(
+            id=t["id"],
+            template_id=t["template_id"],
+            title=t["title"],
+            description=t["description"],
+            order=t["order"],
+            deadline_days=t["deadline_days"],
+            is_required=t["is_required"],
+        ))
+        print(f"  + template task: {t['title']}")
+    await session.commit()
+
+
+async def seed_plans(session: AsyncSession) -> None:
+    for p in SEED_PLANS:
+        exists = (await session.execute(select(OnboardingPlan).where(OnboardingPlan.id == p["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip plan: {p['id']}")
+            continue
+        plan = OnboardingPlan(
+            id=p["id"],
+            user_id=p["user_id"],
+            template_id=p["template_id"],
+            manager_id=p["manager_id"],
+            start_date=p["start_date"],
+            is_active=True,
+        )
+        session.add(plan)
+        await session.flush()
+
+        for t in p["tasks"]:
+            session.add(OnboardingPlanTask(
+                plan_id=plan.id,
+                title=t["title"],
+                description=t["description"],
+                deadline=t["deadline"],
+                status=t["status"],
+                is_required=t["is_required"],
+                order=t["order"],
+            ))
+            print(f"  + plan task: {t['title']} ({t['status'].value})")
+
+        await session.commit()
+        print(f"  + plan: {p['id']}")
+
+
+async def seed_audit_logs(session: AsyncSession) -> None:
+    for a in SEED_AUDIT_LOGS:
+        exists = (await session.execute(select(AuditLog).where(AuditLog.id == a["id"]))).scalar_one_or_none()
+        if exists:
+            print(f"  skip audit: {a['action']}")
+            continue
+        session.add(AuditLog(
+            id=a["id"],
+            actor_id=a["actor_id"],
+            action=a["action"],
+            entity_type=a["entity_type"],
+            entity_id=a["entity_id"],
+            detail=a["detail"],
+        ))
+        print(f"  + audit: {a['action']} — {a['detail']}")
+    await session.commit()
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+async def seed() -> None:
     engine = create_async_engine(DATABASE_URL)
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as session:
-        for seed_dept in SEED_DEPARTMENTS:
-            result = await session.execute(
-                select(Department).where(Department.id == seed_dept["id"])
-            )
-            existing = result.scalar_one_or_none()
+        print("\n[Departments]")
+        await seed_departments(session)
 
-            if existing:
-                print(f"Seed department already exists: {seed_dept['name']}")
-                continue
+        print("\n[Users]")
+        await seed_users(session)
 
-            dept = Department(id=seed_dept["id"], name=seed_dept["name"])
-            session.add(dept)
-            print(f"Seed department created: {seed_dept['name']}")
+        print("\n[Templates]")
+        await seed_templates(session)
 
-        await session.commit()
+        print("\n[Template Tasks]")
+        await seed_template_tasks(session)
 
-        for seed_user in SEED_USERS:
-            result = await session.execute(
-                select(User).where(User.email == seed_user["email"])
-            )
-            existing = result.scalar_one_or_none()
+        print("\n[Plans]")
+        await seed_plans(session)
 
-            if existing:
-                print(f"Seed user already exists: {seed_user['email']}")
-                continue
-
-            user = User(
-                id=seed_user["id"],
-                email=seed_user["email"],
-                password_hash=pwd_context.hash(seed_user["password"]),
-                first_name=seed_user["first_name"],
-                last_name=seed_user["last_name"],
-                role=seed_user["role"],
-                department_id=seed_user["department_id"],
-            )
-            session.add(user)
-            print(f"Seed user created: {seed_user['email']} / {seed_user['password']}")
-
-        await session.commit()
-
-        for seed_tmpl in SEED_TEMPLATES:
-            result = await session.execute(
-                select(OnboardingTemplate).where(OnboardingTemplate.id == seed_tmpl["id"])
-            )
-            existing = result.scalar_one_or_none()
-
-            if existing:
-                print(f"Seed template already exists: {seed_tmpl['name']}")
-                continue
-
-            tmpl = OnboardingTemplate(
-                id=seed_tmpl["id"],
-                name=seed_tmpl["name"],
-                department_id=seed_tmpl["department_id"],
-                is_active=seed_tmpl["is_active"],
-            )
-            session.add(tmpl)
-            print(f"Seed template created: {seed_tmpl['name']}")
-
-        await session.commit()
-
-        for seed_task in SEED_TASKS:
-            result = await session.execute(
-                select(TemplateTask).where(TemplateTask.id == seed_task["id"])
-            )
-            existing = result.scalar_one_or_none()
-
-            if existing:
-                print(f"Seed task already exists: {seed_task['title']}")
-                continue
-
-            task = TemplateTask(
-                id=seed_task["id"],
-                template_id=seed_task["template_id"],
-                title=seed_task["title"],
-                description=seed_task["description"],
-                order=seed_task["order"],
-                deadline_days=seed_task["deadline_days"],
-                is_required=seed_task["is_required"],
-            )
-            session.add(task)
-            print(f"Seed task created: {seed_task['title']}")
-
-        await session.commit()
-
-        result = await session.execute(
-            select(OnboardingPlan).where(
-                OnboardingPlan.user_id == uuid.UUID("00000000-0000-0000-0000-000000000003")
-            )
-        )
-        existing_plan = result.scalar_one_or_none()
-
-        if existing_plan:
-            print("Seed plan already exists")
-        else:
-            plan = OnboardingPlan(
-                id=uuid.UUID("00000000-0000-0000-0003-000000000001"),
-                user_id=uuid.UUID("00000000-0000-0000-0000-000000000003"),
-                template_id=uuid.UUID("00000000-0000-0000-0001-000000000001"),
-                manager_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
-                start_date=date(2026, 5, 1),
-                is_active=True,
-            )
-            session.add(plan)
-            await session.flush()
-
-            task_statuses = [
-                OnboardingPlanTaskStatus.CANCELLED,
-                OnboardingPlanTaskStatus.NOT_STARTED,
-                OnboardingPlanTaskStatus.NOT_STARTED,
-                OnboardingPlanTaskStatus.NOT_STARTED,
-            ]
-            template_tasks_result = await session.execute(
-                select(TemplateTask).where(
-                    TemplateTask.template_id == uuid.UUID("00000000-0000-0000-0001-000000000001"),
-                    TemplateTask.deleted_at.is_(None),
-                ).order_by(TemplateTask.order)
-            )
-            template_tasks = list(template_tasks_result.scalars().all())
-
-            for i, task in enumerate(template_tasks):
-                task_status = task_statuses[i] if i < len(task_statuses) else OnboardingPlanTaskStatus.NOT_STARTED
-                plan_task = OnboardingPlanTask(
-                    plan_id=plan.id,
-                    template_task_id=task.id,
-                    title=task.title,
-                    description=task.description,
-                    deadline=date(2026, 5, 1) + timedelta(days=task.deadline_days),
-                    status=task_status,
-                    is_required=task.is_required,
-                    order=task.order,
-                )
-                session.add(plan_task)
-                print(f"Seed plan task created: {task.title} ({task_status.value})")
-
-            await session.commit()
-            print("Seed plan created for employee")
+        print("\n[Audit Logs]")
+        await seed_audit_logs(session)
 
     await engine.dispose()
+    print("\nSeed complete.")
 
 
 if __name__ == "__main__":

--- a/apps/backend/tests/integration/api/test_reports_endpoints.py
+++ b/apps/backend/tests/integration/api/test_reports_endpoints.py
@@ -1,0 +1,185 @@
+import pytest
+from datetime import date, timedelta
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.enums.user_role import UserRole
+from app.models.department import Department
+from app.models.onboarding_plan import OnboardingPlan
+from app.models.onboarding_plan_task import OnboardingPlanTask
+from app.models.onboarding_template import OnboardingTemplate
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.fixture
+async def department(db_session):
+    dept = Department(name="Engineering")
+    db_session.add(dept)
+    await db_session.flush()
+    return dept
+
+
+@pytest.fixture
+async def template(db_session, department):
+    tmpl = OnboardingTemplate(
+        name="Dev Onboarding",
+        department_id=department.id,
+        is_active=True,
+    )
+    db_session.add(tmpl)
+    await db_session.flush()
+    return tmpl
+
+
+@pytest.fixture
+async def employee(db_session, department):
+    user = User(
+        email="report_employee@test.com",
+        role=UserRole.EMPLOYEE,
+        first_name="Report",
+        last_name="Employee",
+        password_hash="placeholder",
+        is_active=True,
+        department_id=department.id,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.fixture
+async def manager(db_session):
+    user = User(
+        email="report_manager@test.com",
+        role=UserRole.MANAGER,
+        first_name="Report",
+        last_name="Manager",
+        password_hash="placeholder",
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.fixture
+async def approved_plan(db_session, employee, manager, template):
+    plan = OnboardingPlan(
+        user_id=employee.id,
+        manager_id=manager.id,
+        template_id=template.id,
+        start_date=date.today() - timedelta(days=10),
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    task = OnboardingPlanTask(
+        plan_id=plan.id,
+        title="Read Docs",
+        deadline=date.today() + timedelta(days=7),
+        status=OnboardingPlanTaskStatus.APPROVED,
+        is_required=True,
+        order=1,
+    )
+    db_session.add(task)
+    await db_session.flush()
+    return plan
+
+
+@pytest.fixture
+async def plan_with_returned_task(db_session, employee, manager, template):
+    plan = OnboardingPlan(
+        user_id=employee.id,
+        manager_id=manager.id,
+        template_id=template.id,
+        start_date=date.today() - timedelta(days=5),
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    task = OnboardingPlanTask(
+        plan_id=plan.id,
+        title="Write Tests",
+        deadline=date.today() - timedelta(days=1),
+        status=OnboardingPlanTaskStatus.RETURNED,
+        is_required=True,
+        order=1,
+    )
+    db_session.add(task)
+    await db_session.flush()
+    return plan
+
+
+class TestCompletionTimeEndpoint:
+
+    async def test_returns_department_rows(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/completion-time")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert any(row["department_name"] == "Engineering" for row in data)
+
+    async def test_returns_csv(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/completion-time?format=csv")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "department_name" in resp.text
+
+    async def test_date_filter_excludes_old_plans(self, authenticated_client, approved_plan):
+        future = (date.today() + timedelta(days=30)).isoformat()
+        resp = await authenticated_client.get(f"/api/v1/reports/completion-time?start_date={future}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert not any(row["department_name"] == "Engineering" for row in data)
+
+
+class TestTaskCompletionRatesEndpoint:
+
+    async def test_returns_template_rows(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/task-completion-rates")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert any(row["template_name"] == "Dev Onboarding" for row in data)
+
+    async def test_completion_rate_calculation(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/task-completion-rates")
+        row = next(r for r in resp.json() if r["template_name"] == "Dev Onboarding")
+        assert row["total_tasks"] >= 1
+        assert row["completion_rate"] > 0
+
+    async def test_returns_csv(self, authenticated_client, approved_plan):
+        resp = await authenticated_client.get("/api/v1/reports/task-completion-rates?format=csv")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "template_name" in resp.text
+
+
+class TestBottlenecksEndpoint:
+
+    async def test_returns_returned_tasks(self, authenticated_client, plan_with_returned_task):
+        resp = await authenticated_client.get("/api/v1/reports/bottlenecks")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(row["task_title"] == "Write Tests" for row in data)
+
+    async def test_returned_count_correct(self, authenticated_client, plan_with_returned_task):
+        resp = await authenticated_client.get("/api/v1/reports/bottlenecks")
+        row = next(r for r in resp.json() if r["task_title"] == "Write Tests")
+        assert row["returned_count"] >= 1
+
+    async def test_returns_csv(self, authenticated_client, plan_with_returned_task):
+        resp = await authenticated_client.get("/api/v1/reports/bottlenecks?format=csv")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "task_title" in resp.text
+
+
+class TestReportsAuthorization:
+
+    async def test_unauthenticated_rejected(self, client):
+        resp = await client.get("/api/v1/reports/completion-time")
+        assert resp.status_code == 401

--- a/apps/backend/tests/unit/services/test_attachment_service.py
+++ b/apps/backend/tests/unit/services/test_attachment_service.py
@@ -1,0 +1,126 @@
+import pytest
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.errors import ValidationError, PermissionError
+from app.services.attachment_service import AttachmentService
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _make_task(status=OnboardingPlanTaskStatus.IN_PROGRESS):
+    task = MagicMock()
+    task.id = uuid.uuid4()
+    task.status = status
+    task.deleted_at = None
+    return task
+
+
+def _make_attachment(uploaded_by=None, plan_task_id=None):
+    att = MagicMock()
+    att.id = uuid.uuid4()
+    att.uploaded_by = uploaded_by or uuid.uuid4()
+    att.plan_task_id = plan_task_id or uuid.uuid4()
+    att.object_name = f"tasks/{att.plan_task_id}/test.pdf"
+    att.file_name = "test.pdf"
+    att.file_type = "application/pdf"
+    att.file_size = 1024
+    att.created_at = MagicMock()
+    return att
+
+
+def _make_upload_file(content_type="application/pdf", size=1024):
+    file = AsyncMock()
+    file.content_type = content_type
+    file.filename = "test.pdf"
+    file.read = AsyncMock(return_value=b"x" * size)
+    return file
+
+
+class TestUploadAttachment:
+
+    async def test_rejects_invalid_mime_type(self):
+        service = AttachmentService()
+        db = AsyncMock()
+        user = MagicMock()
+        task = _make_task()
+        file = _make_upload_file(content_type="text/plain")
+
+        with patch("app.services.attachment_service.plan_task_repository") as repo:
+            repo.get_by_id = AsyncMock(return_value=task)
+            with pytest.raises(ValidationError) as exc:
+                await service.upload_attachment(db, task.id, file, user)
+        assert exc.value.code == "INVALID_FILE_TYPE"
+
+    async def test_rejects_file_over_10mb(self):
+        service = AttachmentService()
+        db = AsyncMock()
+        user = MagicMock()
+        task = _make_task()
+        file = _make_upload_file(size=11 * 1024 * 1024)
+
+        with patch("app.services.attachment_service.plan_task_repository") as repo:
+            repo.get_by_id = AsyncMock(return_value=task)
+            with pytest.raises(ValidationError) as exc:
+                await service.upload_attachment(db, task.id, file, user)
+        assert exc.value.code == "FILE_TOO_LARGE"
+
+    async def test_raises_not_found_for_missing_task(self):
+        from app.errors import NotFoundError
+        service = AttachmentService()
+        db = AsyncMock()
+        user = MagicMock()
+        file = _make_upload_file()
+
+        with patch("app.services.attachment_service.plan_task_repository") as repo:
+            repo.get_by_id = AsyncMock(return_value=None)
+            with pytest.raises(NotFoundError):
+                await service.upload_attachment(db, uuid.uuid4(), file, user)
+
+
+class TestDeleteAttachment:
+
+    async def test_rejects_delete_by_other_user(self):
+        service = AttachmentService()
+        db = AsyncMock()
+        user = MagicMock()
+        user.id = uuid.uuid4()
+
+        task_id = uuid.uuid4()
+        att = _make_attachment(uploaded_by=uuid.uuid4(), plan_task_id=task_id)
+
+        with patch("app.services.attachment_service.attachment_repository") as repo, \
+             patch("app.services.attachment_service.plan_task_repository"):
+            repo.get_by_id = AsyncMock(return_value=att)
+            with pytest.raises(PermissionError):
+                await service.delete_attachment(db, task_id, att.id, user)
+
+    async def test_rejects_delete_after_approval(self):
+        service = AttachmentService()
+        db = AsyncMock()
+        user = MagicMock()
+        user.id = uuid.uuid4()
+
+        task_id = uuid.uuid4()
+        att = _make_attachment(uploaded_by=user.id, plan_task_id=task_id)
+        task = _make_task(status=OnboardingPlanTaskStatus.APPROVED)
+
+        with patch("app.services.attachment_service.attachment_repository") as att_repo, \
+             patch("app.services.attachment_service.plan_task_repository") as task_repo:
+            att_repo.get_by_id = AsyncMock(return_value=att)
+            task_repo.get_by_id = AsyncMock(return_value=task)
+            with pytest.raises(ValidationError) as exc:
+                await service.delete_attachment(db, task_id, att.id, user)
+        assert exc.value.code == "ATTACHMENT_LOCKED"
+
+    async def test_raises_not_found_for_missing_attachment(self):
+        from app.errors import NotFoundError
+        service = AttachmentService()
+        db = AsyncMock()
+        user = MagicMock()
+
+        with patch("app.services.attachment_service.attachment_repository") as repo:
+            repo.get_by_id = AsyncMock(return_value=None)
+            with pytest.raises(NotFoundError):
+                await service.delete_attachment(db, uuid.uuid4(), uuid.uuid4(), user)

--- a/apps/backend/tests/unit/services/test_scheduler_service.py
+++ b/apps/backend/tests/unit/services/test_scheduler_service.py
@@ -1,0 +1,176 @@
+import pytest
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch, call
+import uuid
+
+from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
+from app.services.scheduler_service import mark_overdue_tasks, send_deadline_reminders
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _make_task(status, deadline, plan_user_id=None, plan_manager_id=None):
+    task = MagicMock()
+    task.id = uuid.uuid4()
+    task.title = "Test Task"
+    task.status = status
+    task.deadline = deadline
+    task.deleted_at = None
+    plan = MagicMock()
+    plan.user_id = plan_user_id or uuid.uuid4()
+    plan.manager_id = plan_manager_id or uuid.uuid4()
+    task.plan = plan
+    return task
+
+
+def _make_session_factory(tasks):
+    session = AsyncMock()
+
+    execute_result = MagicMock()
+    execute_result.scalars.return_value.unique.return_value.all.return_value = tasks
+
+    user = MagicMock()
+    user.email = "test@example.com"
+    user.first_name = "Test"
+    user.last_name = "User"
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+
+    session.execute = AsyncMock(side_effect=[execute_result, user_result, user_result] * (len(tasks) + 1))
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return factory, session
+
+
+class TestMarkOverdueTasks:
+
+    async def test_marks_not_started_task_as_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.NOT_STARTED, yesterday)
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_task_overdue_email = AsyncMock()
+            mock_email.send_task_overdue_manager_email = AsyncMock()
+            await mark_overdue_tasks(factory)
+
+        assert task.status == OnboardingPlanTaskStatus.OVERDUE
+
+    async def test_marks_in_progress_task_as_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.IN_PROGRESS, yesterday)
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_task_overdue_email = AsyncMock()
+            mock_email.send_task_overdue_manager_email = AsyncMock()
+            await mark_overdue_tasks(factory)
+
+        assert task.status == OnboardingPlanTaskStatus.OVERDUE
+
+    async def test_does_not_mark_completed_task_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.COMPLETED, yesterday)
+
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await mark_overdue_tasks(factory)
+        assert task.status == OnboardingPlanTaskStatus.COMPLETED
+
+    async def test_does_not_mark_approved_task_overdue(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.APPROVED, yesterday)
+
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await mark_overdue_tasks(factory)
+        assert task.status == OnboardingPlanTaskStatus.APPROVED
+
+    async def test_commits_after_marking(self):
+        yesterday = date.today() - timedelta(days=1)
+        task = _make_task(OnboardingPlanTaskStatus.NOT_STARTED, yesterday)
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_task_overdue_email = AsyncMock()
+            mock_email.send_task_overdue_manager_email = AsyncMock()
+            await mark_overdue_tasks(factory)
+
+        session.commit.assert_called_once()
+
+    async def test_no_tasks_still_commits(self):
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await mark_overdue_tasks(factory)
+        session.commit.assert_called_once()
+
+
+class TestSendDeadlineReminders:
+
+    async def test_sends_reminder_for_task_due_in_two_days(self):
+        in_two_days = date.today() + timedelta(days=2)
+        task = _make_task(OnboardingPlanTaskStatus.NOT_STARTED, in_two_days)
+        task.deadline = in_two_days
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_deadline_reminder_email = AsyncMock()
+            await send_deadline_reminders(factory)
+
+        mock_email.send_deadline_reminder_email.assert_called_once()
+
+    async def test_sends_reminder_for_overdue_task_due_in_two_days(self):
+        in_two_days = date.today() + timedelta(days=2)
+        task = _make_task(OnboardingPlanTaskStatus.OVERDUE, in_two_days)
+        task.deadline = in_two_days
+        factory, session = _make_session_factory([task])
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_deadline_reminder_email = AsyncMock()
+            await send_deadline_reminders(factory)
+
+        mock_email.send_deadline_reminder_email.assert_called_once()
+
+    async def test_no_tasks_no_emails_sent(self):
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.unique.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=execute_result)
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.scheduler_service.email_service") as mock_email:
+            mock_email.send_deadline_reminder_email = AsyncMock()
+            await send_deadline_reminders(factory)
+
+        mock_email.send_deadline_reminder_email.assert_not_called()

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -22,6 +22,7 @@ import PlanDetailPage from '@/features/plan/pages/PlanDetailPage'
 import EmployeePlanPage from '@/features/plan/pages/EmployeePlanPage'
 import ManagerApprovalsPage from '@/features/plan/pages/ManagerApprovalsPage'
 import ManagerTaskReviewPage from '@/features/plan/pages/ManagerTaskReviewPage'
+import AuditLogPage from '@/features/audit/pages/AuditLogPage'
 
 
 export default function App() {
@@ -44,6 +45,7 @@ export default function App() {
           <Route path="/hr/templates/:id" element={<TemplateDetailPage />} />
           <Route path={ROUTES.HR_PLAN_NEW} element={<CreatePlanPage />} />
           <Route path="/hr/plans/:id" element={<PlanDetailPage />} />
+          <Route path={ROUTES.HR_AUDIT} element={<AuditLogPage />} />
         </Route>
       </Route>
 

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -23,6 +23,7 @@ import EmployeePlanPage from '@/features/plan/pages/EmployeePlanPage'
 import ManagerApprovalsPage from '@/features/plan/pages/ManagerApprovalsPage'
 import ManagerTaskReviewPage from '@/features/plan/pages/ManagerTaskReviewPage'
 import AuditLogPage from '@/features/audit/pages/AuditLogPage'
+import ReportsPage from '@/features/reports/pages/ReportsPage'
 
 
 export default function App() {
@@ -46,6 +47,7 @@ export default function App() {
           <Route path={ROUTES.HR_PLAN_NEW} element={<CreatePlanPage />} />
           <Route path="/hr/plans/:id" element={<PlanDetailPage />} />
           <Route path={ROUTES.HR_AUDIT} element={<AuditLogPage />} />
+          <Route path={ROUTES.HR_REPORTS} element={<ReportsPage />} />
         </Route>
       </Route>
 

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -44,6 +44,11 @@ export const API = {
   MANAGER: {
     APPROVALS: '/api/v1/manager/approvals',
   },
+  DASHBOARD: {
+    HR: '/api/v1/dashboard/hr',
+    MANAGER: '/api/v1/dashboard/manager',
+    EMPLOYEE: '/api/v1/dashboard/employee',
+  },
   TEMPLATES: {
     LIST: '/api/v1/templates/',
     CREATE: '/api/v1/templates/',

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -44,6 +44,9 @@ export const API = {
   MANAGER: {
     APPROVALS: '/api/v1/manager/approvals',
   },
+  AUDIT: {
+    LIST: '/api/v1/audit/',
+  },
   DASHBOARD: {
     HR: '/api/v1/dashboard/hr',
     MANAGER: '/api/v1/dashboard/manager',

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -52,6 +52,11 @@ export const API = {
     MANAGER: '/api/v1/dashboard/manager',
     EMPLOYEE: '/api/v1/dashboard/employee',
   },
+  REPORTS: {
+    COMPLETION_TIME: '/api/v1/reports/completion-time',
+    TASK_COMPLETION_RATES: '/api/v1/reports/task-completion-rates',
+    BOTTLENECKS: '/api/v1/reports/bottlenecks',
+  },
   TEMPLATES: {
     LIST: '/api/v1/templates/',
     CREATE: '/api/v1/templates/',

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -40,6 +40,9 @@ export const API = {
     COMPLETE: (id: string) => `/api/v1/tasks/${id}/complete`,
     APPROVE: (id: string) => `/api/v1/tasks/${id}/approve`,
     RETURN: (id: string) => `/api/v1/tasks/${id}/return`,
+    UPLOAD_ATTACHMENT: (id: string) => `/api/v1/tasks/${id}/attachments`,
+    DELETE_ATTACHMENT: (taskId: string, attId: string) => `/api/v1/tasks/${taskId}/attachments/${attId}`,
+    ADD_COMMENT: (id: string) => `/api/v1/tasks/${id}/comments`,
   },
   MANAGER: {
     APPROVALS: '/api/v1/manager/approvals',

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
   MANAGER_PROFILE: '/manager/profile',
   MANAGER_APPROVALS: '/manager/approvals',
   MANAGER_TASK_REVIEW: (id: string) => `/manager/tasks/${id}`,
+  HR_AUDIT: '/hr/audit',
 }
 
 export const ERROR_ROUTES = {

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
   MANAGER_APPROVALS: '/manager/approvals',
   MANAGER_TASK_REVIEW: (id: string) => `/manager/tasks/${id}`,
   HR_AUDIT: '/hr/audit',
+  HR_REPORTS: '/hr/reports',
 }
 
 export const ERROR_ROUTES = {

--- a/apps/frontend/src/features/audit/hooks/useAuditLog.ts
+++ b/apps/frontend/src/features/audit/hooks/useAuditLog.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+import { getAuditLogs, type AuditLog } from '@/features/audit/services/auditService'
+
+export function useAuditLog(action?: string) {
+  const [logs, setLogs] = useState<AuditLog[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    setLoading(true)
+    getAuditLogs({ action: action || undefined, limit: 200 })
+      .then(setLogs)
+      .finally(() => setLoading(false))
+  }, [action])
+
+  return { logs, loading }
+}

--- a/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
+++ b/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { format } from 'date-fns'
+import { useAuditLog } from '@/features/audit/hooks/useAuditLog'
+
+const ACTION_LABELS: Record<string, string> = {
+  'user.invited': 'User Invited',
+  'user.registered': 'User Registered',
+  'user.deactivated': 'User Deactivated',
+  'user.reactivated': 'User Reactivated',
+  'user.updated': 'User Updated',
+  'plan.created': 'Plan Created',
+  'plan.task_cancelled': 'Task Cancelled',
+  'task.started': 'Task Started',
+  'task.completed': 'Task Completed',
+  'task.approved': 'Task Approved',
+  'task.returned': 'Task Returned',
+}
+
+const ACTION_COLORS: Record<string, string> = {
+  'user.deactivated': 'text-red-600 bg-red-50',
+  'user.reactivated': 'text-green-700 bg-green-50',
+  'task.approved': 'text-green-700 bg-green-50',
+  'task.returned': 'text-orange-600 bg-orange-50',
+  'plan.task_cancelled': 'text-red-600 bg-red-50',
+}
+
+const ACTION_OPTIONS = [
+  { value: '', label: 'All actions' },
+  { value: 'user.invited', label: 'User Invited' },
+  { value: 'user.registered', label: 'User Registered' },
+  { value: 'user.deactivated', label: 'User Deactivated' },
+  { value: 'user.reactivated', label: 'User Reactivated' },
+  { value: 'user.updated', label: 'User Updated' },
+  { value: 'plan.created', label: 'Plan Created' },
+  { value: 'plan.task_cancelled', label: 'Task Cancelled' },
+  { value: 'task.started', label: 'Task Started' },
+  { value: 'task.completed', label: 'Task Completed' },
+  { value: 'task.approved', label: 'Task Approved' },
+  { value: 'task.returned', label: 'Task Returned' },
+]
+
+export default function AuditLogPage() {
+  const [selectedAction, setSelectedAction] = useState('')
+  const { logs, loading } = useAuditLog(selectedAction || undefined)
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Audit Trail</h2>
+          <p className="text-sm text-gray-500 mt-0.5">System activity log for all key actions.</p>
+        </div>
+        <select
+          value={selectedAction}
+          onChange={(e) => setSelectedAction(e.target.value)}
+          className="border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          {ACTION_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+        {loading ? (
+          <p className="text-sm text-gray-400 px-5 py-4">Loading...</p>
+        ) : logs.length === 0 ? (
+          <p className="text-sm text-gray-400 px-5 py-4">No audit logs found.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100">
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Date</th>
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Action</th>
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Entity</th>
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Detail</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {logs.map((log) => (
+                <tr key={log.id} className="hover:bg-gray-50">
+                  <td className="px-5 py-3 text-gray-500 whitespace-nowrap">
+                    {format(new Date(log.created_at), 'dd MMM yyyy HH:mm')}
+                  </td>
+                  <td className="px-5 py-3">
+                    <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${ACTION_COLORS[log.action] ?? 'text-blue-700 bg-blue-50'}`}>
+                      {ACTION_LABELS[log.action] ?? log.action}
+                    </span>
+                  </td>
+                  <td className="px-5 py-3 text-gray-500 font-mono text-xs truncate max-w-[180px]">
+                    {log.entity_type} · {log.entity_id.slice(0, 8)}…
+                  </td>
+                  <td className="px-5 py-3 text-gray-500 truncate max-w-[200px]">
+                    {log.detail ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/audit/services/auditService.ts
+++ b/apps/frontend/src/features/audit/services/auditService.ts
@@ -1,0 +1,17 @@
+import apiClient from '@/lib/apiClient'
+import { API } from '@/constants/apiEndpoints'
+
+export interface AuditLog {
+  id: string
+  actor_id: string
+  action: string
+  entity_type: string
+  entity_id: string
+  detail: string | null
+  created_at: string
+}
+
+export async function getAuditLogs(params?: { action?: string; limit?: number; offset?: number }): Promise<AuditLog[]> {
+  const res = await apiClient.get(API.AUDIT.LIST, { params })
+  return res.data
+}

--- a/apps/frontend/src/features/dashboard/hooks/useEmployeeDashboard.ts
+++ b/apps/frontend/src/features/dashboard/hooks/useEmployeeDashboard.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getEmployeeDashboard, type EmployeeDashboardStats } from '@/features/dashboard/services/dashboardService'
+
+export function useEmployeeDashboard() {
+  const [stats, setStats] = useState<EmployeeDashboardStats | null>(null)
+
+  useEffect(() => {
+    getEmployeeDashboard().then(setStats).catch(() => {})
+  }, [])
+
+  return { stats }
+}

--- a/apps/frontend/src/features/dashboard/hooks/useHRDashboard.ts
+++ b/apps/frontend/src/features/dashboard/hooks/useHRDashboard.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getHRDashboard, type HRDashboardStats } from '@/features/dashboard/services/dashboardService'
+
+export function useHRDashboard() {
+  const [stats, setStats] = useState<HRDashboardStats | null>(null)
+
+  useEffect(() => {
+    getHRDashboard().then(setStats).catch(() => {})
+  }, [])
+
+  return { stats }
+}

--- a/apps/frontend/src/features/dashboard/hooks/useManagerDashboard.ts
+++ b/apps/frontend/src/features/dashboard/hooks/useManagerDashboard.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getManagerDashboard, type ManagerDashboardStats } from '@/features/dashboard/services/dashboardService'
+
+export function useManagerDashboard() {
+  const [stats, setStats] = useState<ManagerDashboardStats | null>(null)
+
+  useEffect(() => {
+    getManagerDashboard().then(setStats).catch(() => {})
+  }, [])
+
+  return { stats }
+}

--- a/apps/frontend/src/features/dashboard/services/dashboardService.ts
+++ b/apps/frontend/src/features/dashboard/services/dashboardService.ts
@@ -1,0 +1,38 @@
+import apiClient from '@/lib/apiClient'
+import { API } from '@/constants/apiEndpoints'
+
+export interface HRDashboardStats {
+  active_users: number
+  active_plans: number
+  active_departments: number
+  pending_approvals: number
+}
+
+export interface ManagerDashboardStats {
+  active_plans: number
+  pending_approvals: number
+  total_employees: number
+}
+
+export interface EmployeeDashboardStats {
+  total_tasks: number
+  approved_tasks: number
+  completed_tasks: number
+  in_progress_tasks: number
+  next_deadline: string | null
+}
+
+export async function getHRDashboard(): Promise<HRDashboardStats> {
+  const res = await apiClient.get(API.DASHBOARD.HR)
+  return res.data
+}
+
+export async function getManagerDashboard(): Promise<ManagerDashboardStats> {
+  const res = await apiClient.get(API.DASHBOARD.MANAGER)
+  return res.data
+}
+
+export async function getEmployeeDashboard(): Promise<EmployeeDashboardStats> {
+  const res = await apiClient.get(API.DASHBOARD.EMPLOYEE)
+  return res.data
+}

--- a/apps/frontend/src/features/plan/hooks/useEmployeePlanPage.ts
+++ b/apps/frontend/src/features/plan/hooks/useEmployeePlanPage.ts
@@ -6,24 +6,14 @@ import type { components } from '@/types/api'
 type OnboardingPlanResponse = components['schemas']['OnboardingPlanResponse']
 type OnboardingPlanTaskResponse = components['schemas']['OnboardingPlanTaskResponse']
 type TaskAttachmentResponse = components['schemas']['TaskAttachmentResponse']
-type TaskCommentResponse = components['schemas']['TaskCommentResponse']
-
-type TaskWithExtras = OnboardingPlanTaskResponse & {
-  attachments: TaskAttachmentResponse[]
-  comments: TaskCommentResponse[]
-}
-
-type PlanWithExtras = Omit<OnboardingPlanResponse, 'tasks'> & {
-  tasks: TaskWithExtras[]
-}
 
 export function useEmployeePlanPage() {
-  const [plan, setPlan] = useState<PlanWithExtras | null>(null)
+  const [plan, setPlan] = useState<OnboardingPlanResponse | null>(null)
   const [notFound, setNotFound] = useState(false)
 
   useEffect(() => {
     getMyPlan()
-      .then((p) => setPlan(p as PlanWithExtras))
+      .then(setPlan)
       .catch(() => setNotFound(true))
   }, [])
 
@@ -58,7 +48,7 @@ export function useEmployeePlanPage() {
     await deleteAttachment(taskId, attachmentId)
     setPlan((prev) =>
       prev
-        ? { ...prev, tasks: prev.tasks.map((t) => t.id === taskId ? { ...t, attachments: t.attachments.filter((a) => a.id !== attachmentId) } : t) }
+        ? { ...prev, tasks: prev.tasks.map((t) => t.id === taskId ? { ...t, attachments: t.attachments.filter((a: TaskAttachmentResponse) => a.id !== attachmentId) } : t) }
         : prev
     )
   }
@@ -73,7 +63,7 @@ export function useEmployeePlanPage() {
   }
 
   const completedCount = plan?.tasks.filter((t) => t.status === 'completed' || t.status === 'approved').length ?? 0
-  const totalCount = plan?.tasks.length ?? 0
+  const totalCount = plan?.tasks.filter((t) => t.status !== 'cancelled').length ?? 0
 
   return {
     plan,

--- a/apps/frontend/src/features/plan/hooks/useEmployeePlanPage.ts
+++ b/apps/frontend/src/features/plan/hooks/useEmployeePlanPage.ts
@@ -1,23 +1,37 @@
 import { useEffect, useState } from 'react'
 import { getMyPlan, startTask, completeTask } from '@/features/plan/services/planService'
+import { uploadAttachment, deleteAttachment, addComment } from '@/features/plan/services/attachmentService'
 import type { components } from '@/types/api'
 
 type OnboardingPlanResponse = components['schemas']['OnboardingPlanResponse']
 type OnboardingPlanTaskResponse = components['schemas']['OnboardingPlanTaskResponse']
+type TaskAttachmentResponse = components['schemas']['TaskAttachmentResponse']
+type TaskCommentResponse = components['schemas']['TaskCommentResponse']
+
+type TaskWithExtras = OnboardingPlanTaskResponse & {
+  attachments: TaskAttachmentResponse[]
+  comments: TaskCommentResponse[]
+}
+
+type PlanWithExtras = Omit<OnboardingPlanResponse, 'tasks'> & {
+  tasks: TaskWithExtras[]
+}
 
 export function useEmployeePlanPage() {
-  const [plan, setPlan] = useState<OnboardingPlanResponse | null>(null)
+  const [plan, setPlan] = useState<PlanWithExtras | null>(null)
   const [notFound, setNotFound] = useState(false)
 
   useEffect(() => {
     getMyPlan()
-      .then(setPlan)
+      .then((p) => setPlan(p as PlanWithExtras))
       .catch(() => setNotFound(true))
   }, [])
 
   function updateTask(updated: OnboardingPlanTaskResponse) {
     setPlan((prev) =>
-      prev ? { ...prev, tasks: prev.tasks.map((t) => (t.id === updated.id ? updated : t)) } : prev
+      prev
+        ? { ...prev, tasks: prev.tasks.map((t) => (t.id === updated.id ? { ...t, ...updated } : t)) }
+        : prev
     )
   }
 
@@ -31,6 +45,33 @@ export function useEmployeePlanPage() {
     updateTask(updated)
   }
 
+  async function handleUpload(taskId: string, file: File) {
+    const att = await uploadAttachment(taskId, file)
+    setPlan((prev) =>
+      prev
+        ? { ...prev, tasks: prev.tasks.map((t) => t.id === taskId ? { ...t, attachments: [...t.attachments, att] } : t) }
+        : prev
+    )
+  }
+
+  async function handleDeleteAttachment(taskId: string, attachmentId: string) {
+    await deleteAttachment(taskId, attachmentId)
+    setPlan((prev) =>
+      prev
+        ? { ...prev, tasks: prev.tasks.map((t) => t.id === taskId ? { ...t, attachments: t.attachments.filter((a) => a.id !== attachmentId) } : t) }
+        : prev
+    )
+  }
+
+  async function handleAddComment(taskId: string, content: string) {
+    const comment = await addComment(taskId, content)
+    setPlan((prev) =>
+      prev
+        ? { ...prev, tasks: prev.tasks.map((t) => t.id === taskId ? { ...t, comments: [...t.comments, comment] } : t) }
+        : prev
+    )
+  }
+
   const completedCount = plan?.tasks.filter((t) => t.status === 'completed' || t.status === 'approved').length ?? 0
   const totalCount = plan?.tasks.length ?? 0
 
@@ -41,5 +82,8 @@ export function useEmployeePlanPage() {
     totalCount,
     handleStartTask,
     handleCompleteTask,
+    handleUpload,
+    handleDeleteAttachment,
+    handleAddComment,
   }
 }

--- a/apps/frontend/src/features/plan/hooks/useManagerApprovalsPage.ts
+++ b/apps/frontend/src/features/plan/hooks/useManagerApprovalsPage.ts
@@ -19,8 +19,12 @@ export function useManagerApprovalsPage() {
   }, [])
 
   async function handleApprove(taskId: string) {
-    await approveTask(taskId)
-    setTasks((prev) => prev.filter((t) => t.id !== taskId))
+    try {
+      await approveTask(taskId)
+      setTasks((prev) => prev.filter((t) => t.id !== taskId))
+    } catch {
+      // task stays in list on failure
+    }
   }
 
   function handleReview(taskId: string) {

--- a/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
+++ b/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
@@ -9,6 +9,7 @@ const STATUS_LABELS: Record<OnboardingPlanTaskStatus, string> = {
   completed: 'Completed',
   approved: 'Approved',
   returned: 'Returned',
+  overdue: 'Overdue',
   cancelled: 'Cancelled',
 }
 
@@ -18,6 +19,7 @@ const STATUS_STYLES: Record<OnboardingPlanTaskStatus, string> = {
   completed: 'bg-green-50 text-green-700 border-green-100',
   approved: 'bg-green-100 text-green-800 border-green-200',
   returned: 'bg-red-50 text-red-700 border-red-100',
+  overdue: 'bg-red-100 text-red-800 border-red-200',
   cancelled: 'bg-gray-100 text-gray-400 border-gray-200',
 }
 
@@ -73,7 +75,7 @@ export default function EmployeePlanPage() {
                 </div>
 
                 <div className="shrink-0">
-                  {task.status === 'not_started' && (
+                  {(task.status === 'not_started' || task.status === 'overdue') && (
                     <button
                       onClick={() => handleStartTask(task.id)}
                       className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
@@ -81,7 +83,7 @@ export default function EmployeePlanPage() {
                       Start
                     </button>
                   )}
-                  {task.status === 'in_progress' && (
+                  {(task.status === 'in_progress' || task.status === 'overdue') && (
                     <button
                       onClick={() => handleCompleteTask(task.id)}
                       className="text-xs bg-green-700 hover:bg-green-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"

--- a/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
+++ b/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
@@ -5,6 +5,7 @@ import type { components } from '@/types/api'
 type OnboardingPlanTaskStatus = components['schemas']['OnboardingPlanTaskStatus']
 type TaskAttachmentResponse = components['schemas']['TaskAttachmentResponse']
 type TaskCommentResponse = components['schemas']['TaskCommentResponse']
+type OnboardingPlanTaskResponse = components['schemas']['OnboardingPlanTaskResponse']
 
 const STATUS_LABELS: Record<OnboardingPlanTaskStatus, string> = {
   not_started: 'Not started',
@@ -125,10 +126,10 @@ export default function EmployeePlanPage() {
       </div>
 
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100">
-        {plan.tasks.map((task) => {
+        {plan.tasks.map((task: OnboardingPlanTaskResponse) => {
           const isExpanded = expandedTask === task.id
-          const attachments: TaskAttachmentResponse[] = (task as any).attachments ?? []
-          const comments: TaskCommentResponse[] = (task as any).comments ?? []
+          const attachments: TaskAttachmentResponse[] = task.attachments
+          const comments: TaskCommentResponse[] = task.comments
           const canDelete = task.status !== 'approved' && task.status !== 'cancelled'
 
           return (
@@ -163,7 +164,7 @@ export default function EmployeePlanPage() {
                       Start
                     </button>
                   )}
-                  {(task.status === 'in_progress' || task.status === 'overdue') && (
+                  {task.status === 'in_progress' && (
                     <button
                       onClick={() => handleCompleteTask(task.id)}
                       className="text-xs bg-green-700 hover:bg-green-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
@@ -178,6 +179,12 @@ export default function EmployeePlanPage() {
                 <div className="mt-3 space-y-3 border-t border-gray-100 pt-3">
                   {task.description && (
                     <p className="text-xs text-gray-600">{task.description}</p>
+                  )}
+                  {task.return_comment && (
+                    <div className="bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+                      <p className="text-xs font-medium text-red-700 mb-0.5">Manager feedback</p>
+                      <p className="text-xs text-red-600">{task.return_comment}</p>
+                    </div>
                   )}
 
                   <div>

--- a/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
+++ b/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
@@ -1,7 +1,10 @@
+import { useRef, useState } from 'react'
 import { useEmployeePlanPage } from '@/features/plan/hooks/useEmployeePlanPage'
 import type { components } from '@/types/api'
 
 type OnboardingPlanTaskStatus = components['schemas']['OnboardingPlanTaskStatus']
+type TaskAttachmentResponse = components['schemas']['TaskAttachmentResponse']
+type TaskCommentResponse = components['schemas']['TaskCommentResponse']
 
 const STATUS_LABELS: Record<OnboardingPlanTaskStatus, string> = {
   not_started: 'Not started',
@@ -23,9 +26,64 @@ const STATUS_STYLES: Record<OnboardingPlanTaskStatus, string> = {
   cancelled: 'bg-gray-100 text-gray-400 border-gray-200',
 }
 
+function AttachmentList({
+  attachments,
+  taskId,
+  canDelete,
+  onDelete,
+}: {
+  attachments: TaskAttachmentResponse[]
+  taskId: string
+  canDelete: boolean
+  onDelete: (taskId: string, attId: string) => void
+}) {
+  if (attachments.length === 0) return null
+  return (
+    <ul className="mt-2 space-y-1">
+      {attachments.map((att) => (
+        <li key={att.id} className="flex items-center gap-2 text-xs text-gray-600">
+          <a href={att.download_url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline truncate max-w-[200px]">
+            {att.file_name}
+          </a>
+          <span className="text-gray-400">({(att.file_size / 1024).toFixed(0)} KB)</span>
+          {canDelete && (
+            <button
+              onClick={() => onDelete(taskId, att.id)}
+              className="text-red-400 hover:text-red-600 text-xs"
+            >
+              ✕
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function CommentList({ comments }: { comments: TaskCommentResponse[] }) {
+  if (comments.length === 0) return null
+  return (
+    <ul className="mt-2 space-y-1">
+      {comments.map((c) => (
+        <li key={c.id} className="text-xs text-gray-600 bg-gray-50 rounded px-2 py-1">
+          {c.content}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
 export default function EmployeePlanPage() {
-  const { plan, notFound, completedCount, totalCount, handleStartTask, handleCompleteTask } =
-    useEmployeePlanPage()
+  const {
+    plan, notFound, completedCount, totalCount,
+    handleStartTask, handleCompleteTask,
+    handleUpload, handleDeleteAttachment, handleAddComment,
+  } = useEmployeePlanPage()
+
+  const [expandedTask, setExpandedTask] = useState<string | null>(null)
+  const [commentText, setCommentText] = useState<Record<string, string>>({})
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploadingFor, setUploadingFor] = useState<string | null>(null)
 
   if (notFound) {
     return (
@@ -39,6 +97,24 @@ export default function EmployeePlanPage() {
 
   if (!plan) return null
 
+  function toggleExpand(taskId: string) {
+    setExpandedTask((prev) => (prev === taskId ? null : taskId))
+  }
+
+  async function onFileChange(e: React.ChangeEvent<HTMLInputElement>, taskId: string) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    await handleUpload(taskId, file)
+    e.target.value = ''
+  }
+
+  async function onAddComment(taskId: string) {
+    const text = commentText[taskId]?.trim()
+    if (!text) return
+    await handleAddComment(taskId, text)
+    setCommentText((prev) => ({ ...prev, [taskId]: '' }))
+  }
+
   return (
     <div className="max-w-2xl mx-auto">
       <div className="flex items-center justify-between mb-6">
@@ -50,18 +126,22 @@ export default function EmployeePlanPage() {
 
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100">
         {plan.tasks.map((task) => {
-          const isOverdue = task.status === 'not_started' || task.status === 'in_progress'
-            ? new Date(task.deadline) < new Date()
-            : false
+          const isExpanded = expandedTask === task.id
+          const attachments: TaskAttachmentResponse[] = (task as any).attachments ?? []
+          const comments: TaskCommentResponse[] = (task as any).comments ?? []
+          const canDelete = task.status !== 'approved' && task.status !== 'cancelled'
 
           return (
             <div key={task.id} className="px-5 py-4">
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className={`text-sm font-medium ${task.status === 'cancelled' ? 'line-through text-gray-400' : 'text-gray-900'}`}>
+                    <button
+                      onClick={() => toggleExpand(task.id)}
+                      className={`text-sm font-medium text-left ${task.status === 'cancelled' ? 'line-through text-gray-400' : 'text-gray-900'}`}
+                    >
                       {task.title}
-                    </span>
+                    </button>
                     <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${STATUS_STYLES[task.status]}`}>
                       {STATUS_LABELS[task.status]}
                     </span>
@@ -69,12 +149,12 @@ export default function EmployeePlanPage() {
                       {task.is_required ? 'Required' : 'Optional'}
                     </span>
                   </div>
-                  <p className={`text-xs mt-0.5 ${isOverdue ? 'text-red-500 font-medium' : 'text-gray-500'}`}>
-                    Due: {task.deadline}{isOverdue ? ' · Overdue' : ''}
+                  <p className="text-xs mt-0.5 text-gray-500">
+                    Due: {task.deadline}
                   </p>
                 </div>
 
-                <div className="shrink-0">
+                <div className="shrink-0 flex gap-2">
                   {(task.status === 'not_started' || task.status === 'overdue') && (
                     <button
                       onClick={() => handleStartTask(task.id)}
@@ -93,6 +173,65 @@ export default function EmployeePlanPage() {
                   )}
                 </div>
               </div>
+
+              {isExpanded && task.status !== 'cancelled' && (
+                <div className="mt-3 space-y-3 border-t border-gray-100 pt-3">
+                  {task.description && (
+                    <p className="text-xs text-gray-600">{task.description}</p>
+                  )}
+
+                  <div>
+                    <p className="text-xs font-medium text-gray-700 mb-1">Attachments</p>
+                    <AttachmentList
+                      attachments={attachments}
+                      taskId={task.id}
+                      canDelete={canDelete}
+                      onDelete={handleDeleteAttachment}
+                    />
+                    {canDelete && (
+                      <>
+                        <input
+                          ref={uploadingFor === task.id ? fileInputRef : undefined}
+                          type="file"
+                          accept=".pdf,.docx,.png,.jpg,.jpeg"
+                          className="hidden"
+                          onChange={(e) => onFileChange(e, task.id)}
+                          id={`file-${task.id}`}
+                        />
+                        <label
+                          htmlFor={`file-${task.id}`}
+                          onClick={() => setUploadingFor(task.id)}
+                          className="mt-1 inline-block text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
+                        >
+                          + Upload file
+                        </label>
+                        <p className="text-xs text-gray-400">PDF, DOCX, PNG or JPEG · max 10 MB</p>
+                      </>
+                    )}
+                  </div>
+
+                  <div>
+                    <p className="text-xs font-medium text-gray-700 mb-1">Comments</p>
+                    <CommentList comments={comments} />
+                    <div className="flex gap-2 mt-1">
+                      <input
+                        type="text"
+                        placeholder="Add a comment…"
+                        value={commentText[task.id] ?? ''}
+                        onChange={(e) => setCommentText((prev) => ({ ...prev, [task.id]: e.target.value }))}
+                        onKeyDown={(e) => e.key === 'Enter' && onAddComment(task.id)}
+                        className="flex-1 text-xs border border-gray-300 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                      <button
+                        onClick={() => onAddComment(task.id)}
+                        className="text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium px-2 py-1.5 rounded-lg transition-colors"
+                      >
+                        Send
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           )
         })}

--- a/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.test.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.test.tsx
@@ -34,6 +34,8 @@ const mockTask = {
   created_at: '',
   employee_name: 'John Employee',
   plan_start_date: '2026-06-01',
+  return_comment: null,
+  attachments: [],
 }
 
 function renderPage() {

--- a/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.tsx
@@ -1,6 +1,9 @@
 import { Link } from 'react-router-dom'
 import { useManagerTaskReviewPage } from '@/features/plan/hooks/useManagerTaskReviewPage'
 import { ROUTES } from '@/constants/routes'
+import type { components } from '@/types/api'
+
+type TaskAttachmentResponse = components['schemas']['TaskAttachmentResponse']
 
 export default function ManagerTaskReviewPage() {
   const {
@@ -54,6 +57,22 @@ export default function ManagerTaskReviewPage() {
           </span>
         </div>
       </div>
+
+      {task.attachments.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5 mb-4">
+          <p className="text-sm font-medium text-gray-700 mb-2">Attachments</p>
+          <ul className="space-y-1">
+            {task.attachments.map((att: TaskAttachmentResponse) => (
+              <li key={att.id} className="flex items-center gap-2 text-xs text-gray-600">
+                <a href={att.download_url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline truncate max-w-xs">
+                  {att.file_name}
+                </a>
+                <span className="text-gray-400">({(att.file_size / 1024).toFixed(0)} KB)</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <div className="flex gap-3">
         <button

--- a/apps/frontend/src/features/plan/pages/PlanDetailPage.tsx
+++ b/apps/frontend/src/features/plan/pages/PlanDetailPage.tsx
@@ -1,6 +1,29 @@
 import { Link } from 'react-router-dom'
 import { usePlanDetailPage } from '@/features/plan/hooks/usePlanDetailPage'
 import { ROUTES } from '@/constants/routes'
+import type { components } from '@/types/api'
+
+type OnboardingPlanTaskStatus = components['schemas']['OnboardingPlanTaskStatus']
+
+const STATUS_LABELS: Record<OnboardingPlanTaskStatus, string> = {
+  not_started: 'Not started',
+  in_progress: 'In progress',
+  completed: 'Completed',
+  approved: 'Approved',
+  returned: 'Returned',
+  overdue: 'Overdue',
+  cancelled: 'Cancelled',
+}
+
+const STATUS_STYLES: Record<OnboardingPlanTaskStatus, string> = {
+  not_started: 'bg-gray-100 text-gray-500 border-gray-200',
+  in_progress: 'bg-amber-50 text-amber-700 border-amber-100',
+  completed: 'bg-green-50 text-green-700 border-green-100',
+  approved: 'bg-green-100 text-green-800 border-green-200',
+  returned: 'bg-red-50 text-red-700 border-red-100',
+  overdue: 'bg-red-100 text-red-800 border-red-200',
+  cancelled: 'bg-gray-100 text-gray-400 border-gray-200',
+}
 
 export default function PlanDetailPage() {
   const {
@@ -27,8 +50,8 @@ export default function PlanDetailPage() {
   return (
     <div className="max-w-3xl mx-auto">
       <div className="flex items-center gap-3 mb-6">
-        <Link to={ROUTES.HR_PLAN_NEW} className="text-sm text-gray-500 hover:text-gray-700 transition-colors">
-          ← Plans
+        <Link to={ROUTES.HR_DASHBOARD} className="text-sm text-gray-500 hover:text-gray-700 transition-colors">
+          ← Dashboard
         </Link>
         <span className="text-gray-300">/</span>
         <h2 className="text-xl font-semibold text-gray-900">Onboarding Plan</h2>
@@ -106,12 +129,8 @@ export default function PlanDetailPage() {
                     <span className={`text-sm font-medium ${task.status === 'cancelled' ? 'line-through text-gray-400' : 'text-gray-900'}`}>
                       {task.title}
                     </span>
-                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${
-                      task.status === 'cancelled'
-                        ? 'bg-gray-100 text-gray-500 border-gray-200'
-                        : 'bg-blue-50 text-blue-700 border-blue-100'
-                    }`}>
-                      {task.status === 'not_started' ? 'Not started' : 'Cancelled'}
+                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${STATUS_STYLES[task.status]}`}>
+                      {STATUS_LABELS[task.status]}
                     </span>
                     <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600' : 'text-gray-400'}`}>
                       {task.is_required ? 'Required' : 'Optional'}

--- a/apps/frontend/src/features/plan/services/attachmentService.ts
+++ b/apps/frontend/src/features/plan/services/attachmentService.ts
@@ -1,0 +1,24 @@
+import apiClient from '@/lib/apiClient'
+import { API } from '@/constants/apiEndpoints'
+import type { components } from '@/types/api'
+
+type TaskAttachmentResponse = components['schemas']['TaskAttachmentResponse']
+type TaskCommentResponse = components['schemas']['TaskCommentResponse']
+
+export async function uploadAttachment(taskId: string, file: File): Promise<TaskAttachmentResponse> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await apiClient.post(API.TASKS.UPLOAD_ATTACHMENT(taskId), form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return res.data
+}
+
+export async function deleteAttachment(taskId: string, attachmentId: string): Promise<void> {
+  await apiClient.delete(API.TASKS.DELETE_ATTACHMENT(taskId, attachmentId))
+}
+
+export async function addComment(taskId: string, content: string): Promise<TaskCommentResponse> {
+  const res = await apiClient.post(API.TASKS.ADD_COMMENT(taskId), { content })
+  return res.data
+}

--- a/apps/frontend/src/features/reports/hooks/useReports.ts
+++ b/apps/frontend/src/features/reports/hooks/useReports.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  getCompletionTime,
+  getTaskCompletionRates,
+  getBottlenecks,
+  type DepartmentCompletionRow,
+  type TemplateCompletionRow,
+  type BottleneckRow,
+  type ReportFilters,
+} from '@/features/reports/services/reportsService'
+
+export function useReports(filters: ReportFilters) {
+  const [completionTime, setCompletionTime] = useState<DepartmentCompletionRow[]>([])
+  const [taskRates, setTaskRates] = useState<TemplateCompletionRow[]>([])
+  const [bottlenecks, setBottlenecks] = useState<BottleneckRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    const [ct, tr, bn] = await Promise.all([
+      getCompletionTime(filters),
+      getTaskCompletionRates(filters),
+      getBottlenecks(filters),
+    ])
+    setCompletionTime(ct)
+    setTaskRates(tr)
+    setBottlenecks(bn)
+    setLoading(false)
+  }, [filters.start_date, filters.end_date])
+
+  useEffect(() => { load() }, [load])
+
+  return { completionTime, taskRates, bottlenecks, loading, reload: load }
+}

--- a/apps/frontend/src/features/reports/pages/ReportsPage.test.tsx
+++ b/apps/frontend/src/features/reports/pages/ReportsPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import ReportsPage from './ReportsPage'
+import * as reportsService from '@/features/reports/services/reportsService'
+
+vi.mock('@/features/reports/services/reportsService')
+
+const mockCompletionTime = [
+  { department_name: 'Engineering', total_plans: 3, avg_completion_days: 12.5, avg_completion_days_rounded: 12.5 },
+]
+const mockTaskRates = [
+  { template_name: 'Dev Onboarding', total_tasks: 10, completed_tasks: 8, completion_rate: 80 },
+]
+const mockBottlenecks = [
+  { task_title: 'Write Tests', returned_count: 3, overdue_count: 1 },
+]
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <ReportsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ReportsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(reportsService.getCompletionTime).mockResolvedValue(mockCompletionTime)
+    vi.mocked(reportsService.getTaskCompletionRates).mockResolvedValue(mockTaskRates)
+    vi.mocked(reportsService.getBottlenecks).mockResolvedValue(mockBottlenecks)
+  })
+
+  it('renders section headings', async () => {
+    renderPage()
+    expect(await screen.findByText(/average completion time by department/i)).toBeInTheDocument()
+    expect(screen.getByText(/task completion rates by template/i)).toBeInTheDocument()
+    expect(screen.getByText(/bottlenecks/i)).toBeInTheDocument()
+  })
+
+  it('renders completion time data', async () => {
+    renderPage()
+    expect(await screen.findByText('Engineering')).toBeInTheDocument()
+    expect(screen.getByText('12.5 days')).toBeInTheDocument()
+  })
+
+  it('renders task completion rate data', async () => {
+    renderPage()
+    expect(await screen.findByText('Dev Onboarding')).toBeInTheDocument()
+    expect(screen.getByText('80%')).toBeInTheDocument()
+  })
+
+  it('renders bottleneck data', async () => {
+    renderPage()
+    expect(await screen.findByText('Write Tests')).toBeInTheDocument()
+  })
+
+  it('renders three export CSV buttons', async () => {
+    renderPage()
+    const buttons = await screen.findAllByText(/export csv/i)
+    expect(buttons).toHaveLength(3)
+  })
+})

--- a/apps/frontend/src/features/reports/pages/ReportsPage.tsx
+++ b/apps/frontend/src/features/reports/pages/ReportsPage.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react'
+import { useReports } from '@/features/reports/hooks/useReports'
+import { downloadCsv } from '@/features/reports/services/reportsService'
+import { API } from '@/constants/apiEndpoints'
+
+export default function ReportsPage() {
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+
+  const filters = {
+    start_date: startDate || undefined,
+    end_date: endDate || undefined,
+  }
+
+  const { completionTime, taskRates, bottlenecks, loading } = useReports(filters)
+
+  function handleExport(endpoint: string, filename: string) {
+    downloadCsv(endpoint, filename, filters)
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Reports</h2>
+          <p className="text-sm text-gray-500 mt-0.5">Onboarding activity analysis and export.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-0.5">
+            <label className="text-xs text-gray-500">From</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <label className="text-xs text-gray-500">To</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-gray-400">Loading...</p>
+      ) : (
+        <>
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-700">Average Completion Time by Department</h3>
+              <button
+                onClick={() => handleExport(API.REPORTS.COMPLETION_TIME, 'completion-time.csv')}
+                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+              >
+                Export CSV
+              </button>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+              {completionTime.length === 0 ? (
+                <p className="text-sm text-gray-400 px-5 py-4">No completed plans found.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100">
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Department</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completed Plans</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Avg. Days to Complete</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {completionTime.map((row) => (
+                      <tr key={row.department_name} className="hover:bg-gray-50">
+                        <td className="px-5 py-3 font-medium text-gray-800">{row.department_name}</td>
+                        <td className="px-5 py-3 text-gray-600">{row.total_plans}</td>
+                        <td className="px-5 py-3 text-gray-600">
+                          {row.avg_completion_days_rounded != null ? `${row.avg_completion_days_rounded} days` : '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-700">Task Completion Rates by Template</h3>
+              <button
+                onClick={() => handleExport(API.REPORTS.TASK_COMPLETION_RATES, 'task-completion-rates.csv')}
+                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+              >
+                Export CSV
+              </button>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+              {taskRates.length === 0 ? (
+                <p className="text-sm text-gray-400 px-5 py-4">No data found.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100">
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Template</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Total Tasks</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completed</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completion Rate</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {taskRates.map((row) => (
+                      <tr key={row.template_name} className="hover:bg-gray-50">
+                        <td className="px-5 py-3 font-medium text-gray-800">{row.template_name}</td>
+                        <td className="px-5 py-3 text-gray-600">{row.total_tasks}</td>
+                        <td className="px-5 py-3 text-gray-600">{row.completed_tasks}</td>
+                        <td className="px-5 py-3">
+                          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                            row.completion_rate >= 75
+                              ? 'text-green-700 bg-green-50'
+                              : row.completion_rate >= 40
+                              ? 'text-yellow-700 bg-yellow-50'
+                              : 'text-red-600 bg-red-50'
+                          }`}>
+                            {row.completion_rate}%
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-700">Bottlenecks — Most Returned & Overdue Tasks</h3>
+              <button
+                onClick={() => handleExport(API.REPORTS.BOTTLENECKS, 'bottlenecks.csv')}
+                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+              >
+                Export CSV
+              </button>
+            </div>
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+              {bottlenecks.length === 0 ? (
+                <p className="text-sm text-gray-400 px-5 py-4">No bottlenecks found.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100">
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Task</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Times Returned</th>
+                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Times Overdue</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {bottlenecks.map((row) => (
+                      <tr key={row.task_title} className="hover:bg-gray-50">
+                        <td className="px-5 py-3 font-medium text-gray-800">{row.task_title}</td>
+                        <td className="px-5 py-3">
+                          {row.returned_count > 0 ? (
+                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-orange-600 bg-orange-50">
+                              {row.returned_count}
+                            </span>
+                          ) : (
+                            <span className="text-gray-400">0</span>
+                          )}
+                        </td>
+                        <td className="px-5 py-3">
+                          {row.overdue_count > 0 ? (
+                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-red-600 bg-red-50">
+                              {row.overdue_count}
+                            </span>
+                          ) : (
+                            <span className="text-gray-400">0</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/features/reports/services/reportsService.ts
+++ b/apps/frontend/src/features/reports/services/reportsService.ts
@@ -1,0 +1,55 @@
+import apiClient from '@/lib/apiClient'
+import { API } from '@/constants/apiEndpoints'
+
+export interface DepartmentCompletionRow {
+  department_name: string
+  total_plans: number
+  avg_completion_days: number | null
+  avg_completion_days_rounded: number | null
+}
+
+export interface TemplateCompletionRow {
+  template_name: string
+  total_tasks: number
+  completed_tasks: number
+  completion_rate: number
+}
+
+export interface BottleneckRow {
+  task_title: string
+  returned_count: number
+  overdue_count: number
+}
+
+export interface ReportFilters {
+  start_date?: string
+  end_date?: string
+}
+
+export async function getCompletionTime(filters: ReportFilters): Promise<DepartmentCompletionRow[]> {
+  const res = await apiClient.get(API.REPORTS.COMPLETION_TIME, { params: filters })
+  return res.data
+}
+
+export async function getTaskCompletionRates(filters: ReportFilters): Promise<TemplateCompletionRow[]> {
+  const res = await apiClient.get(API.REPORTS.TASK_COMPLETION_RATES, { params: filters })
+  return res.data
+}
+
+export async function getBottlenecks(filters: ReportFilters): Promise<BottleneckRow[]> {
+  const res = await apiClient.get(API.REPORTS.BOTTLENECKS, { params: filters })
+  return res.data
+}
+
+export async function downloadCsv(endpoint: string, filename: string, filters: ReportFilters): Promise<void> {
+  const res = await apiClient.get(endpoint, {
+    params: { ...filters, format: 'csv' },
+    responseType: 'blob',
+  })
+  const url = URL.createObjectURL(new Blob([res.data], { type: 'text/csv' }))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
@@ -1,23 +1,70 @@
 import { Link } from 'react-router-dom'
+import { format } from 'date-fns'
 import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
+import { useEmployeeDashboard } from '@/features/dashboard/hooks/useEmployeeDashboard'
+
+function StatCard({ label, value }: { label: string; value: string | number | undefined }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    </div>
+  )
+}
 
 export default function EmployeeDashboard() {
   const user = useAuthStore((state) => state.user)
+  const { stats } = useEmployeeDashboard()
+
+  const progressPct = stats && stats.total_tasks > 0
+    ? Math.round(((stats.approved_tasks) / stats.total_tasks) * 100)
+    : null
 
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
           <span className="text-blue-700 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">
-          Welcome, {user?.first_name}
-        </h2>
-        <p className="text-sm text-gray-500 mt-2">You're signed in as Employee.</p>
+        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 mt-1">You're signed in as Employee.</p>
       </div>
+
+      {stats && stats.total_tasks > 0 ? (
+        <>
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-sm font-medium text-gray-700">Plan Progress</p>
+              <p className="text-sm font-semibold text-gray-900">{progressPct}%</p>
+            </div>
+            <div className="w-full bg-gray-100 rounded-full h-2">
+              <div
+                className="bg-blue-600 h-2 rounded-full transition-all"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-500 mt-2">
+              {stats.approved_tasks} of {stats.total_tasks} tasks approved
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-4">
+            <StatCard label="In Progress" value={stats.in_progress_tasks} />
+            <StatCard label="Completed" value={stats.completed_tasks} />
+            <StatCard
+              label="Next Deadline"
+              value={stats.next_deadline ? format(new Date(stats.next_deadline), 'dd MMM yyyy') : 'None'}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+          <p className="text-sm text-gray-400">No active onboarding plan assigned.</p>
+        </div>
+      )}
 
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
         <h3 className="text-sm font-medium text-gray-700 mb-3">Quick links</h3>

--- a/apps/frontend/src/features/users/pages/HRDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.tsx
@@ -1,20 +1,36 @@
 import { useAuthStore } from '@/stores/authStore'
+import { useHRDashboard } from '@/features/dashboard/hooks/useHRDashboard'
+
+function StatCard({ label, value }: { label: string; value: number | undefined }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    </div>
+  )
+}
 
 export default function HRDashboard() {
   const user = useAuthStore((state) => state.user)
+  const { stats } = useHRDashboard()
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
           <span className="text-blue-700 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">
-          Welcome, {user?.first_name}
-        </h2>
-        <p className="text-sm text-gray-500 mt-2">You're signed in as HR Admin.</p>
+        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 mt-1">You're signed in as HR Admin.</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <StatCard label="Active Users" value={stats?.active_users} />
+        <StatCard label="Active Plans" value={stats?.active_plans} />
+        <StatCard label="Active Departments" value={stats?.active_departments} />
+        <StatCard label="Pending Approvals" value={stats?.pending_approvals} />
       </div>
     </div>
   )

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -1,22 +1,37 @@
 import { Link } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
+import { useManagerDashboard } from '@/features/dashboard/hooks/useManagerDashboard'
+
+function StatCard({ label, value }: { label: string; value: number | undefined }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    </div>
+  )
+}
 
 export default function ManagerDashboard() {
   const user = useAuthStore((state) => state.user)
+  const { stats } = useManagerDashboard()
 
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
           <span className="text-blue-700 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">
-          Welcome, {user?.first_name}
-        </h2>
-        <p className="text-sm text-gray-500 mt-2">You're signed in as Manager.</p>
+        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 mt-1">You're signed in as Manager.</p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <StatCard label="Active Plans" value={stats?.active_plans} />
+        <StatCard label="Pending Approvals" value={stats?.pending_approvals} />
+        <StatCard label="Employees" value={stats?.total_employees} />
       </div>
 
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -122,6 +122,16 @@ export default function HRDashboardLayout() {
             >
               Plans
             </NavLink>
+            <NavLink
+              to={ROUTES.HR_AUDIT}
+              className={({ isActive }) =>
+                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                }`
+              }
+            >
+              Audit Trail
+            </NavLink>
           </nav>
         </aside>
 

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -132,6 +132,16 @@ export default function HRDashboardLayout() {
             >
               Audit Trail
             </NavLink>
+            <NavLink
+              to={ROUTES.HR_REPORTS}
+              className={({ isActive }) =>
+                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                }`
+              }
+            >
+              Reports
+            </NavLink>
           </nav>
         </aside>
 

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -753,7 +753,7 @@ export interface components {
          * OnboardingPlanTaskStatus
          * @enum {string}
          */
-        OnboardingPlanTaskStatus: "not_started" | "in_progress" | "completed" | "approved" | "returned" | "cancelled";
+        OnboardingPlanTaskStatus: "not_started" | "in_progress" | "completed" | "approved" | "returned" | "overdue" | "cancelled";
         /** OnboardingPlanTaskUpdate */
         OnboardingPlanTaskUpdate: {
             /**

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -754,6 +754,25 @@ export interface components {
          * @enum {string}
          */
         OnboardingPlanTaskStatus: "not_started" | "in_progress" | "completed" | "approved" | "returned" | "overdue" | "cancelled";
+        /** TaskAttachmentResponse */
+        TaskAttachmentResponse: {
+            id: string;
+            plan_task_id: string;
+            uploaded_by: string;
+            file_name: string;
+            file_type: string;
+            file_size: number;
+            download_url: string;
+            created_at: string;
+        };
+        /** TaskCommentResponse */
+        TaskCommentResponse: {
+            id: string;
+            plan_task_id: string;
+            user_id: string;
+            content: string;
+            created_at: string;
+        };
         /** OnboardingPlanTaskUpdate */
         OnboardingPlanTaskUpdate: {
             /**

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -660,6 +660,10 @@ export interface components {
              * Format: date
              */
             plan_start_date: string;
+            /** Return Comment */
+            return_comment: string | null;
+            /** Attachments */
+            attachments: components["schemas"]["TaskAttachmentResponse"][];
         };
         /** OnboardingPlanResponse */
         OnboardingPlanResponse: {
@@ -748,6 +752,12 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            /** Return Comment */
+            return_comment: string | null;
+            /** Attachments */
+            attachments: components["schemas"]["TaskAttachmentResponse"][];
+            /** Comments */
+            comments: components["schemas"]["TaskCommentResponse"][];
         };
         /**
          * OnboardingPlanTaskStatus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,14 @@ services:
       SENDGRID_API_KEY: ${SENDGRID_API_KEY}
       SENDGRID_FROM_EMAIL: ${SENDGRID_FROM_EMAIL}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      GCS_BUCKET_NAME: ${GCS_BUCKET_NAME}
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS}
       LOGIN_RATE_LIMIT: "1000/minute"
     ports:
       - "8000:8000"
     volumes:
       - ./apps/backend:/app
+      - ./gcs-key.json:/app/gcs-key.json:ro
     depends_on:
       - db
 

--- a/docs/guides/tutorials/backend/011-state-machine.md
+++ b/docs/guides/tutorials/backend/011-state-machine.md
@@ -13,10 +13,12 @@ This guide explains how task status transitions are enforced in this project.
 ## Valid Transitions
 
 ```
-NOT_STARTED  →  IN_PROGRESS   (start)
-IN_PROGRESS  →  COMPLETED     (complete)
-COMPLETED    →  APPROVED       (approve — manager, US-015)
-COMPLETED    →  IN_PROGRESS   (return — manager, US-015)
+NOT_STARTED  →  IN_PROGRESS              (employee: start)
+IN_PROGRESS  →  COMPLETED               (employee: complete)
+OVERDUE      →  IN_PROGRESS             (employee: start — task missed deadline but not yet started)
+OVERDUE      →  COMPLETED               (employee: complete — task was in progress when deadline passed)
+COMPLETED    →  APPROVED                (manager: approve)
+COMPLETED    →  IN_PROGRESS             (manager: return — sends back for rework)
 ```
 
 CANCELLED and APPROVED are terminal — no further transitions allowed.
@@ -25,14 +27,18 @@ CANCELLED and APPROVED are terminal — no further transitions allowed.
 
 ## Implementation
 
-Transitions are expressed as a dict mapping the current status to the only valid next status:
+Transitions are expressed as a dict mapping each status to the **set** of valid next statuses:
 
 ```python
 # app/services/task_workflow_service.py
 
-VALID_TRANSITIONS = {
-    OnboardingPlanTaskStatus.NOT_STARTED: OnboardingPlanTaskStatus.IN_PROGRESS,
-    OnboardingPlanTaskStatus.IN_PROGRESS: OnboardingPlanTaskStatus.COMPLETED,
+VALID_TRANSITIONS: dict[OnboardingPlanTaskStatus, set[OnboardingPlanTaskStatus]] = {
+    OnboardingPlanTaskStatus.NOT_STARTED: {OnboardingPlanTaskStatus.IN_PROGRESS},
+    OnboardingPlanTaskStatus.IN_PROGRESS: {OnboardingPlanTaskStatus.COMPLETED},
+    OnboardingPlanTaskStatus.OVERDUE: {
+        OnboardingPlanTaskStatus.IN_PROGRESS,
+        OnboardingPlanTaskStatus.COMPLETED,
+    },
 }
 ```
 
@@ -42,7 +48,7 @@ A single helper validates the transition before any mutation:
 def _assert_transition(
     self, task: OnboardingPlanTask, target: OnboardingPlanTaskStatus
 ) -> None:
-    if VALID_TRANSITIONS.get(task.status) != target:
+    if target not in VALID_TRANSITIONS.get(task.status, set()):
         raise ValidationError(*messages.INVALID_TASK_TRANSITION)
 ```
 
@@ -60,9 +66,34 @@ async def start_task(self, db, task_id, current_user):
 
 ---
 
-## Why a Dict Instead of if/elif
+## Why a Set Instead of a Single Value
 
-A dict makes the full transition table readable at a glance. Adding a new transition (e.g. RETURNED → IN_PROGRESS for manager return) is a one-line change with no branching logic to touch.
+The first version of `VALID_TRANSITIONS` mapped each status to a single next status (a plain value, not a set). This broke when `OVERDUE` was introduced — an overdue task can transition to either `IN_PROGRESS` or `COMPLETED` depending on context. A set makes this explicit and keeps `_assert_transition` a one-liner (`target not in ...`) with no branching.
+
+Adding a new transition is a one-line change to the dict. No branching logic needs to change.
+
+---
+
+## OVERDUE Status
+
+The scheduler (`apscheduler`) runs nightly and transitions any `NOT_STARTED` or `IN_PROGRESS` task whose deadline has passed to `OVERDUE`. Once overdue, the task is still actionable — the employee can start it (→ `IN_PROGRESS`) or mark it complete directly (→ `COMPLETED`).
+
+---
+
+## return_comment
+
+When a manager returns a task, the task transitions `COMPLETED → IN_PROGRESS` and the return comment is stored on the task:
+
+```python
+async def return_task(self, db, task_id, current_user, data: ReturnTask):
+    task = await self._get_task_for_manager(db, task_id, current_user)
+    ...
+    task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+    task.return_comment = data.content   # stored on the task, shown to employee
+    await db.commit()
+```
+
+The `return_comment` column is nullable — it is only set when the task has been returned at least once. The employee sees this feedback in their plan page.
 
 ---
 
@@ -82,7 +113,9 @@ Invalid transitions return HTTP 400:
 
 ## Ownership Check
 
-Before asserting the transition, the service verifies the task belongs to the authenticated user's active plan:
+Before asserting the transition, the service verifies the task belongs to the right actor.
+
+**Employee actions** — task must belong to the employee's active plan:
 
 ```python
 async def _get_task_for_user(self, db, task_id, current_user):
@@ -95,4 +128,17 @@ async def _get_task_for_user(self, db, task_id, current_user):
     return task
 ```
 
-Returning `PLAN_TASK_NOT_FOUND` (not a 403) avoids leaking whether the task exists at all.
+**Manager actions** — task must belong to a plan the manager owns:
+
+```python
+async def _get_task_for_manager(self, db, task_id, current_user):
+    task = await plan_task_repository.get_by_id(db, task_id)
+    if not task:
+        raise NotFoundError(*messages.PLAN_TASK_NOT_FOUND)
+    plan = await plan_repository.get_by_id(db, task.plan_id)
+    if not plan or plan.manager_id != current_user.id:
+        raise NotFoundError(*messages.PLAN_TASK_NOT_FOUND)
+    return task
+```
+
+Both return `PLAN_TASK_NOT_FOUND` (not a 403) to avoid leaking whether the task exists at all.

--- a/docs/guides/tutorials/backend/012-cross-model-response.md
+++ b/docs/guides/tutorials/backend/012-cross-model-response.md
@@ -2,15 +2,16 @@
 
 ## The Problem
 
-The standard response pattern is `ResponseSchema.model_validate(orm_instance)` — it works when all response fields map directly to a single ORM object. This breaks when a response needs fields from **multiple related models**.
+The standard response pattern is `ResponseSchema.model_validate(orm_instance)` — it works when all response fields map directly to a single ORM object. This breaks in two situations:
 
-`ApprovalTaskResponse` is an example: it combines fields from `OnboardingPlanTask`, `OnboardingPlan`, and `User` (the employee). There is no single ORM object to validate against.
+1. A response needs fields from **multiple related models** (e.g. task + plan + employee name)
+2. A response needs a **computed field** that does not exist on the ORM object (e.g. a signed URL generated from `object_name`)
 
 ---
 
-## The Pattern
+## Pattern 1 — Fields from Multiple Models
 
-When a response spans multiple models, build it manually in the service layer.
+`ApprovalTaskResponse` combines fields from `OnboardingPlanTask`, `OnboardingPlan`, and `User` (the employee). There is no single ORM object to validate against.
 
 **1. Define the schema without `from_attributes`**
 
@@ -23,8 +24,10 @@ class ApprovalTaskResponse(BaseModel):
     title: str
     deadline: date
     status: OnboardingPlanTaskStatus
-    employee_name: str       # from plan.employee
-    plan_start_date: date    # from plan
+    employee_name: str          # from plan.employee
+    plan_start_date: date       # from plan
+    return_comment: str | None = None
+    attachments: list[TaskAttachmentResponse] = []
     # no model_config — cannot use from_attributes here
 ```
 
@@ -47,10 +50,17 @@ async def get_pending_approvals(self, db, current_user):
                     status=task.status,
                     employee_name=f"{plan.employee.first_name} {plan.employee.last_name}",
                     plan_start_date=plan.start_date,
-                    ...
+                    return_comment=task.return_comment,
+                    attachments=[
+                        TaskAttachmentResponse.model_validate(a)
+                        for a in task.attachments
+                        if a.deleted_at is None
+                    ],
                 ))
     return result
 ```
+
+`TaskAttachmentResponse.model_validate(a)` works here because `TaskAttachmentResponse` has a `model_validator` that handles ORM objects — see Pattern 2 below.
 
 **3. Repository must eager-load all needed relationships**
 
@@ -59,16 +69,68 @@ async def get_pending_approvals(self, db, current_user):
 
 select(OnboardingPlan)
     .options(
-        selectinload(OnboardingPlan.tasks),
+        selectinload(OnboardingPlan.tasks).options(
+            selectinload(OnboardingPlanTask.attachments),
+            selectinload(OnboardingPlanTask.comments),
+        ),
         selectinload(OnboardingPlan.employee),  # needed for employee_name
     )
 ```
 
 ---
 
+## Pattern 2 — Computed Fields Not Present on the ORM
+
+`TaskAttachmentResponse` needs a `download_url` field. This is a GCS signed URL generated at response time from `object_name`. The `TaskAttachment` ORM model has `object_name` but not `download_url`.
+
+`model_validate(orm_obj)` with `from_attributes=True` reads attributes by name — it would fail because `download_url` is not an attribute on the model.
+
+**Solution: `model_validator(mode='before')` with lazy import**
+
+```python
+# app/schemas/attachment.py
+
+class TaskAttachmentResponse(BaseModel):
+    id: uuid.UUID
+    plan_task_id: uuid.UUID
+    uploaded_by: uuid.UUID
+    file_name: str
+    file_type: str
+    file_size: int
+    download_url: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def compute_download_url(cls, v):
+        if isinstance(v, dict):
+            return v          # already built manually (e.g. in AttachmentService)
+        from app.services.storage_service import StorageService
+        storage = StorageService()
+        return {
+            'id': v.id,
+            'plan_task_id': v.plan_task_id,
+            'uploaded_by': v.uploaded_by,
+            'file_name': v.file_name,
+            'file_type': v.file_type,
+            'file_size': v.file_size,
+            'download_url': storage.signed_url(v.object_name),
+            'created_at': v.created_at,
+        }
+```
+
+The validator runs before Pydantic reads fields. When input is an ORM object (not a dict), it converts to dict and generates the signed URL inline. When input is already a dict (manual construction in `AttachmentService._to_response()`), it passes through unchanged.
+
+The import of `StorageService` is inside the method body — **lazy import** — so `google.cloud.storage` is never imported at module load time. See `013-pydantic-model-validator.md` for why this matters.
+
+---
+
 ## Rule
 
-> Use `model_validate(orm_instance)` when the response maps to one ORM object.
+> Use `model_validate(orm_instance)` when the response maps to one ORM object and all fields exist as attributes.
 > Build manually when the response aggregates fields from multiple objects.
+> Use `model_validator(mode='before')` when a field must be computed at serialization time.
 
 Manual construction is more verbose but avoids lazy-load errors and keeps the schema honest — it doesn't pretend to be an ORM-backed object when it isn't.

--- a/docs/guides/tutorials/backend/013-pydantic-model-validator.md
+++ b/docs/guides/tutorials/backend/013-pydantic-model-validator.md
@@ -1,0 +1,121 @@
+# Pydantic model_validator — Computed Fields from ORM Objects
+
+## The Problem
+
+The standard pattern `ResponseSchema.model_validate(orm_obj)` reads field values from ORM attributes by name. This breaks when the response needs a field that does not exist on the ORM model — for example, a signed URL that must be generated at serialization time from a stored `object_name`.
+
+```python
+class TaskAttachmentResponse(BaseModel):
+    download_url: str    # not an attribute on TaskAttachment ORM model
+    ...
+
+    model_config = ConfigDict(from_attributes=True)
+
+# This fails — Pydantic cannot find 'download_url' on the ORM object
+TaskAttachmentResponse.model_validate(attachment_orm_obj)
+```
+
+---
+
+## The Solution — `model_validator(mode='before')`
+
+A `model_validator(mode='before')` runs before Pydantic reads any fields. It receives the raw input — either a dict (when the schema is constructed manually) or an ORM object (when `model_validate` is called).
+
+This is the right place to convert an ORM object to a dict and compute any derived fields:
+
+```python
+from pydantic import BaseModel, ConfigDict, model_validator
+
+class TaskAttachmentResponse(BaseModel):
+    id: uuid.UUID
+    plan_task_id: uuid.UUID
+    uploaded_by: uuid.UUID
+    file_name: str
+    file_type: str
+    file_size: int
+    download_url: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def compute_download_url(cls, v):
+        if isinstance(v, dict):
+            return v          # already a dict — pass through unchanged
+        from app.services.storage_service import StorageService
+        storage = StorageService()
+        return {
+            'id': v.id,
+            'plan_task_id': v.plan_task_id,
+            'uploaded_by': v.uploaded_by,
+            'file_name': v.file_name,
+            'file_type': v.file_type,
+            'file_size': v.file_size,
+            'download_url': storage.signed_url(v.object_name),
+            'created_at': v.created_at,
+        }
+```
+
+After this, both construction paths work:
+
+```python
+# Path 1: called from AttachmentService._to_response() — already a dict
+TaskAttachmentResponse(id=..., download_url=signed_url, ...)
+
+# Path 2: called from plan response — ORM object, URL computed by validator
+TaskAttachmentResponse.model_validate(attachment_orm_obj)
+```
+
+---
+
+## Lazy Import — Why the Import Is Inside the Method
+
+The import of `StorageService` is inside the method body, not at the top of the file. This is intentional.
+
+**The problem with a module-level import:**
+
+```python
+# attachment.py — schema file
+from app.services.storage_service import StorageService  # ← module-level
+
+_storage = StorageService()
+```
+
+When `attachment.py` is imported (which happens at startup, because `onboarding_plan.py` schema imports from it), Python immediately imports `storage_service.py`, which imports `google.cloud.storage`. If the GCS library has any issue — missing package, namespace conflict, environment not set up — the entire backend fails to start, even if no attachment is being served.
+
+**With lazy import:**
+
+```python
+@model_validator(mode='before')
+@classmethod
+def compute_download_url(cls, v):
+    if isinstance(v, dict):
+        return v
+    from app.services.storage_service import StorageService   # ← lazy
+    storage = StorageService()
+    ...
+```
+
+`google.cloud.storage` is only imported when the validator actually runs — that is, only when an attachment is being serialized. Startup succeeds regardless. A GCS failure becomes a runtime error on the specific request that needs it, not a total startup failure.
+
+---
+
+## Rule
+
+> Schemas should be infrastructure-free at import time.
+> If a schema needs a service (storage, email, etc.), import it lazily inside the method that uses it — never at module level.
+
+This keeps the schema layer decoupled from infrastructure and prevents startup failures caused by unrelated service issues.
+
+---
+
+## When to Use This Pattern
+
+Use `model_validator(mode='before')` when:
+
+- A response field must be **computed** from another field on the ORM object (e.g. signed URL from `object_name`)
+- The ORM field that drives the computation has a **different name** than the response field
+- The computation requires calling a **service or external library**
+
+Do not use it when `from_attributes=True` is sufficient — i.e. when all response fields exist as attributes on the ORM object with the same names.

--- a/docs/guides/tutorials/frontend/008-openapi-typescript.md
+++ b/docs/guides/tutorials/frontend/008-openapi-typescript.md
@@ -83,6 +83,35 @@ The generated `src/types/api.ts` is committed to the repository — every develo
 
 ---
 
+## When the Backend Is Not Running — Manual Update
+
+If the backend cannot start (e.g. a broken Docker image, missing env vars, infrastructure outage), the generate command is unavailable. In that case, add the new fields directly to `src/types/api.ts` by hand and commit them. The file is just TypeScript — it can be edited like any other source file.
+
+Find the schema by name (`Ctrl+F` for the Python class name) and add the missing fields:
+
+```typescript
+// Before — backend schema added return_comment but types weren't regenerated
+OnboardingPlanTaskResponse: {
+    id: string;
+    title: string;
+    // ...
+};
+
+// After — manually added
+OnboardingPlanTaskResponse: {
+    id: string;
+    title: string;
+    // ...
+    return_comment: string | null;
+    attachments: components["schemas"]["TaskAttachmentResponse"][];
+    comments: components["schemas"]["TaskCommentResponse"][];
+};
+```
+
+Once the backend is running again, regenerate with the command above and commit the result. The manual edit and the generated output should be identical — if they differ, the generate command wins.
+
+---
+
 ## What NOT to Do
 
 Do not write manual TypeScript types that mirror BE schemas:

--- a/docs/guides/tutorials/frontend/018-ui-patterns.md
+++ b/docs/guides/tutorials/frontend/018-ui-patterns.md
@@ -144,7 +144,7 @@ Used when a single field needs to be editable without opening a separate page or
 
 ---
 
-## Status Badge
+## Status Badge — Boolean (Active / Inactive)
 
 Used to show active/inactive state consistently across all list pages:
 
@@ -157,3 +157,47 @@ Used to show active/inactive state consistently across all list pages:
   {item.is_active ? 'Active' : 'Inactive'}
 </span>
 ```
+
+---
+
+## Status Badge — Enum (Multiple States)
+
+Used when a field has more than two possible values and each needs its own colour. Declaring the labels and styles as `Record<EnumType, string>` outside the component gives TypeScript exhaustiveness — if a new enum value is added and the record is not updated, the build fails.
+
+```tsx
+import type { components } from '@/types/api'
+
+type OnboardingPlanTaskStatus = components['schemas']['OnboardingPlanTaskStatus']
+
+const STATUS_LABELS: Record<OnboardingPlanTaskStatus, string> = {
+  not_started: 'Not started',
+  in_progress: 'In progress',
+  completed: 'Completed',
+  approved: 'Approved',
+  returned: 'Returned',
+  overdue: 'Overdue',
+  cancelled: 'Cancelled',
+}
+
+const STATUS_STYLES: Record<OnboardingPlanTaskStatus, string> = {
+  not_started: 'bg-gray-100 text-gray-500 border-gray-200',
+  in_progress: 'bg-amber-50 text-amber-700 border-amber-100',
+  completed: 'bg-green-50 text-green-700 border-green-100',
+  approved: 'bg-green-100 text-green-800 border-green-200',
+  returned: 'bg-red-50 text-red-700 border-red-100',
+  overdue: 'bg-red-100 text-red-800 border-red-200',
+  cancelled: 'bg-gray-100 text-gray-400 border-gray-200',
+}
+```
+
+Usage in JSX:
+
+```tsx
+<span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${STATUS_STYLES[task.status]}`}>
+  {STATUS_LABELS[task.status]}
+</span>
+```
+
+### Why not a switch or if/else
+
+A `Record` makes the full mapping visible at a glance. Adding a new status is a two-line change (label + style) with no branching logic to touch. TypeScript enforces completeness — a missing key is a compile error.

--- a/docs/postmortems/2026-05-15-return-comment-data-loss.md
+++ b/docs/postmortems/2026-05-15-return-comment-data-loss.md
@@ -1,0 +1,98 @@
+# Post-mortem: return_comment Data Loss on Task Return
+
+**Date:** 2026-05-15
+**Branch:** `feature/fix-plan-flow-bugs`
+**Severity:** Critical — silent data loss
+**Outcome:** Column added to model + migration, schema updated, frontend renders feedback
+
+---
+
+## Initial State
+
+The task return flow was implemented in `task_workflow_service.py`:
+
+```python
+async def return_task(self, db, task_id, current_user, data: ReturnTask):
+    task = await self._get_task_for_manager(db, task_id, current_user)
+    task.status = OnboardingPlanTaskStatus.IN_PROGRESS
+    task.return_comment = data.content   # ← written here
+    await db.commit()
+```
+
+The `ManagerTaskReviewPage` had a Return modal where the manager typed a comment. Submitting the form called this service method.
+
+---
+
+## The Bug
+
+`task.return_comment = data.content` was written in the service but `return_comment` was never added to the `OnboardingPlanTask` model or the database schema.
+
+**Outcome A — AttributeError (SQLAlchemy strict mode):** Setting an attribute that doesn't exist on a mapped class raises `AttributeError` at runtime.
+
+**Outcome B — Silent loss (SQLAlchemy permissive mode):** The attribute is set on the Python object but SQLAlchemy does not include it in the `UPDATE` statement because it is not a mapped column. `await db.commit()` succeeds. No error is raised. The comment is gone.
+
+Either way, the manager's feedback never reached the database. The employee saw the task returned to `IN_PROGRESS` with no explanation.
+
+---
+
+## Root Cause
+
+The service code for `return_task` was written at the same time as the rest of the task workflow (US-015). The `return_comment` field was referenced in the service but the corresponding model column and Alembic migration were never created. The gap was not caught because:
+
+1. The return flow path was not covered by integration tests that checked the database state after the operation
+2. `return_comment` was also absent from `OnboardingPlanTaskResponse`, so the frontend had no way to display it even if it had been stored
+
+---
+
+## Discovery
+
+Found during a cross-feature code review of the plan flow, when tracing the full return path from the manager's modal submit to the employee's plan page. Reading `task_workflow_service.py` and `onboarding_plan_task.py` side by side made the missing column obvious.
+
+---
+
+## Fix
+
+**1. Model** (`app/models/onboarding_plan_task.py`):
+
+```python
+return_comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+```
+
+**2. Migration** (`alembic/versions/a1b2c3d4e5f6_add_return_comment_to_plan_tasks.py`):
+
+```python
+def upgrade() -> None:
+    op.add_column(
+        'onboarding_plan_tasks',
+        sa.Column('return_comment', sa.Text, nullable=True),
+    )
+```
+
+**3. Schema** (`app/schemas/onboarding_plan.py`):
+
+```python
+class OnboardingPlanTaskResponse(BaseModel):
+    ...
+    return_comment: str | None = None
+```
+
+**4. Frontend** (`EmployeePlanPage.tsx`) — renders the feedback box when `return_comment` is set:
+
+```tsx
+{task.return_comment && (
+  <div className="bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+    <p className="text-xs font-medium text-red-700 mb-0.5">Manager feedback</p>
+    <p className="text-xs text-red-600">{task.return_comment}</p>
+  </div>
+)}
+```
+
+---
+
+## Lessons Learned
+
+1. **Model, migration, and schema must be written together.** When a new field is referenced in service code, the model column, Alembic migration, and Pydantic response schema are all required. Missing any one of them silently breaks the feature.
+
+2. **Silent SQLAlchemy behaviour is dangerous.** Setting an unmapped attribute on an ORM object does not raise an error — it is simply ignored by `db.commit()`. There is no warning. Tests that only check HTTP status codes or response shapes will not catch this.
+
+3. **Test the full round-trip, not just the happy path status.** A test that calls `return_task` and checks the HTTP 200 response would pass even with this bug. The gap is only caught by a test that reads `return_comment` back from the database after the call.

--- a/docs/postmortems/2026-05-15-schema-service-import-startup-failure.md
+++ b/docs/postmortems/2026-05-15-schema-service-import-startup-failure.md
@@ -1,0 +1,133 @@
+# Post-mortem: Backend Startup Failure After Schema-Service Import
+
+**Date:** 2026-05-15
+**Branch:** `feature/fix-plan-flow-bugs`
+**Duration:** ~20 minutes
+**Outcome:** Lazy import pattern adopted, backend running
+
+---
+
+## Initial State
+
+As part of the plan flow bug fixes, `TaskAttachmentResponse` needed a `model_validator` that generates a `download_url` from the ORM object's `object_name`. The first implementation imported `StorageService` at the top of the schema file:
+
+```python
+# app/schemas/attachment.py — first attempt
+
+from app.services.storage_service import StorageService
+
+_storage = StorageService()
+
+class TaskAttachmentResponse(BaseModel):
+    ...
+    @model_validator(mode='before')
+    @classmethod
+    def compute_download_url(cls, v):
+        if isinstance(v, dict):
+            return v
+        return {
+            ...
+            'download_url': _storage.signed_url(v.object_name),
+        }
+```
+
+`onboarding_plan.py` schema was also updated to import from `attachment.py`:
+
+```python
+# app/schemas/onboarding_plan.py
+from app.schemas.attachment import TaskAttachmentResponse, TaskCommentResponse
+```
+
+---
+
+## The Failure
+
+After committing and starting the backend container:
+
+```
+File "/app/app/schemas/onboarding_plan.py", line 6, in <module>
+    from app.schemas.attachment import TaskAttachmentResponse, TaskCommentResponse
+  File "/app/app/schemas/attachment.py", line 4, in <module>
+    from app.services.storage_service import StorageService
+  File "/app/app/services/storage_service.py", line 3, in <module>
+    from google.cloud import storage
+ImportError: cannot import name 'storage' from 'google.cloud' (unknown location)
+```
+
+The backend refused to start. Login was unavailable.
+
+---
+
+## Diagnosis
+
+### Issue 1 — Module-level import in schema layer
+
+The import chain at startup:
+
+```
+router.py
+  → onboarding_plan API
+    → onboarding_plan schema
+      → attachment schema          ← NEW: added by this PR
+        → storage_service.py
+          → google.cloud.storage   ← fails here
+```
+
+Before this change, `storage_service.py` was only imported via `attachment_service.py` → `attachments` API router. After the change, the same module was reached earlier through the schema layer. The underlying `google.cloud.storage` import was now triggered at startup before any request was made.
+
+This revealed an architectural violation: **schema files should not import from the service layer**. Schemas define data shapes. Services contain infrastructure dependencies. Importing a service into a schema couples the data layer to the infrastructure layer and causes startup failures when the infrastructure is unavailable.
+
+### Issue 2 — Stale Docker image
+
+The `google.cloud.storage` import failure indicated the Docker image had a broken or outdated `google-cloud-storage` package installation. The package is in `requirements.txt` and was present on disk, but the running image had been built before a clean install was last performed.
+
+Clearing Python `__pycache__` from the host and restarting the container did not help — the image itself needed to be rebuilt.
+
+---
+
+## Fix
+
+**Part 1 — Lazy import inside the method body**
+
+Moving the import inside the validator method means `google.cloud.storage` is only imported when the validator actually runs, not at module load time:
+
+```python
+# app/schemas/attachment.py — fixed
+
+class TaskAttachmentResponse(BaseModel):
+    ...
+    @model_validator(mode='before')
+    @classmethod
+    def compute_download_url(cls, v):
+        if isinstance(v, dict):
+            return v
+        from app.services.storage_service import StorageService   # ← lazy
+        storage = StorageService()
+        return {
+            ...
+            'download_url': storage.signed_url(v.object_name),
+        }
+```
+
+Startup no longer touches `google.cloud.storage`. A GCS failure becomes a runtime error on the specific request that needs it, not a total startup failure.
+
+**Part 2 — Docker image rebuild**
+
+```powershell
+docker compose build backend
+docker compose up backend -d
+```
+
+Rebuilding ensured `google-cloud-storage` was freshly installed. After the rebuild the backend started cleanly.
+
+---
+
+## Lessons Learned
+
+1. **Schemas must not import from services.** Schema files (`app/schemas/`) define data shapes for serialization. Service files (`app/services/`) contain business logic and infrastructure clients (GCS, SendGrid, etc.). Importing a service into a schema drags infrastructure dependencies into the startup path, causing failures unrelated to the request being served.
+
+2. **Lazy imports isolate infrastructure from startup.** If a schema genuinely needs a service at serialization time (not at import time), import it inside the method body. Python caches modules — the first call imports it, subsequent calls reuse the cached module. There is no performance cost after the first invocation.
+
+3. **Stale Docker images hide real failures.** The `google.cloud.storage` error existed in the running image before this PR. It was masked because the import was not triggered at startup in the old code. When the new import chain reached it earlier, the failure surfaced. A rebuild was required — not just a restart. When a backend fails to start with an import error for a package that is in `requirements.txt`, rebuild the image first before investigating the code.
+
+4. **Test startup, not just functionality.** A backend that starts and a backend that serves requests are two different things. If import errors only surface at request time (e.g. lazy imports gone wrong), they will not be caught by unit tests. An integration test that starts the app and hits a health endpoint catches startup failures early.

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -767,7 +767,10 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ✅ File upload & comments (US-014b) — GCS bucket (`stepup-494114-attachments`, europe-west4), `TaskAttachment` + `TaskComment` models, signed URL download, MIME/size validation, expandable task panel in `EmployeePlanPage`
 
 ### Sprint 10 — Final Polish
-- ✅ Technical quality & polish (US-021) — critical plan flow bug fixes, API response completeness, UI consistency
+- ✅ US-021 Technical quality & polish — critical plan flow bug fixes, API response completeness, UI consistency
+- ⬜ List endpoint pagination
+- ⬜ Full E2E regression suite passing in CI
+- ⬜ README and Swagger polish for demo
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
@@ -843,7 +846,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.6 | 2026-05-14 | US-016 email notifications done; plan started, task completed/approved/returned emails added via SendGrid |
 | 1.7 | 2026-05-14 | Sprint 9 done; US-017 scheduler (OVERDUE status + APScheduler lifespan + 2 daily jobs), US-020 reports (3 endpoints + CSV + ReportsPage), comprehensive seed data, audit_log migration fix; Sprint 8 closed, Sprint 9 added, Sprint 10 scoped |
 | 1.8 | 2026-05-14 | US-014b done; GCS bucket created, TaskAttachment + TaskComment models, signed URL downloads, EmployeePlanPage expandable panel; Sprint 9 updated, Sprint 10 reduced to US-021 only |
-| 1.9 | 2026-05-15 | Sprint 10 US-021 done; critical bug fixes: return_comment DB column added, attachments/comments in API responses, manager review shows attachments, employee sees manager feedback, overdue button logic, PlanDetailPage navigation, error handling; DB schema updated |
+| 1.9 | 2026-05-15 | Sprint 10 US-021 done; return_comment added to DB schema; Sprint 10 remaining items (pagination, E2E, README) marked pending |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -757,15 +757,15 @@ ADR-007: Structured logging to GCP Cloud Logging
 ### Sprint 8 — Notifications ✅ Done
 - ✅ Email notifications via SendGrid — plan started (employee), task completed (manager), task approved/returned (employee)
 
-### Sprint 9 — Scheduler, Reports & Seed ✅ Done
+### Sprint 9 — Scheduler, Reports, Seed & File Upload ✅ Done
 - ✅ APScheduler wired into FastAPI lifespan — `mark_overdue_tasks` (00:05 UTC) and `send_deadline_reminders` (00:00 UTC) run daily
 - ✅ `OVERDUE` task status added — tasks past deadline auto-marked; employee and manager emailed; overdue tasks remain actionable
 - ✅ Admin reports — 3 endpoints (completion time by dept, task rates by template, bottlenecks) + CSV export + `ReportsPage` with date range filter
 - ✅ Comprehensive seed data — 6 users, 3 templates, 10 template tasks, 3 plans with realistic task statuses, 17 audit log entries
 - ✅ Fixed broken `audit_logs` migration chain
+- ✅ File upload & comments (US-014b) — GCS bucket (`stepup-494114-attachments`, europe-west4), `TaskAttachment` + `TaskComment` models, signed URL download, MIME/size validation, expandable task panel in `EmployeePlanPage`
 
-### Sprint 10 — File Upload & Quality
-- ⬜ File upload per task (US-014b, GCS integration)
+### Sprint 10 — Final Polish
 - ⬜ Technical quality & polish (US-021)
 
 ### Bonus (If Time Allows)
@@ -841,6 +841,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.5 | 2026-05-14 | Sprint 7 done; role-based dashboards (US-018) and audit trail (US-019) complete; bug fixes (auth is_active, login error display, return_comment, playwright config); Sprint 8 scope updated |
 | 1.6 | 2026-05-14 | US-016 email notifications done; plan started, task completed/approved/returned emails added via SendGrid |
 | 1.7 | 2026-05-14 | Sprint 9 done; US-017 scheduler (OVERDUE status + APScheduler lifespan + 2 daily jobs), US-020 reports (3 endpoints + CSV + ReportsPage), comprehensive seed data, audit_log migration fix; Sprint 8 closed, Sprint 9 added, Sprint 10 scoped |
+| 1.8 | 2026-05-14 | US-014b done; GCS bucket created, TaskAttachment + TaskComment models, signed URL downloads, EmployeePlanPage expandable panel; Sprint 9 updated, Sprint 10 reduced to US-021 only |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -767,15 +767,7 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ✅ File upload & comments (US-014b) — GCS bucket (`stepup-494114-attachments`, europe-west4), `TaskAttachment` + `TaskComment` models, signed URL download, MIME/size validation, expandable task panel in `EmployeePlanPage`
 
 ### Sprint 10 — Final Polish
-- ✅ Critical bug fixes (US-021 — Technical quality & polish)
-  - `return_comment` column was missing from DB — manager feedback silently lost on task return; model + migration added
-  - `attachments` and `comments` missing from API responses — page reload lost uploaded files; Pydantic schema updated, `TaskAttachmentResponse` now serialises from ORM via `model_validator`
-  - Manager review page could not see employee attachments — `ApprovalTaskResponse` extended
-  - Employee could not see manager feedback — `return_comment` rendered in `EmployeePlanPage`
-  - Overdue task showed both Start and Complete buttons simultaneously — FE button logic fixed
-  - `PlanDetailPage` back link pointed to create-plan form; task status badge only showed two states
-  - `handleApprove` had no error handling — silent failure removed task from list on API error
-  - `OnboardingPlanTaskRepository.get_by_id` now eager-loads `attachments` and `comments` to prevent `MissingGreenlet` errors on async serialisation
+- ✅ Technical quality & polish (US-021) — critical plan flow bug fixes, API response completeness, UI consistency
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -578,7 +578,8 @@ onboarding_plans    → id, user_id, template_id, manager_id,
 
 onboarding_plan_tasks → id, plan_id, template_task_id, title,
                         description, status, deadline,
-                        is_required, order, deleted_at, created_at
+                        is_required, order, return_comment,
+                        deleted_at, created_at
 
 task_comments       → id, plan_task_id, user_id, content, created_at
 
@@ -766,7 +767,15 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ✅ File upload & comments (US-014b) — GCS bucket (`stepup-494114-attachments`, europe-west4), `TaskAttachment` + `TaskComment` models, signed URL download, MIME/size validation, expandable task panel in `EmployeePlanPage`
 
 ### Sprint 10 — Final Polish
-- ⬜ Technical quality & polish (US-021)
+- ✅ Critical bug fixes (US-021 — Technical quality & polish)
+  - `return_comment` column was missing from DB — manager feedback silently lost on task return; model + migration added
+  - `attachments` and `comments` missing from API responses — page reload lost uploaded files; Pydantic schema updated, `TaskAttachmentResponse` now serialises from ORM via `model_validator`
+  - Manager review page could not see employee attachments — `ApprovalTaskResponse` extended
+  - Employee could not see manager feedback — `return_comment` rendered in `EmployeePlanPage`
+  - Overdue task showed both Start and Complete buttons simultaneously — FE button logic fixed
+  - `PlanDetailPage` back link pointed to create-plan form; task status badge only showed two states
+  - `handleApprove` had no error handling — silent failure removed task from list on API error
+  - `OnboardingPlanTaskRepository.get_by_id` now eager-loads `attachments` and `comments` to prevent `MissingGreenlet` errors on async serialisation
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
@@ -842,6 +851,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.6 | 2026-05-14 | US-016 email notifications done; plan started, task completed/approved/returned emails added via SendGrid |
 | 1.7 | 2026-05-14 | Sprint 9 done; US-017 scheduler (OVERDUE status + APScheduler lifespan + 2 daily jobs), US-020 reports (3 endpoints + CSV + ReportsPage), comprehensive seed data, audit_log migration fix; Sprint 8 closed, Sprint 9 added, Sprint 10 scoped |
 | 1.8 | 2026-05-14 | US-014b done; GCS bucket created, TaskAttachment + TaskComment models, signed URL downloads, EmployeePlanPage expandable panel; Sprint 9 updated, Sprint 10 reduced to US-021 only |
+| 1.9 | 2026-05-15 | Sprint 10 US-021 done; critical bug fixes: return_comment DB column added, attachments/comments in API responses, manager review shows attachments, employee sees manager feedback, overdue button logic, PlanDetailPage navigation, error handling; DB schema updated |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -749,21 +749,16 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ✅ UI polish: user dropdown menu, template creation, clickable cards, role-specific profile routes
 - ⬜ US-014b (file upload) deferred to Sprint 8
 
-### Sprint 7 — Notifications, Scheduler & Dashboards
-- Email notifications via SendGrid (plan started, task completed, approved, returned, deadline reminder)
-- APScheduler: daily overdue detection + deadline reminders
-- Employee dashboard (progress, tasks by status, upcoming deadlines)
-- Manager dashboard (team overview, pending approvals, overdue alerts)
-- HR Admin dashboard (system-wide stats, avg completion time)
+### Sprint 7 — Dashboards & Audit Trail ✅ Done
+- ✅ Role-based dashboards: HR Admin (active users, plans, departments, pending approvals), Manager (active plans, pending approvals, team size), Employee (progress bar, task breakdown, next deadline)
+- ✅ Audit trail: all key actions logged (user invited/registered/deactivated, plan created, task started/completed/approved/returned), HR Admin filter page
+- ✅ Bug fixes: deactivated user login rejection, login form error display, return_comment persistence, playwright baseURL env var
 
-### Sprint 7 — Audit Trail, Reports & Quality
-- Audit trail (complete, uneditable, filterable, paginated)
-- Admin reports + CSV export
-- Pagination on all list endpoints
-- Health check endpoint + request ID middleware
-- Full E2E regression suite (Playwright)
-- README + Swagger polish
-- Demo seed data finalized
+### Sprint 8 — Notifications, Scheduler & Reports
+- Email notifications via SendGrid (task completed, approved/returned, deadline reminder)
+- APScheduler: daily overdue detection + deadline reminders
+- Admin reports (completion rates, avg time per department, bottlenecks)
+- File upload (US-014b, GCS integration)
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
@@ -835,6 +830,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.2 | 2026-05-03 | Updated error handling to app/errors/ package, updated monorepo structure |
 | 1.3 | 2026-05-12 | Sprints 2–4 marked done, Sprint 5 in progress; added reactivate to user management; updated onboarding_plans schema to match implementation |
 | 1.4 | 2026-05-14 | Sprint 5 done, Sprint 6 done; task workflow and manager review complete; department added to invitation; US-014b deferred to Sprint 8; sprint numbering adjusted |
+| 1.5 | 2026-05-14 | Sprint 7 done; role-based dashboards (US-018) and audit trail (US-019) complete; bug fixes (auth is_active, login error display, return_comment, playwright config); Sprint 8 scope updated |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -754,11 +754,19 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ✅ Audit trail: all key actions logged (user invited/registered/deactivated, plan created, task started/completed/approved/returned), HR Admin filter page
 - ✅ Bug fixes: deactivated user login rejection, login form error display, return_comment persistence, playwright baseURL env var
 
-### Sprint 8 — Notifications, Scheduler & Reports
+### Sprint 8 — Notifications ✅ Done
 - ✅ Email notifications via SendGrid — plan started (employee), task completed (manager), task approved/returned (employee)
-- ⬜ APScheduler: daily overdue detection + deadline reminders (US-017)
-- ⬜ Admin reports (completion rates, avg time per department) (US-020)
-- ⬜ File upload (US-014b, GCS integration)
+
+### Sprint 9 — Scheduler, Reports & Seed ✅ Done
+- ✅ APScheduler wired into FastAPI lifespan — `mark_overdue_tasks` (00:05 UTC) and `send_deadline_reminders` (00:00 UTC) run daily
+- ✅ `OVERDUE` task status added — tasks past deadline auto-marked; employee and manager emailed; overdue tasks remain actionable
+- ✅ Admin reports — 3 endpoints (completion time by dept, task rates by template, bottlenecks) + CSV export + `ReportsPage` with date range filter
+- ✅ Comprehensive seed data — 6 users, 3 templates, 10 template tasks, 3 plans with realistic task statuses, 17 audit log entries
+- ✅ Fixed broken `audit_logs` migration chain
+
+### Sprint 10 — File Upload & Quality
+- ⬜ File upload per task (US-014b, GCS integration)
+- ⬜ Technical quality & polish (US-021)
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
@@ -832,6 +840,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.4 | 2026-05-14 | Sprint 5 done, Sprint 6 done; task workflow and manager review complete; department added to invitation; US-014b deferred to Sprint 8; sprint numbering adjusted |
 | 1.5 | 2026-05-14 | Sprint 7 done; role-based dashboards (US-018) and audit trail (US-019) complete; bug fixes (auth is_active, login error display, return_comment, playwright config); Sprint 8 scope updated |
 | 1.6 | 2026-05-14 | US-016 email notifications done; plan started, task completed/approved/returned emails added via SendGrid |
+| 1.7 | 2026-05-14 | Sprint 9 done; US-017 scheduler (OVERDUE status + APScheduler lifespan + 2 daily jobs), US-020 reports (3 endpoints + CSV + ReportsPage), comprehensive seed data, audit_log migration fix; Sprint 8 closed, Sprint 9 added, Sprint 10 scoped |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -755,10 +755,10 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ✅ Bug fixes: deactivated user login rejection, login form error display, return_comment persistence, playwright baseURL env var
 
 ### Sprint 8 — Notifications, Scheduler & Reports
-- Email notifications via SendGrid (task completed, approved/returned, deadline reminder)
-- APScheduler: daily overdue detection + deadline reminders
-- Admin reports (completion rates, avg time per department, bottlenecks)
-- File upload (US-014b, GCS integration)
+- ✅ Email notifications via SendGrid — plan started (employee), task completed (manager), task approved/returned (employee)
+- ⬜ APScheduler: daily overdue detection + deadline reminders (US-017)
+- ⬜ Admin reports (completion rates, avg time per department) (US-020)
+- ⬜ File upload (US-014b, GCS integration)
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
@@ -831,6 +831,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.3 | 2026-05-12 | Sprints 2–4 marked done, Sprint 5 in progress; added reactivate to user management; updated onboarding_plans schema to match implementation |
 | 1.4 | 2026-05-14 | Sprint 5 done, Sprint 6 done; task workflow and manager review complete; department added to invitation; US-014b deferred to Sprint 8; sprint numbering adjusted |
 | 1.5 | 2026-05-14 | Sprint 7 done; role-based dashboards (US-018) and audit trail (US-019) complete; bug fixes (auth is_active, login error display, return_comment, playwright config); Sprint 8 scope updated |
+| 1.6 | 2026-05-14 | US-016 email notifications done; plan started, task completed/approved/returned emails added via SendGrid |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/scrum/review/sprint-10.md
+++ b/docs/scrum/review/sprint-10.md
@@ -1,0 +1,63 @@
+# Sprint 10 — Review
+
+## Sprint Goal
+Employees can upload documents and add comments to onboarding tasks. Files are stored securely in GCP Cloud Storage. Managers can see uploaded files when reviewing tasks.
+
+## Sprint Goal Achieved?
+Yes — US-014b fully delivered.
+
+## Completed User Stories
+
+| US | Title | Status | Notes |
+|----|-------|--------|-------|
+| US-014b | File Upload & Comments | Done | GCS bucket, 3 endpoints, signed URLs, expandable task panel, 6 unit tests |
+
+## Incomplete / Deferred User Stories
+
+| US | Title | Reason | Moved to |
+|----|-------|--------|----------|
+| US-021 | Technical Quality & Polish | Natural final sprint | Sprint 11 |
+
+## Metrics
+- USs planned: 1
+- USs completed: 1
+- PRs merged: 1 (#194)
+
+## Key Decisions Made This Sprint
+
+### GCS bucket created via gcloud — not Console
+Bucket `stepup-494114-attachments` was created programmatically using `gcloud storage buckets create`. Compute service account granted `Storage Object Admin` directly on the bucket (not project-wide). `GCS_BUCKET_NAME` stored in Secret Manager. Service account key created for local dev, added to `.gitignore` and mounted as a read-only Docker volume.
+
+### Files stored by object name, signed URL generated per request
+`TaskAttachment.object_name` stores the GCS path (`tasks/{task_id}/{uuid}_{filename}`). The `file_url` / `download_url` in the API response is a v4 signed URL generated fresh on each request (1-hour expiry). This means no stale URLs in the DB — each API call returns a valid link.
+
+### StorageService lazily initializes GCS client
+`StorageService._client` is `None` on import and instantiated on first call. This prevents the GCS client from being created at module load time (which would fail in test environments without credentials), and lets unit tests patch `storage.Client` easily.
+
+### Attachment delete guarded by two rules: ownership + approval state
+- Only the uploader can delete their own attachment (`uploaded_by == current_user.id` check)
+- Once the task is `APPROVED`, attachments are locked — prevents post-approval evidence tampering
+- Both checks happen before GCS delete call to avoid partial state
+
+### Plan repository extended to selectinload attachments + comments
+All plan queries (`get_by_id`, `get_active_by_user`, `get_all_by_manager`) now chain `selectinload(OnboardingPlan.tasks).options(selectinload(OnboardingPlanTask.attachments), selectinload(OnboardingPlanTask.comments))`. This is the correct async SQLAlchemy pattern for nested eager loading — avoids N+1 and lazy-load errors in async context.
+
+### FE uses expandable task rows — not a separate page
+Clicking a task title expands an inline panel (attachments + upload input + comment form). No new route needed. `useEmployeePlanPage` hook manages optimistic state updates for all three operations (upload, delete, comment) without refetching the full plan.
+
+## Allowed File Types
+
+| MIME type | Extension |
+|-----------|-----------|
+| `application/pdf` | .pdf |
+| `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | .docx |
+| `image/png` | .png |
+| `image/jpeg` | .jpg / .jpeg |
+
+Max size: 10 MB
+
+## Notes
+- `gcs-key.json` is gitignored via `*.json` pattern (with exceptions for `package.json`, `tsconfig*.json`, `turbo.json`)
+- `GOOGLE_APPLICATION_CREDENTIALS` env var points to `/app/gcs-key.json` inside the container
+- In Cloud Run production, application default credentials are used automatically — no key file needed
+- Signed URLs use v4 signing (more secure than v2) and require `google.auth` service account credentials

--- a/docs/scrum/review/sprint-7.md
+++ b/docs/scrum/review/sprint-7.md
@@ -1,0 +1,85 @@
+# Sprint 7 — Review
+
+## Sprint Goal
+All three roles have a dedicated dashboard with real stats. Every key action in the system is logged in an audit trail. HR Admin can view and filter the full audit history.
+
+## Sprint Goal Achieved?
+Yes — dashboards and audit trail delivered. Reports (US-020) and remaining open issues deferred.
+
+## Completed User Stories
+
+| US | Title | Status | Notes |
+|----|-------|--------|-------|
+| US-018 | Role-Based Dashboards | Done | BE stats endpoints + FE stat cards for all 3 roles |
+| US-019 | Audit Trail | Done | Model, migration, repo, service, API endpoint, FE page |
+
+## Incomplete / Deferred User Stories
+
+| US | Title | Reason | Moved to |
+|----|-------|--------|----------|
+| US-020 | Admin Reports & Export | Not started — no blocking dependency, next sprint | Sprint 8 |
+| US-016 | Email Notifications | Requires hooking into task/plan events across services | Sprint 8 |
+| US-017 | Automated Scheduler | Depends on US-016 (deadline reminder emails) | Sprint 8 |
+
+## Metrics
+- USs planned: 3 (US-018, US-019, US-020)
+- USs completed: 2
+- USs deferred: 1 (US-020 → Sprint 8)
+
+## Bug Fixes (Outside US Scope)
+
+Four bugs identified through code review and fixed before US work:
+
+| File | Bug | Fix |
+|------|-----|-----|
+| `auth_service.py` | Deactivated users could log in — token issued, then 401 on next request | Added `is_active` check in `login()` before issuing tokens |
+| `useLoginForm.ts` | API errors silently logged to console — user saw no feedback on wrong password | Added `submitError` state; catch block sets it instead of `console.error` |
+| `task_workflow_service.py` + `OnboardingPlanTask` | Manager's return comment validated but never persisted — no column on model | Added `return_comment: Text` column, Alembic migration, assignment in service |
+| `playwright.config.ts` | `baseURL` hardcoded to Docker hostname — local test runs always failed | Reads `process.env.BASE_URL` with `http://localhost:5173` fallback |
+
+## Key Decisions Made This Sprint
+
+### Dashboard stats via dedicated `/dashboard` endpoints
+Stats for each role are served from role-gated endpoints (`/api/v1/dashboard/hr`, `/manager`, `/employee`). Count methods added to existing repositories (`count_active()` on User, OnboardingPlan, Department; `count_completed_across_active_plans()` and `count_completed_by_manager()` on OnboardingPlanTask). Service layer orchestrates repo calls, no direct SQL in service.
+
+### Audit log in separate post-commit transaction
+`AuditService.log()` is called **after** the main `db.commit()` in every service method. This ensures:
+- A bug in audit logging never rolls back the main operation
+- Audit entry is only written for actions that actually committed
+
+Each hook follows the pattern:
+```python
+# main operation
+task.status = APPROVED
+await db.commit()
+await db.refresh(task)
+# audit — separate commit
+await audit_service.log(db, ...)
+await db.commit()
+```
+
+### `AuditLog` model is append-only — no `TimestampMixin`
+`AuditLog` does not extend `TimestampMixin` (which adds `updated_at` and `deleted_at`). Audit logs must never be updated or soft-deleted. Only `created_at` is stored. Indexes on `action` and `created_at` for filter/sort performance.
+
+### Actions logged
+
+| Action | Triggered by |
+|--------|-------------|
+| `user.invited` | HR Admin sends invitation |
+| `user.registered` | New user completes registration |
+| `user.deactivated` | HR Admin deactivates user |
+| `user.reactivated` | HR Admin reactivates user |
+| `user.updated` | HR Admin changes user role or department |
+| `plan.created` | HR Admin creates onboarding plan |
+| `plan.task_cancelled` | HR Admin cancels task within plan |
+| `task.started` | Employee starts task |
+| `task.completed` | Employee marks task complete |
+| `task.approved` | Manager approves task |
+| `task.returned` | Manager returns task with comment |
+
+## Notes
+- All previous BE tests still passing (141)
+- All previous FE tests still passing (61)
+- Migration `a3f1c8e2d047`: adds `return_comment` to `onboarding_plan_tasks`
+- Migration `c9a4b2e1f8d3`: creates `audit_logs` table with two indexes
+- Open US issues with completed code: #119, #120, #121, #123, #124, #125, #130, #182 — code done, GitHub issues not yet closed

--- a/docs/scrum/review/sprint-8.md
+++ b/docs/scrum/review/sprint-8.md
@@ -1,0 +1,48 @@
+# Sprint 8 — Review
+
+## Sprint Goal
+Email notifications are sent at every key workflow stage. APScheduler automatically marks overdue tasks daily and sends deadline reminders. HR Admins have access to basic onboarding reports. Employees can upload documents to tasks stored in GCP Cloud Storage.
+
+## Sprint Goal Achieved?
+Partially — US-016 (email notifications) delivered. US-017, US-020, US-014b deferred.
+
+## Completed User Stories
+
+| US | Title | Status | Notes |
+|----|-------|--------|-------|
+| US-016 | Email Notifications | Done | 4 email types via SendGrid; hooks in plan and task workflow services |
+
+## Incomplete / Deferred User Stories
+
+| US | Title | Reason | Moved to |
+|----|-------|--------|----------|
+| US-017 | Automated Scheduler | Depends on deadline reminder email (US-016 prerequisite now done) | Sprint 9 |
+| US-020 | Admin Reports & Export | No blocking dependency | Sprint 9 |
+| US-014b | File Upload & Comments | GCS infrastructure required | Sprint 9 |
+
+## Metrics
+- USs planned: 4
+- USs completed: 1
+- USs deferred: 3
+
+## Key Decisions Made This Sprint
+
+### Email calls are fire-and-forget after commit
+All email sends happen after `db.commit()` inside a `try/except` block. SendGrid failure is logged via `logger.error` but never raises — the main operation always succeeds regardless of email outcome. This matches the pattern established for audit logging.
+
+### Recipient fetched via user_repository, not relationship
+`task_workflow_service` already had the task and plan in scope. Rather than adding `selectinload` for employee/manager to plan queries (which would affect all callers), recipient users are fetched with a separate `user_repository.get_by_id()` call inside the email block. This keeps the change minimal and non-invasive.
+
+### Emails sent
+
+| Method | To | When |
+|--------|----|------|
+| `send_plan_started_email` | Employee | HR Admin creates onboarding plan |
+| `send_task_completed_email` | Manager | Employee marks task complete |
+| `send_task_approved_email` | Employee | Manager approves task |
+| `send_task_returned_email` | Employee | Manager returns task — feedback comment included in email body |
+
+## Notes
+- No schema changes — email notifications are stateless (no DB writes)
+- No migration needed
+- US-017 (deadline reminder) is now unblocked — `send_deadline_reminder_email` method can be added to `EmailService` and called from the scheduler

--- a/docs/scrum/review/sprint-9.md
+++ b/docs/scrum/review/sprint-9.md
@@ -1,0 +1,61 @@
+# Sprint 9 — Review
+
+## Sprint Goal
+APScheduler marks overdue tasks daily and sends deadline reminders. HR Admin reports are live. Seed data covers all features end-to-end.
+
+## Sprint Goal Achieved?
+Yes — US-017, US-020, and seed data fully delivered.
+
+## Completed User Stories
+
+| US | Title | Status | Notes |
+|----|-------|--------|-------|
+| US-017 | Automated Scheduler | Done | APScheduler lifespan, 2 daily jobs, OVERDUE enum + migration, 3 email templates, 9 unit tests |
+| US-020 | Admin Reports & Export | Done | 3 report endpoints, CSV export per endpoint, ReportsPage with date range filter, 10 BE + 5 FE tests |
+| Seed | Comprehensive seed data | Done | 6 users, 3 templates, 3 plans with varied statuses, 17 audit logs, migration chain fixed |
+
+## Incomplete / Deferred User Stories
+
+| US | Title | Reason | Moved to |
+|----|-------|--------|----------|
+| US-014b | File Upload & Comments | GCS infrastructure required | Sprint 10 |
+| US-021 | Technical Quality & Polish | Natural last sprint | Sprint 10 |
+
+## Metrics
+- USs planned: 2 (US-017, US-020)
+- USs completed: 2
+- PRs merged: 2 (#192 Reports, #193 Scheduler)
+
+## Key Decisions Made This Sprint
+
+### APScheduler wired into FastAPI lifespan (not a separate process)
+APScheduler runs inside the FastAPI process via `lifespan`. This is the simplest approach for Cloud Run (single process, no worker dyno). If job load grows, the scheduler can be extracted to a dedicated Cloud Run job triggered by Cloud Scheduler.
+
+### OVERDUE tasks remain actionable via two transitions
+`VALID_TRANSITIONS` updated to `dict[status, set[status]]`. OVERDUE → IN_PROGRESS (start) and OVERDUE → COMPLETED (complete directly). This handles both cases: task was NOT_STARTED when marked overdue, and task was IN_PROGRESS when marked overdue.
+
+### Reports use direct SQL aggregations — no dedicated analytics layer
+All three report queries run direct SQLAlchemy aggregations against `onboarding_plan_tasks` and `onboarding_plans`. No materialized views or separate analytics tables. Acceptable for current scale; can be optimized if report query time exceeds 1s in production.
+
+### CSV export via `?format=csv` query param — no separate endpoint
+Each report endpoint returns JSON by default and CSV when `?format=csv`. The FE uses `apiClient` with `responseType: blob` + `URL.createObjectURL` for download — avoids CORS issues since cookies are sent automatically.
+
+### Seed is fully idempotent — skip if exists by fixed ID
+All seed entities use fixed UUIDs. Each section checks for existence before inserting. Running the seed twice is safe. New entities are added by extending the constants, not by modifying logic.
+
+### audit_logs migration chain was broken — fixed
+`c9a4b2e1f8d3` referenced a lost parent `a3f1c8e2d047`. Fixed by repointing to `14e90742db5f` (the actual head). An inline `index=True` on the `action` column conflicted with the explicit `op.create_index` call — fixed by removing `index=True` from the column definition.
+
+## Emails Added This Sprint
+
+| Method | To | When |
+|--------|----|------|
+| `send_task_overdue_email` | Employee | Task deadline passed, marked OVERDUE |
+| `send_task_overdue_manager_email` | Manager | Employee's task marked OVERDUE |
+| `send_deadline_reminder_email` | Employee | Task deadline is in exactly 2 days |
+
+## Notes
+- `mark_overdue_tasks` runs at 00:05 UTC daily (after reminders) to avoid race conditions
+- Scheduler jobs log summary: `tasks_marked=N, emails_sent=N, errors=N`
+- Email failures inside jobs are caught per-task and logged — one failure does not abort the entire job run
+- OVERDUE status displayed as red badge in `EmployeePlanPage`; Start and Complete buttons both visible on OVERDUE tasks

--- a/docs/scrum/sprint-goals.md
+++ b/docs/scrum/sprint-goals.md
@@ -25,9 +25,18 @@ All three roles have a dedicated dashboard with real system stats. Every key act
 Email notifications are sent at every key workflow stage. APScheduler automatically marks overdue tasks daily and sends deadline reminders. HR Admins have access to basic onboarding reports. Employees can upload documents to tasks stored in GCP Cloud Storage.
 
 - ✅ US-016 Email Notifications
-- ⬜ US-017 Automated Scheduler
-- ⬜ US-020 Admin Reports
-- ⬜ US-014b File Upload
+- ⬜ US-017 Automated Scheduler (deferred to Sprint 9)
+- ⬜ US-020 Admin Reports (deferred to Sprint 9)
+- ⬜ US-014b File Upload (deferred to Sprint 9)
 
-## Sprint 9 — Quality & Polish
-All list endpoints are paginated. Seed data creates a realistic demo dataset. Full E2E regression suite passes in CI pipeline. README and Swagger polished for demo.
+## Sprint 9 — Scheduler, Reports & Quality
+APScheduler marks overdue tasks daily and sends deadline reminders. HR Admin reports are live. Seed data covers all features. Quality polish and remaining US-021 work.
+
+- ✅ US-017 Automated Scheduler (APScheduler lifespan, mark_overdue_tasks, send_deadline_reminders, OVERDUE enum)
+- ✅ US-020 Admin Reports & Export (3 endpoints, CSV export, ReportsPage with date filter)
+- ✅ Comprehensive seed data (alice, bob, manager2, Product template, 3 plans, 17 audit logs)
+- ⬜ US-014b File Upload
+- ⬜ US-021 Technical Quality & Polish
+
+## Sprint 10 — Final Polish & File Upload
+All list endpoints are paginated. File upload via GCS. Full E2E regression suite passes in CI. README and Swagger polished for demo.

--- a/docs/scrum/sprint-goals.md
+++ b/docs/scrum/sprint-goals.md
@@ -24,5 +24,10 @@ All three roles have a dedicated dashboard with real system stats. Every key act
 ## Sprint 8 — Notifications, Scheduler, Reports & Attachments
 Email notifications are sent at every key workflow stage. APScheduler automatically marks overdue tasks daily and sends deadline reminders. HR Admins have access to basic onboarding reports. Employees can upload documents to tasks stored in GCP Cloud Storage.
 
+- ✅ US-016 Email Notifications
+- ⬜ US-017 Automated Scheduler
+- ⬜ US-020 Admin Reports
+- ⬜ US-014b File Upload
+
 ## Sprint 9 — Quality & Polish
 All list endpoints are paginated. Seed data creates a realistic demo dataset. Full E2E regression suite passes in CI pipeline. README and Swagger polished for demo.

--- a/docs/scrum/sprint-goals.md
+++ b/docs/scrum/sprint-goals.md
@@ -15,17 +15,14 @@ HR Admin can create, manage, and clone onboarding templates. Templates have orde
 ## Sprint 5 — Plan & Task Workflow
 HR Admin can create onboarding plans for employees from templates. Employees can view their plan and work through tasks. Managers can approve or return completed tasks with feedback. The full task state machine is enforced.
 
-## Sprint 6 — Notifications & Scheduler
-Email notifications are sent at every key workflow stage. APScheduler automatically marks overdue tasks daily and sends deadline reminders 2 days in advance.
+## Sprint 6 — Task Workflow & Manager Review
+Employee can view their onboarding plan and work through tasks. Managers can approve or return completed tasks with mandatory feedback. The full task state machine is enforced.
 
-## Sprint 7 — Dashboards
-All three roles have a dedicated dashboard. Employees see their progress, managers see their team's status and pending approvals, HR Admins see system-wide onboarding health.
+## Sprint 7 — Dashboards & Audit Trail ✅ Done
+All three roles have a dedicated dashboard with real system stats. Every key action is logged in an uneditable audit trail visible and filterable by HR Admins.
 
-## Sprint 8 — Attachments
-Employees can upload documents to tasks. Files are stored in GCP Cloud Storage, validated by MIME type, and accessible to managers via presigned URLs.
+## Sprint 8 — Notifications, Scheduler, Reports & Attachments
+Email notifications are sent at every key workflow stage. APScheduler automatically marks overdue tasks daily and sends deadline reminders. HR Admins have access to basic onboarding reports. Employees can upload documents to tasks stored in GCP Cloud Storage.
 
-## Sprint 9 — Audit Trail & Reports
-Every action in the system is logged in the audit trail. HR Admins can filter and export audit data. Basic onboarding reports are available with CSV export.
-
-## Sprint 10 — Quality & Polish
-All list endpoints are paginated. Seed data creates a realistic demo dataset. Health check endpoint is in place. Full E2E regression passes in CI pipeline.
+## Sprint 9 — Quality & Polish
+All list endpoints are paginated. Seed data creates a realistic demo dataset. Full E2E regression suite passes in CI pipeline. README and Swagger polished for demo.

--- a/docs/scrum/sprint-goals.md
+++ b/docs/scrum/sprint-goals.md
@@ -35,8 +35,8 @@ APScheduler marks overdue tasks daily and sends deadline reminders. HR Admin rep
 - ✅ US-017 Automated Scheduler (APScheduler lifespan, mark_overdue_tasks, send_deadline_reminders, OVERDUE enum)
 - ✅ US-020 Admin Reports & Export (3 endpoints, CSV export, ReportsPage with date filter)
 - ✅ Comprehensive seed data (alice, bob, manager2, Product template, 3 plans, 17 audit logs)
-- ⬜ US-014b File Upload
+- ✅ US-014b File Upload & Comments (GCS bucket, TaskAttachment, TaskComment, signed URLs, EmployeePlanPage panel)
 - ⬜ US-021 Technical Quality & Polish
 
-## Sprint 10 — Final Polish & File Upload
-All list endpoints are paginated. File upload via GCS. Full E2E regression suite passes in CI. README and Swagger polished for demo.
+## Sprint 10 — Final Polish
+All list endpoints are paginated. Full E2E regression suite passes in CI. README and Swagger polished for demo. US-021 quality & polish.


### PR DESCRIPTION
## Summary

- **return_comment missing from DB**: Added `return_comment` column to `onboarding_plan_tasks` table with Alembic migration — manager return feedback was being silently lost
- **attachments/comments missing from API responses**: `OnboardingPlanTaskResponse` and `ApprovalTaskResponse` now include `attachments`, `comments`, and `return_comment`; `TaskAttachmentResponse` generates signed GCS URLs from ORM objects via model_validator
- **Manager review page blind to attachments**: `ManagerTaskReviewPage` now renders employee-uploaded files
- **Employee can't see manager feedback**: `EmployeePlanPage` shows return_comment in a styled feedback box when task status is `returned`
- **Overdue task showed both Start + Complete**: Fixed to show only Start for overdue tasks; Complete only appears after transitioning to in_progress
- **PlanDetailPage back link broken**: Was pointing to create-plan form; now points to HR dashboard
- **PlanDetailPage status badge incomplete**: Only handled not_started/cancelled; now covers all 7 statuses
- **handleApprove silent failure**: Wrapped in try/catch so failed approvals don't disappear from the list

## Test plan

- [ ] Manager returns a task with a comment → employee sees the feedback box on reload
- [ ] Employee uploads a file → manager sees it in the review page
- [ ] Task in overdue status → only Start button visible (no Mark as Complete)
- [ ] After starting an overdue task → in_progress → Mark as Complete appears
- [ ] PlanDetailPage back arrow → goes to HR dashboard
- [ ] Task badges show correct status/color for all states (in_progress, completed, approved, returned, overdue)
- [ ] Run Alembic migration on a dev DB → column added without errors