### PR TITLE
feat: Dark / Light / System theme toggle (US-198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ StepUp replaces email chains and spreadsheets with a structured onboarding workf
 - View manager feedback on returned tasks
 - Notifications on plan start, task approved/returned, deadline reminders
 
+### UI
+- Dark / Light / System theme toggle in the hamburger menu — persists across reloads
+
 ### System (automated)
 - APScheduler marks tasks as Overdue daily when deadline passes
 - Deadline reminder emails sent 2 days before due date
@@ -124,7 +127,7 @@ stepup/
         features/     # Feature modules (auth, plan, template, audit, reports…)
         layouts/      # Dashboard layouts per role
         lib/          # Axios client + interceptor
-        stores/       # Zustand auth store
+        stores/       # Zustand stores (authStore, themeStore)
         types/        # api.ts (OpenAPI-aligned type definitions)
       tests/e2e/      # Playwright E2E tests
   docs/

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -7,7 +7,10 @@
     <script>
       (function () {
         try {
-          var theme = localStorage.getItem('stepup-theme') || 'system'
+          var v = localStorage.getItem('stepup-theme')
+          // Clear old zustand-persist JSON format if present
+          if (v && v[0] === '{') { localStorage.removeItem('stepup-theme'); v = null }
+          var theme = v === 'light' || v === 'dark' || v === 'system' ? v : 'system'
           if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
             document.documentElement.classList.add('dark')
           }

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>StepUp</title>
+    <script>
+      (function () {
+        try {
+          var s = JSON.parse(localStorage.getItem('stepup-theme') || '{}')
+          var theme = (s.state && s.state.theme) || 'system'
+          if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark')
+          }
+        } catch (e) {}
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -7,8 +7,7 @@
     <script>
       (function () {
         try {
-          var s = JSON.parse(localStorage.getItem('stepup-theme') || '{}')
-          var theme = (s.state && s.state.theme) || 'system'
+          var theme = localStorage.getItem('stepup-theme') || 'system'
           if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
             document.documentElement.classList.add('dark')
           }

--- a/apps/frontend/src/components/KebabMenu.tsx
+++ b/apps/frontend/src/components/KebabMenu.tsx
@@ -7,9 +7,9 @@ interface KebabMenuItem {
 }
 
 const variantClass: Record<NonNullable<KebabMenuItem['variant']>, string> = {
-  default: 'text-gray-700 hover:bg-gray-50',
-  danger: 'text-red-600 hover:bg-red-50',
-  success: 'text-green-600 hover:bg-green-50',
+  default: 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700',
+  danger: 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20',
+  success: 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20',
 }
 
 export default function KebabMenu({ items }: { items: KebabMenuItem[] }) {
@@ -21,7 +21,7 @@ export default function KebabMenu({ items }: { items: KebabMenuItem[] }) {
     <div className="relative inline-flex">
       <button
         onClick={() => setIsOpen((prev) => !prev)}
-        className="text-gray-400 hover:text-gray-600 w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-colors text-lg"
+        className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-lg"
         aria-label="actions"
       >
         ⋮
@@ -30,7 +30,7 @@ export default function KebabMenu({ items }: { items: KebabMenuItem[] }) {
       {isOpen && (
         <>
           <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
-          <div className="absolute right-0 bottom-full mb-1 z-20 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[140px]">
+          <div className="absolute right-0 bottom-full mb-1 z-20 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-1 min-w-[140px]">
             {items.map((item) => (
               <button
                 key={item.label}

--- a/apps/frontend/src/components/ThemeProvider.tsx
+++ b/apps/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { useThemeStore } from '@/stores/themeStore'
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const theme = useThemeStore((state) => state.theme)
+
+  useEffect(() => {
+    const root = document.documentElement
+
+    function applyTheme(t: string) {
+      if (t === 'dark') {
+        root.classList.add('dark')
+      } else if (t === 'light') {
+        root.classList.remove('dark')
+      } else {
+        root.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches)
+      }
+    }
+
+    applyTheme(theme)
+
+    if (theme === 'system') {
+      const mq = window.matchMedia('(prefers-color-scheme: dark)')
+      const handler = (e: MediaQueryListEvent) => root.classList.toggle('dark', e.matches)
+      mq.addEventListener('change', handler)
+      return () => mq.removeEventListener('change', handler)
+    }
+  }, [theme])
+
+  return <>{children}</>
+}

--- a/apps/frontend/src/components/ThemeProvider.tsx
+++ b/apps/frontend/src/components/ThemeProvider.tsx
@@ -1,20 +1,3 @@
-import { useEffect } from 'react'
-import { useThemeStore, applyTheme } from '@/stores/themeStore'
-
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const theme = useThemeStore((state) => state.theme)
-
-  useEffect(() => {
-    applyTheme(theme)
-
-    if (theme === 'system') {
-      const mq = window.matchMedia('(prefers-color-scheme: dark)')
-      const handler = (e: MediaQueryListEvent) =>
-        document.documentElement.classList.toggle('dark', e.matches)
-      mq.addEventListener('change', handler)
-      return () => mq.removeEventListener('change', handler)
-    }
-  }, [theme])
-
   return <>{children}</>
 }

--- a/apps/frontend/src/components/ThemeProvider.tsx
+++ b/apps/frontend/src/components/ThemeProvider.tsx
@@ -1,3 +1,27 @@
+import { useEffect } from 'react'
+import { useThemeStore, applyTheme, readTheme } from '@/stores/themeStore'
+
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const theme = useThemeStore((s) => s.theme)
+
+  // Apply theme whenever store changes — this is the React-side guarantee
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  // Apply on mount in case module-level call ran before DOM was ready
+  useEffect(() => {
+    applyTheme(readTheme())
+  }, [])
+
+  // System mode: keep in sync with OS changes
+  useEffect(() => {
+    if (theme !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = () => applyTheme('system')
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [theme])
+
   return <>{children}</>
 }

--- a/apps/frontend/src/components/ThemeProvider.tsx
+++ b/apps/frontend/src/components/ThemeProvider.tsx
@@ -1,20 +1,18 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useThemeStore, applyTheme, readTheme } from '@/stores/themeStore'
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme = useThemeStore((s) => s.theme)
+  const [htmlClass, setHtmlClass] = useState('')
 
-  // Apply theme whenever store changes — this is the React-side guarantee
   useEffect(() => {
     applyTheme(theme)
   }, [theme])
 
-  // Apply on mount in case module-level call ran before DOM was ready
   useEffect(() => {
     applyTheme(readTheme())
   }, [])
 
-  // System mode: keep in sync with OS changes
   useEffect(() => {
     if (theme !== 'system') return
     const mq = window.matchMedia('(prefers-color-scheme: dark)')
@@ -23,5 +21,28 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
     return () => mq.removeEventListener('change', handler)
   }, [theme])
 
-  return <>{children}</>
+  // DEBUG: watch html classList changes
+  useEffect(() => {
+    setHtmlClass(document.documentElement.className)
+    const obs = new MutationObserver(() =>
+      setHtmlClass(document.documentElement.className)
+    )
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => obs.disconnect()
+  }, [])
+
+  return (
+    <>
+      {children}
+      {/* DEBUG OVERLAY — remove after fix confirmed */}
+      <div style={{
+        position: 'fixed', bottom: 8, right: 8, zIndex: 99999,
+        background: 'black', color: 'lime', padding: '6px 10px',
+        fontSize: 11, fontFamily: 'monospace', borderRadius: 4,
+        pointerEvents: 'none',
+      }}>
+        store: <b>{theme}</b> | html.class: "<b>{htmlClass}</b>"
+      </div>
+    </>
+  )
 }

--- a/apps/frontend/src/components/ThemeProvider.tsx
+++ b/apps/frontend/src/components/ThemeProvider.tsx
@@ -1,27 +1,16 @@
 import { useEffect } from 'react'
-import { useThemeStore } from '@/stores/themeStore'
+import { useThemeStore, applyTheme } from '@/stores/themeStore'
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme = useThemeStore((state) => state.theme)
 
   useEffect(() => {
-    const root = document.documentElement
-
-    function applyTheme(t: string) {
-      if (t === 'dark') {
-        root.classList.add('dark')
-      } else if (t === 'light') {
-        root.classList.remove('dark')
-      } else {
-        root.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches)
-      }
-    }
-
     applyTheme(theme)
 
     if (theme === 'system') {
       const mq = window.matchMedia('(prefers-color-scheme: dark)')
-      const handler = (e: MediaQueryListEvent) => root.classList.toggle('dark', e.matches)
+      const handler = (e: MediaQueryListEvent) =>
+        document.documentElement.classList.toggle('dark', e.matches)
       mq.addEventListener('change', handler)
       return () => mq.removeEventListener('change', handler)
     }

--- a/apps/frontend/src/components/ThemeProvider.tsx
+++ b/apps/frontend/src/components/ThemeProvider.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useThemeStore, applyTheme, readTheme } from '@/stores/themeStore'
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme = useThemeStore((s) => s.theme)
-  const [htmlClass, setHtmlClass] = useState('')
 
   useEffect(() => {
     applyTheme(theme)
@@ -21,28 +20,5 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
     return () => mq.removeEventListener('change', handler)
   }, [theme])
 
-  // DEBUG: watch html classList changes
-  useEffect(() => {
-    setHtmlClass(document.documentElement.className)
-    const obs = new MutationObserver(() =>
-      setHtmlClass(document.documentElement.className)
-    )
-    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
-    return () => obs.disconnect()
-  }, [])
-
-  return (
-    <>
-      {children}
-      {/* DEBUG OVERLAY — remove after fix confirmed */}
-      <div style={{
-        position: 'fixed', bottom: 8, right: 8, zIndex: 99999,
-        background: 'black', color: 'lime', padding: '6px 10px',
-        fontSize: 11, fontFamily: 'monospace', borderRadius: 4,
-        pointerEvents: 'none',
-      }}>
-        store: <b>{theme}</b> | html.class: "<b>{htmlClass}</b>"
-      </div>
-    </>
-  )
+  return <>{children}</>
 }

--- a/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
+++ b/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
@@ -17,11 +17,11 @@ const ACTION_LABELS: Record<string, string> = {
 }
 
 const ACTION_COLORS: Record<string, string> = {
-  'user.deactivated': 'text-red-600 bg-red-50',
-  'user.reactivated': 'text-green-700 bg-green-50',
-  'task.approved': 'text-green-700 bg-green-50',
-  'task.returned': 'text-orange-600 bg-orange-50',
-  'plan.task_cancelled': 'text-red-600 bg-red-50',
+  'user.deactivated': 'text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30',
+  'user.reactivated': 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-900/30',
+  'task.approved': 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-900/30',
+  'task.returned': 'text-orange-600 bg-orange-50 dark:text-orange-400 dark:bg-orange-900/30',
+  'plan.task_cancelled': 'text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30',
 }
 
 const ACTION_OPTIONS = [
@@ -47,13 +47,13 @@ export default function AuditLogPage() {
     <div className="max-w-4xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Audit Trail</h2>
-          <p className="text-sm text-gray-500 mt-0.5">System activity log for all key actions.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Audit Trail</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">System activity log for all key actions.</p>
         </div>
         <select
           value={selectedAction}
           onChange={(e) => setSelectedAction(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           {ACTION_OPTIONS.map((opt) => (
             <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -61,36 +61,36 @@ export default function AuditLogPage() {
         </select>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
         {loading ? (
-          <p className="text-sm text-gray-400 px-5 py-4">Loading...</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">Loading...</p>
         ) : logs.length === 0 ? (
-          <p className="text-sm text-gray-400 px-5 py-4">No audit logs found.</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">No audit logs found.</p>
         ) : (
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-100">
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Date</th>
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Action</th>
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Entity</th>
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Detail</th>
+              <tr className="border-b border-gray-100 dark:border-gray-700">
+                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Date</th>
+                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Action</th>
+                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Entity</th>
+                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Detail</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
               {logs.map((log) => (
-                <tr key={log.id} className="hover:bg-gray-50">
-                  <td className="px-5 py-3 text-gray-500 whitespace-nowrap">
+                <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
                     {format(new Date(log.created_at), 'dd MMM yyyy HH:mm')}
                   </td>
                   <td className="px-5 py-3">
-                    <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${ACTION_COLORS[log.action] ?? 'text-blue-700 bg-blue-50'}`}>
+                    <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${ACTION_COLORS[log.action] ?? 'text-blue-700 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30'}`}>
                       {ACTION_LABELS[log.action] ?? log.action}
                     </span>
                   </td>
-                  <td className="px-5 py-3 text-gray-500 font-mono text-xs truncate max-w-[180px]">
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 font-mono text-xs truncate max-w-[180px]">
                     {log.entity_type} · {log.entity_id.slice(0, 8)}…
                   </td>
-                  <td className="px-5 py-3 text-gray-500 truncate max-w-[200px]">
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 truncate max-w-[200px]">
                     {log.detail ?? '—'}
                   </td>
                 </tr>

--- a/apps/frontend/src/features/department/pages/DepartmentsPage.tsx
+++ b/apps/frontend/src/features/department/pages/DepartmentsPage.tsx
@@ -24,8 +24,8 @@ export default function DepartmentsPage() {
     <div className="max-w-3xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Departments</h2>
-          <p className="text-sm text-gray-500 mt-0.5">Manage your organisation's departments.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Departments</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Manage your organisation's departments.</p>
         </div>
         <button
           onClick={() => setShowAddForm((v) => !v)}
@@ -36,18 +36,18 @@ export default function DepartmentsPage() {
       </div>
 
       {pageError && (
-        <div className="mb-4 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+        <div className="mb-4 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-3">
           {pageError}
         </div>
       )}
 
       {showAddForm && (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-5 py-4 mb-4 flex gap-2">
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-5 py-4 mb-4 flex gap-2">
           <input
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder="Department name"
-            className="flex-1 border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           <button
             onClick={handleCreate}
@@ -58,34 +58,34 @@ export default function DepartmentsPage() {
         </div>
       )}
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-100 bg-gray-50 text-left">
-              <th className="px-5 py-3.5 font-medium text-gray-600 rounded-tl-xl">Name</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600">Status</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 text-right rounded-tr-xl">Actions</th>
+            <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 text-left">
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 rounded-tl-xl">Name</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Status</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 text-right rounded-tr-xl">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
             {departments.map((d) => (
-              <tr key={d.id} className="hover:bg-slate-50 transition-colors">
+              <tr key={d.id} className="hover:bg-slate-50 dark:hover:bg-gray-700/50 transition-colors">
                 <td className="px-5 py-3.5">
                   {editingId === d.id ? (
                     <input
                       value={editingName}
                       onChange={(e) => setEditingName(e.target.value)}
-                      className="border border-gray-300 rounded px-2 py-1 text-sm w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm w-full bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     />
                   ) : (
-                    <span className="font-medium text-gray-900">{d.name}</span>
+                    <span className="font-medium text-gray-900 dark:text-gray-100">{d.name}</span>
                   )}
                 </td>
                 <td className="px-5 py-3.5">
                   <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium border ${
                     d.is_active
-                      ? 'bg-green-50 text-green-700 border-green-100'
-                      : 'bg-gray-100 text-gray-500 border-gray-200'
+                      ? 'bg-green-50 text-green-700 border-green-100 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+                      : 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
                   }`}>
                     {d.is_active ? 'Active' : 'Inactive'}
                   </span>
@@ -95,13 +95,13 @@ export default function DepartmentsPage() {
                     <div className="flex justify-end gap-2">
                       <button
                         onClick={handleUpdate}
-                        className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 hover:border-blue-300 px-3 py-1.5 rounded-lg transition-colors"
+                        className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 border border-blue-200 dark:border-blue-700 hover:border-blue-300 px-3 py-1.5 rounded-lg transition-colors"
                       >
                         Save
                       </button>
                       <button
                         onClick={cancelEdit}
-                        className="text-xs text-gray-500 hover:text-gray-700 border border-gray-200 px-3 py-1.5 rounded-lg transition-colors"
+                        className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 border border-gray-200 dark:border-gray-600 px-3 py-1.5 rounded-lg transition-colors"
                       >
                         Cancel
                       </button>
@@ -119,7 +119,7 @@ export default function DepartmentsPage() {
             ))}
             {departments.length === 0 && (
               <tr>
-                <td colSpan={3} className="px-5 py-8 text-center text-gray-400 text-sm">
+                <td colSpan={3} className="px-5 py-8 text-center text-gray-400 dark:text-gray-500 text-sm">
                   No departments yet.
                 </td>
               </tr>

--- a/apps/frontend/src/features/invitation/pages/InviteUserPage.tsx
+++ b/apps/frontend/src/features/invitation/pages/InviteUserPage.tsx
@@ -2,47 +2,39 @@ import { format } from 'date-fns'
 import { useInviteUserForm } from '@/features/invitation/hooks/useInviteUserForm'
 import { ROLE_LABELS } from '@/constants/userRoles'
 
+const inputCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500'
+
 export default function InviteUserPage() {
   const { register, handleSubmit, errors, onSubmit, handleResend, invitations, departments, pageError, success } = useInviteUserForm()
 
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Invite User</h2>
-        <p className="text-sm text-gray-500 mt-0.5">Send an invitation email to onboard a new user.</p>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Invite User</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Send an invitation email to onboard a new user.</p>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5 mb-6">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-            <input
-              {...register('email')}
-              placeholder="name@company.com"
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            {errors.email && <p className="text-xs text-red-600 mt-1">{errors.email.message}</p>}
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email</label>
+            <input {...register('email')} placeholder="name@company.com" className={inputCls} />
+            {errors.email && <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.email.message}</p>}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
-            <select
-              {...register('role')}
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            >
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Role</label>
+            <select {...register('role')} className={inputCls}>
               <option value="employee">Employee</option>
               <option value="manager">Manager</option>
               <option value="hr_admin">HR Admin</option>
             </select>
-            {errors.role && <p className="text-xs text-red-600 mt-1">{errors.role.message}</p>}
+            {errors.role && <p className="text-xs text-red-600 dark:text-red-400 mt-1">{errors.role.message}</p>}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Department</label>
-            <select
-              {...register('department_id')}
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            >
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Department</label>
+            <select {...register('department_id')} className={inputCls}>
               <option value="">No department</option>
               {departments.map((d) => (
                 <option key={d.id} value={d.id}>{d.name}</option>
@@ -51,42 +43,39 @@ export default function InviteUserPage() {
           </div>
 
           {pageError && (
-            <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3.5 py-2">
+            <p className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-100 dark:border-red-800 rounded-lg px-3.5 py-2">
               {pageError}
             </p>
           )}
           {success && (
-            <p className="text-sm text-green-700 bg-green-50 border border-green-100 rounded-lg px-3.5 py-2">
+            <p className="text-sm text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-900/20 border border-green-100 dark:border-green-800 rounded-lg px-3.5 py-2">
               Invitation sent successfully.
             </p>
           )}
 
-          <button
-            type="submit"
-            className="bg-blue-700 hover:bg-blue-800 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-          >
+          <button type="submit" className="bg-blue-700 hover:bg-blue-800 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors">
             Send Invitation
           </button>
         </form>
       </div>
 
       <div>
-        <h3 className="text-sm font-medium text-gray-700 mb-3">Pending Invitations</h3>
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Pending Invitations</h3>
         {invitations.length === 0 ? (
-          <p className="text-sm text-gray-400">No pending invitations.</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">No pending invitations.</p>
         ) : (
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100">
+          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm divide-y divide-gray-100 dark:divide-gray-700">
             {invitations.map((inv) => (
               <div key={inv.id} className="px-5 py-3.5 flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">{inv.email}</p>
-                  <p className="text-xs text-gray-500 mt-0.5">
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{inv.email}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                     {ROLE_LABELS[inv.role] ?? inv.role} · Expires {format(new Date(inv.expires_at), 'dd MMM yyyy')}
                   </p>
                 </div>
                 <button
                   onClick={() => handleResend(inv.id)}
-                  className="text-xs border border-gray-300 hover:border-gray-400 text-gray-600 font-medium px-3 py-1.5 rounded-lg transition-colors shrink-0"
+                  className="text-xs border border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-gray-600 dark:text-gray-400 font-medium px-3 py-1.5 rounded-lg transition-colors shrink-0"
                 >
                   Resend
                 </button>

--- a/apps/frontend/src/features/plan/pages/CreatePlanPage.tsx
+++ b/apps/frontend/src/features/plan/pages/CreatePlanPage.tsx
@@ -1,5 +1,7 @@
 import { useCreatePlanPage } from '@/features/plan/hooks/useCreatePlanPage'
 
+const selectCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500'
+
 export default function CreatePlanPage() {
   const {
     employees, managers, templates,
@@ -14,24 +16,20 @@ export default function CreatePlanPage() {
   return (
     <div className="max-w-xl mx-auto">
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Create Onboarding Plan</h2>
-        <p className="text-sm text-gray-500 mt-0.5">Assign an onboarding plan to an employee.</p>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Create Onboarding Plan</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Assign an onboarding plan to an employee.</p>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-6 space-y-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-6 space-y-4">
         {error && (
-          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-3">
             {error}
           </div>
         )}
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">Employee</label>
-          <select
-            value={userId}
-            onChange={(e) => setUserId(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Employee</label>
+          <select value={userId} onChange={(e) => setUserId(e.target.value)} className={selectCls}>
             <option value="">Select employee</option>
             {employees.map((u) => (
               <option key={u.id} value={u.id}>{u.first_name} {u.last_name}</option>
@@ -40,12 +38,8 @@ export default function CreatePlanPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">Template</label>
-          <select
-            value={templateId}
-            onChange={(e) => setTemplateId(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Template</label>
+          <select value={templateId} onChange={(e) => setTemplateId(e.target.value)} className={selectCls}>
             <option value="">Select template</option>
             {templates.map((t) => (
               <option key={t.id} value={t.id}>{t.name}</option>
@@ -54,12 +48,8 @@ export default function CreatePlanPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">Manager</label>
-          <select
-            value={managerId}
-            onChange={(e) => setManagerId(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Manager</label>
+          <select value={managerId} onChange={(e) => setManagerId(e.target.value)} className={selectCls}>
             <option value="">Select manager</option>
             {managers.map((u) => (
               <option key={u.id} value={u.id}>{u.first_name} {u.last_name}</option>
@@ -68,12 +58,12 @@ export default function CreatePlanPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">Start Date</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Start Date</label>
           <input
             type="date"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className={selectCls}
           />
         </div>
 

--- a/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
+++ b/apps/frontend/src/features/plan/pages/EmployeePlanPage.tsx
@@ -17,21 +17,16 @@ const STATUS_LABELS: Record<OnboardingPlanTaskStatus, string> = {
 }
 
 const STATUS_STYLES: Record<OnboardingPlanTaskStatus, string> = {
-  not_started: 'bg-gray-100 text-gray-500 border-gray-200',
-  in_progress: 'bg-amber-50 text-amber-700 border-amber-100',
-  completed: 'bg-green-50 text-green-700 border-green-100',
-  approved: 'bg-green-100 text-green-800 border-green-200',
-  returned: 'bg-red-50 text-red-700 border-red-100',
-  overdue: 'bg-red-100 text-red-800 border-red-200',
-  cancelled: 'bg-gray-100 text-gray-400 border-gray-200',
+  not_started: 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600',
+  in_progress: 'bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-900/30 dark:text-amber-400 dark:border-amber-800',
+  completed: 'bg-green-50 text-green-700 border-green-100 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800',
+  approved: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/40 dark:text-green-300 dark:border-green-700',
+  returned: 'bg-red-50 text-red-700 border-red-100 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800',
+  overdue: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/40 dark:text-red-300 dark:border-red-700',
+  cancelled: 'bg-gray-100 text-gray-400 border-gray-200 dark:bg-gray-700 dark:text-gray-500 dark:border-gray-600',
 }
 
-function AttachmentList({
-  attachments,
-  taskId,
-  canDelete,
-  onDelete,
-}: {
+function AttachmentList({ attachments, taskId, canDelete, onDelete }: {
   attachments: TaskAttachmentResponse[]
   taskId: string
   canDelete: boolean
@@ -41,18 +36,13 @@ function AttachmentList({
   return (
     <ul className="mt-2 space-y-1">
       {attachments.map((att) => (
-        <li key={att.id} className="flex items-center gap-2 text-xs text-gray-600">
-          <a href={att.download_url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline truncate max-w-[200px]">
+        <li key={att.id} className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+          <a href={att.download_url} target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline truncate max-w-[200px]">
             {att.file_name}
           </a>
-          <span className="text-gray-400">({(att.file_size / 1024).toFixed(0)} KB)</span>
+          <span className="text-gray-400 dark:text-gray-500">({(att.file_size / 1024).toFixed(0)} KB)</span>
           {canDelete && (
-            <button
-              onClick={() => onDelete(taskId, att.id)}
-              className="text-red-400 hover:text-red-600 text-xs"
-            >
-              ✕
-            </button>
+            <button onClick={() => onDelete(taskId, att.id)} className="text-red-400 hover:text-red-600 text-xs">✕</button>
           )}
         </li>
       ))}
@@ -65,7 +55,7 @@ function CommentList({ comments }: { comments: TaskCommentResponse[] }) {
   return (
     <ul className="mt-2 space-y-1">
       {comments.map((c) => (
-        <li key={c.id} className="text-xs text-gray-600 bg-gray-50 rounded px-2 py-1">
+        <li key={c.id} className="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-700 rounded px-2 py-1">
           {c.content}
         </li>
       ))}
@@ -88,8 +78,8 @@ export default function EmployeePlanPage() {
   if (notFound) {
     return (
       <div className="max-w-2xl mx-auto">
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-          <p className="text-gray-500 text-sm">No active onboarding plan assigned to you yet.</p>
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-10 text-center">
+          <p className="text-gray-500 dark:text-gray-400 text-sm">No active onboarding plan assigned to you yet.</p>
         </div>
       </div>
     )
@@ -118,13 +108,13 @@ export default function EmployeePlanPage() {
   return (
     <div className="max-w-2xl mx-auto">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">My Onboarding Plan</h2>
-        <span className="text-sm text-gray-500">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">My Onboarding Plan</h2>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
           {completedCount} / {totalCount} tasks done
         </span>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm divide-y divide-gray-100 dark:divide-gray-700">
         {plan.tasks.map((task) => {
           const isExpanded = expandedTask === task.id
           const attachments: TaskAttachmentResponse[] = (task as any).attachments ?? []
@@ -138,36 +128,28 @@ export default function EmployeePlanPage() {
                   <div className="flex items-center gap-2 flex-wrap">
                     <button
                       onClick={() => toggleExpand(task.id)}
-                      className={`text-sm font-medium text-left ${task.status === 'cancelled' ? 'line-through text-gray-400' : 'text-gray-900'}`}
+                      className={`text-sm font-medium text-left ${task.status === 'cancelled' ? 'line-through text-gray-400 dark:text-gray-500' : 'text-gray-900 dark:text-gray-100'}`}
                     >
                       {task.title}
                     </button>
                     <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${STATUS_STYLES[task.status]}`}>
                       {STATUS_LABELS[task.status]}
                     </span>
-                    <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600' : 'text-gray-400'}`}>
+                    <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}`}>
                       {task.is_required ? 'Required' : 'Optional'}
                     </span>
                   </div>
-                  <p className="text-xs mt-0.5 text-gray-500">
-                    Due: {task.deadline}
-                  </p>
+                  <p className="text-xs mt-0.5 text-gray-500 dark:text-gray-400">Due: {task.deadline}</p>
                 </div>
 
                 <div className="shrink-0 flex gap-2">
                   {(task.status === 'not_started' || task.status === 'overdue') && (
-                    <button
-                      onClick={() => handleStartTask(task.id)}
-                      className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
-                    >
+                    <button onClick={() => handleStartTask(task.id)} className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors">
                       Start
                     </button>
                   )}
                   {(task.status === 'in_progress' || task.status === 'overdue') && (
-                    <button
-                      onClick={() => handleCompleteTask(task.id)}
-                      className="text-xs bg-green-700 hover:bg-green-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
-                    >
+                    <button onClick={() => handleCompleteTask(task.id)} className="text-xs bg-green-700 hover:bg-green-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors">
                       Mark as Complete
                     </button>
                   )}
@@ -175,19 +157,14 @@ export default function EmployeePlanPage() {
               </div>
 
               {isExpanded && task.status !== 'cancelled' && (
-                <div className="mt-3 space-y-3 border-t border-gray-100 pt-3">
+                <div className="mt-3 space-y-3 border-t border-gray-100 dark:border-gray-700 pt-3">
                   {task.description && (
-                    <p className="text-xs text-gray-600">{task.description}</p>
+                    <p className="text-xs text-gray-600 dark:text-gray-400">{task.description}</p>
                   )}
 
                   <div>
-                    <p className="text-xs font-medium text-gray-700 mb-1">Attachments</p>
-                    <AttachmentList
-                      attachments={attachments}
-                      taskId={task.id}
-                      canDelete={canDelete}
-                      onDelete={handleDeleteAttachment}
-                    />
+                    <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Attachments</p>
+                    <AttachmentList attachments={attachments} taskId={task.id} canDelete={canDelete} onDelete={handleDeleteAttachment} />
                     {canDelete && (
                       <>
                         <input
@@ -201,17 +178,17 @@ export default function EmployeePlanPage() {
                         <label
                           htmlFor={`file-${task.id}`}
                           onClick={() => setUploadingFor(task.id)}
-                          className="mt-1 inline-block text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
+                          className="mt-1 inline-block text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 cursor-pointer"
                         >
                           + Upload file
                         </label>
-                        <p className="text-xs text-gray-400">PDF, DOCX, PNG or JPEG · max 10 MB</p>
+                        <p className="text-xs text-gray-400 dark:text-gray-500">PDF, DOCX, PNG or JPEG · max 10 MB</p>
                       </>
                     )}
                   </div>
 
                   <div>
-                    <p className="text-xs font-medium text-gray-700 mb-1">Comments</p>
+                    <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Comments</p>
                     <CommentList comments={comments} />
                     <div className="flex gap-2 mt-1">
                       <input
@@ -220,11 +197,11 @@ export default function EmployeePlanPage() {
                         value={commentText[task.id] ?? ''}
                         onChange={(e) => setCommentText((prev) => ({ ...prev, [task.id]: e.target.value }))}
                         onKeyDown={(e) => e.key === 'Enter' && onAddComment(task.id)}
-                        className="flex-1 text-xs border border-gray-300 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="flex-1 text-xs border border-gray-300 dark:border-gray-600 rounded-lg px-2 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
                       />
                       <button
                         onClick={() => onAddComment(task.id)}
-                        className="text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium px-2 py-1.5 rounded-lg transition-colors"
+                        className="text-xs bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium px-2 py-1.5 rounded-lg transition-colors"
                       >
                         Send
                       </button>

--- a/apps/frontend/src/features/plan/pages/ManagerApprovalsPage.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerApprovalsPage.tsx
@@ -7,19 +7,19 @@ export default function ManagerApprovalsPage() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      <h2 className="text-xl font-semibold text-gray-900 mb-6">Pending Approvals</h2>
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-6">Pending Approvals</h2>
 
       {tasks.length === 0 ? (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-10 text-center">
-          <p className="text-gray-500 text-sm">No tasks pending approval.</p>
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-10 text-center">
+          <p className="text-gray-500 dark:text-gray-400 text-sm">No tasks pending approval.</p>
         </div>
       ) : (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100">
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm divide-y divide-gray-100 dark:divide-gray-700">
           {tasks.map((task) => (
             <div key={task.id} className="px-5 py-4 flex items-center justify-between gap-4">
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-gray-900">{task.title}</p>
-                <p className="text-xs text-gray-500 mt-0.5">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{task.title}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                   {task.employee_name} · Due: {task.deadline}
                 </p>
               </div>
@@ -32,7 +32,7 @@ export default function ManagerApprovalsPage() {
                 </button>
                 <button
                   onClick={() => handleReview(task.id)}
-                  className="text-xs border border-gray-300 hover:border-gray-400 text-gray-700 font-medium px-3 py-1.5 rounded-lg transition-colors"
+                  className="text-xs border border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-gray-700 dark:text-gray-300 font-medium px-3 py-1.5 rounded-lg transition-colors"
                 >
                   Review
                 </button>

--- a/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.tsx
+++ b/apps/frontend/src/features/plan/pages/ManagerTaskReviewPage.tsx
@@ -5,12 +5,9 @@ import { ROUTES } from '@/constants/routes'
 export default function ManagerTaskReviewPage() {
   const {
     task,
-    showReturnModal,
-    setShowReturnModal,
-    returnComment,
-    setReturnComment,
-    handleApprove,
-    handleReturn,
+    showReturnModal, setShowReturnModal,
+    returnComment, setReturnComment,
+    handleApprove, handleReturn,
   } = useManagerTaskReviewPage()
 
   if (!task) return null
@@ -18,76 +15,85 @@ export default function ManagerTaskReviewPage() {
   return (
     <div className="max-w-2xl mx-auto">
       <div className="flex items-center gap-3 mb-6">
-        <Link
-          to={ROUTES.MANAGER_APPROVALS}
-          className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-        >
+        <Link to={ROUTES.MANAGER_APPROVALS} className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
           ← Approvals
         </Link>
-        <span className="text-gray-300">/</span>
-        <h2 className="text-xl font-semibold text-gray-900">Task Review</h2>
+        <span className="text-gray-300 dark:text-gray-600">/</span>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Task Review</h2>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5 space-y-3 mb-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5 space-y-3 mb-4">
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-gray-500 w-28">Employee</span>
-          <span className="text-gray-900 font-medium">{task.employee_name}</span>
+          <span className="text-gray-500 dark:text-gray-400 w-28">Employee</span>
+          <span className="text-gray-900 dark:text-gray-100 font-medium">{task.employee_name}</span>
         </div>
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-gray-500 w-28">Task</span>
-          <span className="text-gray-900 font-medium">{task.title}</span>
+          <span className="text-gray-500 dark:text-gray-400 w-28">Task</span>
+          <span className="text-gray-900 dark:text-gray-100 font-medium">{task.title}</span>
         </div>
         {task.description && (
           <div className="flex gap-2 text-sm">
-            <span className="text-gray-500 w-28 shrink-0">Description</span>
-            <span className="text-gray-700">{task.description}</span>
+            <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Description</span>
+            <span className="text-gray-700 dark:text-gray-300">{task.description}</span>
           </div>
         )}
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-gray-500 w-28">Deadline</span>
-          <span className="text-gray-900">{task.deadline}</span>
+          <span className="text-gray-500 dark:text-gray-400 w-28">Deadline</span>
+          <span className="text-gray-900 dark:text-gray-100">{task.deadline}</span>
         </div>
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-gray-500 w-28">Required</span>
-          <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600' : 'text-gray-400'}`}>
+          <span className="text-gray-500 dark:text-gray-400 w-28">Required</span>
+          <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}`}>
             {task.is_required ? 'Yes' : 'No'}
           </span>
         </div>
+        {(task as any).attachments?.length > 0 && (
+          <div className="flex gap-2 text-sm">
+            <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Attachments</span>
+            <ul className="space-y-1">
+              {(task as any).attachments.map((att: any) => (
+                <li key={att.id}>
+                  <a href={att.download_url} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 dark:text-blue-400 hover:underline">
+                    {att.file_name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {(task as any).return_comment && (
+          <div className="flex gap-2 text-sm">
+            <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">Last feedback</span>
+            <span className="text-gray-700 dark:text-gray-300 italic">{(task as any).return_comment}</span>
+          </div>
+        )}
       </div>
 
       <div className="flex gap-3">
-        <button
-          onClick={handleApprove}
-          className="bg-green-700 hover:bg-green-800 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-        >
+        <button onClick={handleApprove} className="bg-green-700 hover:bg-green-800 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors">
           Approve
         </button>
-        <button
-          onClick={() => setShowReturnModal(true)}
-          className="border border-red-300 hover:border-red-400 text-red-700 text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-        >
+        <button onClick={() => setShowReturnModal(true)} className="border border-red-300 dark:border-red-700 hover:border-red-400 text-red-700 dark:text-red-400 text-sm font-medium px-4 py-2 rounded-lg transition-colors">
           Return
         </button>
       </div>
 
       {showReturnModal && (
-        <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-md mx-4">
-            <h3 className="text-base font-semibold text-gray-900 mb-3">Return Task</h3>
-            <p className="text-sm text-gray-500 mb-3">
-              Provide feedback so the employee knows what to fix.
-            </p>
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 w-full max-w-md mx-4 border border-gray-200 dark:border-gray-700">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3">Return Task</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">Provide feedback so the employee knows what to fix.</p>
             <textarea
               value={returnComment}
               onChange={(e) => setReturnComment(e.target.value)}
               placeholder="Feedback comment (required)"
               rows={4}
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
             />
             <div className="flex gap-2 mt-4 justify-end">
               <button
                 onClick={() => { setShowReturnModal(false); setReturnComment('') }}
-                className="text-sm border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:border-gray-400 transition-colors"
+                className="text-sm border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg hover:border-gray-400 dark:hover:border-gray-500 transition-colors"
               >
                 Cancel
               </button>

--- a/apps/frontend/src/features/plan/pages/PlanDetailPage.tsx
+++ b/apps/frontend/src/features/plan/pages/PlanDetailPage.tsx
@@ -2,6 +2,9 @@ import { Link } from 'react-router-dom'
 import { usePlanDetailPage } from '@/features/plan/hooks/usePlanDetailPage'
 import { ROUTES } from '@/constants/routes'
 
+const inputCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500'
+const btnSm = 'text-xs border border-gray-200 dark:border-gray-600 px-2.5 py-1 rounded-lg transition-colors'
+
 export default function PlanDetailPage() {
   const {
     plan, managers,
@@ -26,69 +29,54 @@ export default function PlanDetailPage() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <Link to={ROUTES.HR_PLAN_NEW} className="text-sm text-gray-500 hover:text-gray-700 transition-colors">
+      <div className="flex items-center gap-3 mb-6 flex-wrap">
+        <Link to={ROUTES.HR_PLAN_NEW} className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
           ← Plans
         </Link>
-        <span className="text-gray-300">/</span>
-        <h2 className="text-xl font-semibold text-gray-900">Onboarding Plan</h2>
+        <span className="text-gray-300 dark:text-gray-600">/</span>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Onboarding Plan</h2>
         <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${
           plan.is_active
-            ? 'bg-green-50 text-green-700 border-green-100'
-            : 'bg-gray-100 text-gray-500 border-gray-200'
+            ? 'bg-green-50 text-green-700 border-green-100 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+            : 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
         }`}>
           {plan.is_active ? 'Active' : 'Inactive'}
         </span>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5 mb-4 space-y-3">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5 mb-4 space-y-3">
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-gray-500 w-24">Start date</span>
-          <span className="text-gray-900 font-medium">{plan.start_date}</span>
+          <span className="text-gray-500 dark:text-gray-400 w-24">Start date</span>
+          <span className="text-gray-900 dark:text-gray-100 font-medium">{plan.start_date}</span>
         </div>
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-gray-500 w-24">Manager</span>
+          <span className="text-gray-500 dark:text-gray-400 w-24">Manager</span>
           {editingManagerId !== null ? (
             <div className="flex items-center gap-2">
               <select
                 value={editingManagerId}
                 onChange={(e) => setEditingManagerId(e.target.value)}
-                className="border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 {managers.map((m) => (
                   <option key={m.id} value={m.id}>{m.first_name} {m.last_name}</option>
                 ))}
               </select>
-              <button
-                onClick={() => handleChangeManager(editingManagerId)}
-                className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 px-2.5 py-1 rounded-lg transition-colors"
-              >
-                Save
-              </button>
-              <button
-                onClick={() => setEditingManagerId(null)}
-                className="text-xs text-gray-500 hover:text-gray-700 border border-gray-200 px-2.5 py-1 rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
+              <button onClick={() => handleChangeManager(editingManagerId)} className={`${btnSm} text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-700`}>Save</button>
+              <button onClick={() => setEditingManagerId(null)} className={`${btnSm} text-gray-500 dark:text-gray-400`}>Cancel</button>
             </div>
           ) : (
             <div className="flex items-center gap-2">
-              <span className="text-gray-900 font-medium">{getManagerName(plan.manager_id)}</span>
-              <button
-                onClick={() => setEditingManagerId(plan.manager_id)}
-                className="text-xs text-gray-500 hover:text-gray-700 border border-gray-200 px-2.5 py-1 rounded-lg transition-colors"
-              >
-                Edit
-              </button>
+              <span className="text-gray-900 dark:text-gray-100 font-medium">{getManagerName(plan.manager_id)}</span>
+              <button onClick={() => setEditingManagerId(plan.manager_id)} className={`${btnSm} text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200`}>Edit</button>
             </div>
           )}
         </div>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
-        <div className="flex items-center justify-between px-5 py-3.5 border-b border-gray-100 bg-gray-50 rounded-tl-xl rounded-tr-xl">
-          <span className="text-sm font-medium text-gray-700">Tasks</span>
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="flex items-center justify-between px-5 py-3.5 border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 rounded-tl-xl rounded-tr-xl">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Tasks</span>
           <button
             onClick={() => setShowAddForm((v) => !v)}
             className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
@@ -97,60 +85,40 @@ export default function PlanDetailPage() {
           </button>
         </div>
 
-        <ul className="divide-y divide-gray-100">
+        <ul className="divide-y divide-gray-100 dark:divide-gray-700">
           {plan.tasks.map((task) => (
             <li key={task.id} className="px-5 py-4">
               <div className="flex items-start gap-3">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className={`text-sm font-medium ${task.status === 'cancelled' ? 'line-through text-gray-400' : 'text-gray-900'}`}>
+                    <span className={`text-sm font-medium ${task.status === 'cancelled' ? 'line-through text-gray-400 dark:text-gray-500' : 'text-gray-900 dark:text-gray-100'}`}>
                       {task.title}
                     </span>
                     <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${
                       task.status === 'cancelled'
-                        ? 'bg-gray-100 text-gray-500 border-gray-200'
-                        : 'bg-blue-50 text-blue-700 border-blue-100'
+                        ? 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
+                        : 'bg-blue-50 text-blue-700 border-blue-100 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800'
                     }`}>
                       {task.status === 'not_started' ? 'Not started' : 'Cancelled'}
                     </span>
-                    <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600' : 'text-gray-400'}`}>
+                    <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}`}>
                       {task.is_required ? 'Required' : 'Optional'}
                     </span>
                   </div>
-                  <p className="text-xs text-gray-500 mt-0.5">Due: {task.deadline}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Due: {task.deadline}</p>
                 </div>
 
                 {task.status !== 'cancelled' && (
                   <div className="flex items-center gap-2 shrink-0">
-                    <button
-                      onClick={() => startEditDeadline(task)}
-                      className="text-xs text-gray-600 hover:text-gray-800 border border-gray-200 px-2.5 py-1 rounded-lg transition-colors"
-                    >
-                      Edit deadline
-                    </button>
+                    <button onClick={() => startEditDeadline(task)} className={`${btnSm} text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200`}>Edit deadline</button>
                     {cancelConfirmTaskId === task.id ? (
                       <div className="flex items-center gap-1">
-                        <span className="text-xs text-gray-600">Cancel task?</span>
-                        <button
-                          onClick={() => handleCancelTask(task.id)}
-                          className="text-xs text-red-600 hover:text-red-800 border border-red-200 px-2.5 py-1 rounded-lg transition-colors"
-                        >
-                          Yes
-                        </button>
-                        <button
-                          onClick={() => setCancelConfirmTaskId(null)}
-                          className="text-xs text-gray-500 hover:text-gray-700 border border-gray-200 px-2.5 py-1 rounded-lg transition-colors"
-                        >
-                          No
-                        </button>
+                        <span className="text-xs text-gray-600 dark:text-gray-400">Cancel task?</span>
+                        <button onClick={() => handleCancelTask(task.id)} className={`${btnSm} text-red-600 dark:text-red-400 border-red-200 dark:border-red-700`}>Yes</button>
+                        <button onClick={() => setCancelConfirmTaskId(null)} className={`${btnSm} text-gray-500 dark:text-gray-400`}>No</button>
                       </div>
                     ) : (
-                      <button
-                        onClick={() => setCancelConfirmTaskId(task.id)}
-                        className="text-xs text-red-600 hover:text-red-800 border border-red-200 px-2.5 py-1 rounded-lg transition-colors"
-                      >
-                        Cancel
-                      </button>
+                      <button onClick={() => setCancelConfirmTaskId(task.id)} className={`${btnSm} text-red-600 dark:text-red-400 border-red-200 dark:border-red-700`}>Cancel</button>
                     )}
                   </div>
                 )}
@@ -162,20 +130,10 @@ export default function PlanDetailPage() {
                     type="date"
                     value={editingDeadline}
                     onChange={(e) => setEditingDeadline(e.target.value)}
-                    className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
-                  <button
-                    onClick={handleUpdateDeadline}
-                    className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 px-2.5 py-1.5 rounded-lg transition-colors"
-                  >
-                    Save
-                  </button>
-                  <button
-                    onClick={() => setEditingTaskId(null)}
-                    className="text-xs text-gray-500 hover:text-gray-700 border border-gray-200 px-2.5 py-1.5 rounded-lg transition-colors"
-                  >
-                    Cancel
-                  </button>
+                  <button onClick={handleUpdateDeadline} className={`${btnSm} text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-700`}>Save</button>
+                  <button onClick={() => setEditingTaskId(null)} className={`${btnSm} text-gray-500 dark:text-gray-400`}>Cancel</button>
                 </div>
               )}
             </li>
@@ -183,43 +141,23 @@ export default function PlanDetailPage() {
         </ul>
 
         {showAddForm && (
-          <div className="px-5 py-5 border-t border-gray-100 space-y-3">
-            <p className="text-sm font-medium text-gray-700">New Task</p>
-            <input
-              value={newTitle}
-              onChange={(e) => setNewTitle(e.target.value)}
-              placeholder="Title"
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            <input
-              value={newDescription}
-              onChange={(e) => setNewDescription(e.target.value)}
-              placeholder="Description (optional)"
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
+          <div className="px-5 py-5 border-t border-gray-100 dark:border-gray-700 space-y-3">
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">New Task</p>
+            <input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} placeholder="Title" className={inputCls} />
+            <input value={newDescription} onChange={(e) => setNewDescription(e.target.value)} placeholder="Description (optional)" className={inputCls} />
             <div className="flex gap-3 items-center">
               <input
                 type="date"
                 value={newDeadline}
                 onChange={(e) => setNewDeadline(e.target.value)}
-                className="border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
-              <label className="flex items-center gap-2 text-sm text-gray-700">
-                <input
-                  type="checkbox"
-                  checked={newIsRequired}
-                  onChange={(e) => setNewIsRequired(e.target.checked)}
-                  className="rounded"
-                />
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <input type="checkbox" checked={newIsRequired} onChange={(e) => setNewIsRequired(e.target.checked)} className="rounded" />
                 Required
               </label>
             </div>
-            <button
-              onClick={handleAddTask}
-              className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors"
-            >
-              Add Task
-            </button>
+            <button onClick={handleAddTask} className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors">Add Task</button>
           </div>
         )}
       </div>

--- a/apps/frontend/src/features/reports/pages/ReportsPage.tsx
+++ b/apps/frontend/src/features/reports/pages/ReportsPage.tsx
@@ -22,63 +22,63 @@ export default function ReportsPage() {
     <div className="max-w-5xl mx-auto space-y-8">
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Reports</h2>
-          <p className="text-sm text-gray-500 mt-0.5">Onboarding activity analysis and export.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Reports</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Onboarding activity analysis and export.</p>
         </div>
         <div className="flex items-center gap-2">
           <div className="flex flex-col gap-0.5">
-            <label className="text-xs text-gray-500">From</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
             <input
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
           <div className="flex flex-col gap-0.5">
-            <label className="text-xs text-gray-500">To</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
             <input
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
         </div>
       </div>
 
       {loading ? (
-        <p className="text-sm text-gray-400">Loading...</p>
+        <p className="text-sm text-gray-400 dark:text-gray-500">Loading...</p>
       ) : (
         <>
           <section>
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold text-gray-700">Average Completion Time by Department</h3>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Average Completion Time by Department</h3>
               <button
                 onClick={() => handleExport(API.REPORTS.COMPLETION_TIME, 'completion-time.csv')}
-                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
               >
                 Export CSV
               </button>
             </div>
-            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
               {completionTime.length === 0 ? (
-                <p className="text-sm text-gray-400 px-5 py-4">No completed plans found.</p>
+                <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">No completed plans found.</p>
               ) : (
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b border-gray-100">
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Department</th>
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completed Plans</th>
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Avg. Days to Complete</th>
+                    <tr className="border-b border-gray-100 dark:border-gray-700">
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Department</th>
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Completed Plans</th>
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Avg. Days to Complete</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-100">
+                  <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
                     {completionTime.map((row) => (
-                      <tr key={row.department_name} className="hover:bg-gray-50">
-                        <td className="px-5 py-3 font-medium text-gray-800">{row.department_name}</td>
-                        <td className="px-5 py-3 text-gray-600">{row.total_plans}</td>
-                        <td className="px-5 py-3 text-gray-600">
+                      <tr key={row.department_name} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                        <td className="px-5 py-3 font-medium text-gray-800 dark:text-gray-200">{row.department_name}</td>
+                        <td className="px-5 py-3 text-gray-600 dark:text-gray-400">{row.total_plans}</td>
+                        <td className="px-5 py-3 text-gray-600 dark:text-gray-400">
                           {row.avg_completion_days_rounded != null ? `${row.avg_completion_days_rounded} days` : '—'}
                         </td>
                       </tr>
@@ -91,40 +91,40 @@ export default function ReportsPage() {
 
           <section>
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold text-gray-700">Task Completion Rates by Template</h3>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Task Completion Rates by Template</h3>
               <button
                 onClick={() => handleExport(API.REPORTS.TASK_COMPLETION_RATES, 'task-completion-rates.csv')}
-                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
               >
                 Export CSV
               </button>
             </div>
-            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
               {taskRates.length === 0 ? (
-                <p className="text-sm text-gray-400 px-5 py-4">No data found.</p>
+                <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">No data found.</p>
               ) : (
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b border-gray-100">
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Template</th>
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Total Tasks</th>
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completed</th>
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Completion Rate</th>
+                    <tr className="border-b border-gray-100 dark:border-gray-700">
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Template</th>
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Total Tasks</th>
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Completed</th>
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Completion Rate</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-100">
+                  <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
                     {taskRates.map((row) => (
-                      <tr key={row.template_name} className="hover:bg-gray-50">
-                        <td className="px-5 py-3 font-medium text-gray-800">{row.template_name}</td>
-                        <td className="px-5 py-3 text-gray-600">{row.total_tasks}</td>
-                        <td className="px-5 py-3 text-gray-600">{row.completed_tasks}</td>
+                      <tr key={row.template_name} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                        <td className="px-5 py-3 font-medium text-gray-800 dark:text-gray-200">{row.template_name}</td>
+                        <td className="px-5 py-3 text-gray-600 dark:text-gray-400">{row.total_tasks}</td>
+                        <td className="px-5 py-3 text-gray-600 dark:text-gray-400">{row.completed_tasks}</td>
                         <td className="px-5 py-3">
                           <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
                             row.completion_rate >= 75
-                              ? 'text-green-700 bg-green-50'
+                              ? 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-900/30'
                               : row.completion_rate >= 40
-                              ? 'text-yellow-700 bg-yellow-50'
-                              : 'text-red-600 bg-red-50'
+                              ? 'text-yellow-700 bg-yellow-50 dark:text-yellow-400 dark:bg-yellow-900/30'
+                              : 'text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30'
                           }`}>
                             {row.completion_rate}%
                           </span>
@@ -139,46 +139,46 @@ export default function ReportsPage() {
 
           <section>
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold text-gray-700">Bottlenecks — Most Returned & Overdue Tasks</h3>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Bottlenecks — Most Returned & Overdue Tasks</h3>
               <button
                 onClick={() => handleExport(API.REPORTS.BOTTLENECKS, 'bottlenecks.csv')}
-                className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
               >
                 Export CSV
               </button>
             </div>
-            <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
               {bottlenecks.length === 0 ? (
-                <p className="text-sm text-gray-400 px-5 py-4">No bottlenecks found.</p>
+                <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">No bottlenecks found.</p>
               ) : (
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b border-gray-100">
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Task</th>
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Times Returned</th>
-                      <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Times Overdue</th>
+                    <tr className="border-b border-gray-100 dark:border-gray-700">
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Task</th>
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Times Returned</th>
+                      <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Times Overdue</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-100">
+                  <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
                     {bottlenecks.map((row) => (
-                      <tr key={row.task_title} className="hover:bg-gray-50">
-                        <td className="px-5 py-3 font-medium text-gray-800">{row.task_title}</td>
+                      <tr key={row.task_title} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                        <td className="px-5 py-3 font-medium text-gray-800 dark:text-gray-200">{row.task_title}</td>
                         <td className="px-5 py-3">
                           {row.returned_count > 0 ? (
-                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-orange-600 bg-orange-50">
+                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-orange-600 bg-orange-50 dark:text-orange-400 dark:bg-orange-900/30">
                               {row.returned_count}
                             </span>
                           ) : (
-                            <span className="text-gray-400">0</span>
+                            <span className="text-gray-400 dark:text-gray-500">0</span>
                           )}
                         </td>
                         <td className="px-5 py-3">
                           {row.overdue_count > 0 ? (
-                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-red-600 bg-red-50">
+                            <span className="text-xs font-medium px-2 py-0.5 rounded-full text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30">
                               {row.overdue_count}
                             </span>
                           ) : (
-                            <span className="text-gray-400">0</span>
+                            <span className="text-gray-400 dark:text-gray-500">0</span>
                           )}
                         </td>
                       </tr>

--- a/apps/frontend/src/features/template/pages/TemplateDetailPage.tsx
+++ b/apps/frontend/src/features/template/pages/TemplateDetailPage.tsx
@@ -2,81 +2,59 @@ import { Link } from 'react-router-dom'
 import { useTemplateDetailPage } from '@/features/template/hooks/useTemplateDetailPage'
 import { ROUTES } from '@/constants/routes'
 
+const inputCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500'
+
 export default function TemplateDetailPage() {
   const {
-    template,
-    tasks,
-    showAddForm,
-    setShowAddForm,
-    newTitle,
-    setNewTitle,
-    newDescription,
-    setNewDescription,
-    newDeadlineDays,
-    setNewDeadlineDays,
-    newIsRequired,
-    setNewIsRequired,
+    template, tasks,
+    showAddForm, setShowAddForm,
+    newTitle, setNewTitle,
+    newDescription, setNewDescription,
+    newDeadlineDays, setNewDeadlineDays,
+    newIsRequired, setNewIsRequired,
     editingTaskId,
-    editTitle,
-    setEditTitle,
-    editDescription,
-    setEditDescription,
-    editDeadlineDays,
-    setEditDeadlineDays,
-    editIsRequired,
-    setEditIsRequired,
-    startEdit,
-    cancelEdit,
-    handleAddTask,
-    handleUpdateTask,
-    handleDeleteTask,
-    handleReorder,
-    handleActivate,
-    handleDeactivate,
+    editTitle, setEditTitle,
+    editDescription, setEditDescription,
+    editDeadlineDays, setEditDeadlineDays,
+    editIsRequired, setEditIsRequired,
+    startEdit, cancelEdit,
+    handleAddTask, handleUpdateTask, handleDeleteTask,
+    handleReorder, handleActivate, handleDeactivate,
   } = useTemplateDetailPage()
 
   if (!template) return null
 
   return (
     <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <Link
-          to={ROUTES.HR_TEMPLATES}
-          className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-        >
+      <div className="flex items-center gap-3 mb-6 flex-wrap">
+        <Link to={ROUTES.HR_TEMPLATES} className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
           ← Templates
         </Link>
-        <span className="text-gray-300">/</span>
-        <h2 className="text-xl font-semibold text-gray-900">{template.name}</h2>
+        <span className="text-gray-300 dark:text-gray-600">/</span>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{template.name}</h2>
         <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${
           template.is_active
-            ? 'bg-green-50 text-green-700 border-green-100'
-            : 'bg-gray-100 text-gray-500 border-gray-200'
+            ? 'bg-green-50 text-green-700 border-green-100 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+            : 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
         }`}>
           {template.is_active ? 'Active' : 'Inactive'}
         </span>
         <div className="ml-auto">
           {template.is_active ? (
-            <button
-              onClick={handleDeactivate}
-              className="text-xs text-red-600 hover:text-red-800 border border-red-200 hover:border-red-300 px-3 py-1.5 rounded-lg transition-colors"
-            >
+            <button onClick={handleDeactivate} className="text-xs text-red-600 dark:text-red-400 hover:text-red-800 border border-red-200 dark:border-red-700 hover:border-red-300 px-3 py-1.5 rounded-lg transition-colors">
               Deactivate
             </button>
           ) : (
-            <button
-              onClick={handleActivate}
-              className="text-xs text-green-600 hover:text-green-800 border border-green-200 hover:border-green-300 px-3 py-1.5 rounded-lg transition-colors"
-            >
+            <button onClick={handleActivate} className="text-xs text-green-600 dark:text-green-400 hover:text-green-800 border border-green-200 dark:border-green-700 hover:border-green-300 px-3 py-1.5 rounded-lg transition-colors">
               Activate
             </button>
           )}
         </div>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden mb-4">
-        <div className="flex items-center justify-between px-5 py-3.5 border-b border-gray-100 bg-gray-50">
-          <span className="text-sm font-medium text-gray-700">Tasks</span>
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden mb-4">
+        <div className="flex items-center justify-between px-5 py-3.5 border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Tasks</span>
           <button
             onClick={() => setShowAddForm((v) => !v)}
             className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
@@ -86,99 +64,45 @@ export default function TemplateDetailPage() {
         </div>
 
         {tasks.length === 0 && !showAddForm && (
-          <p className="px-5 py-8 text-center text-gray-400 text-sm">No tasks yet.</p>
+          <p className="px-5 py-8 text-center text-gray-400 dark:text-gray-500 text-sm">No tasks yet.</p>
         )}
 
-        <ul className="divide-y divide-gray-100">
+        <ul className="divide-y divide-gray-100 dark:divide-gray-700">
           {tasks.map((task, index) => (
             <li key={task.id} className="px-5 py-4">
               <div className="flex items-center gap-3">
-                <span className="text-xs text-gray-400 w-5 text-right">{task.order}</span>
+                <span className="text-xs text-gray-400 dark:text-gray-500 w-5 text-right">{task.order}</span>
                 <div className="flex-1 min-w-0">
-                  <span className="text-sm font-medium text-gray-900">{task.title}</span>
+                  <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{task.title}</span>
                   <div className="flex gap-3 mt-0.5">
-                    <span className="text-xs text-gray-500">{task.deadline_days} day{task.deadline_days !== 1 ? 's' : ''}</span>
-                    <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600' : 'text-gray-400'}`}>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">{task.deadline_days} day{task.deadline_days !== 1 ? 's' : ''}</span>
+                    <span className={`text-xs font-medium ${task.is_required ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}`}>
                       {task.is_required ? 'Required' : 'Optional'}
                     </span>
                   </div>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button
-                    onClick={() => handleReorder(task.id, task.order - 1)}
-                    disabled={index === 0}
-                    className="text-xs text-gray-400 hover:text-gray-600 disabled:opacity-30 px-1.5 py-1 rounded"
-                  >
-                    ↑
-                  </button>
-                  <button
-                    onClick={() => handleReorder(task.id, task.order + 1)}
-                    disabled={index === tasks.length - 1}
-                    className="text-xs text-gray-400 hover:text-gray-600 disabled:opacity-30 px-1.5 py-1 rounded"
-                  >
-                    ↓
-                  </button>
-                  <button
-                    onClick={() => startEdit(task)}
-                    className="text-xs text-gray-600 hover:text-gray-800 border border-gray-200 hover:border-gray-300 px-2.5 py-1 rounded-lg transition-colors ml-1"
-                  >
-                    Edit
-                  </button>
-                  <button
-                    onClick={() => handleDeleteTask(task.id)}
-                    className="text-xs text-red-600 hover:text-red-800 border border-red-200 hover:border-red-300 px-2.5 py-1 rounded-lg transition-colors"
-                  >
-                    Delete
-                  </button>
+                  <button onClick={() => handleReorder(task.id, task.order - 1)} disabled={index === 0} className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 px-1.5 py-1 rounded">↑</button>
+                  <button onClick={() => handleReorder(task.id, task.order + 1)} disabled={index === tasks.length - 1} className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30 px-1.5 py-1 rounded">↓</button>
+                  <button onClick={() => startEdit(task)} className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 border border-gray-200 dark:border-gray-600 hover:border-gray-300 px-2.5 py-1 rounded-lg transition-colors ml-1">Edit</button>
+                  <button onClick={() => handleDeleteTask(task.id)} className="text-xs text-red-600 dark:text-red-400 hover:text-red-800 border border-red-200 dark:border-red-700 hover:border-red-300 px-2.5 py-1 rounded-lg transition-colors">Delete</button>
                 </div>
               </div>
 
               {editingTaskId === task.id && (
-                <div className="mt-4 pt-4 border-t border-gray-100 space-y-3">
-                  <input
-                    value={editTitle}
-                    onChange={(e) => setEditTitle(e.target.value)}
-                    placeholder="Title"
-                    className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                  <input
-                    value={editDescription}
-                    onChange={(e) => setEditDescription(e.target.value)}
-                    placeholder="Description (optional)"
-                    className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
+                <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700 space-y-3">
+                  <input value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Title" className={inputCls} />
+                  <input value={editDescription} onChange={(e) => setEditDescription(e.target.value)} placeholder="Description (optional)" className={inputCls} />
                   <div className="flex gap-3">
-                    <input
-                      type="number"
-                      min={1}
-                      value={editDeadlineDays}
-                      onChange={(e) => setEditDeadlineDays(Number(e.target.value))}
-                      placeholder="Deadline (days)"
-                      className="w-36 border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    <label className="flex items-center gap-2 text-sm text-gray-700">
-                      <input
-                        type="checkbox"
-                        checked={editIsRequired}
-                        onChange={(e) => setEditIsRequired(e.target.checked)}
-                        className="rounded"
-                      />
+                    <input type="number" min={1} value={editDeadlineDays} onChange={(e) => setEditDeadlineDays(Number(e.target.value))} placeholder="Deadline (days)" className="w-36 border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                      <input type="checkbox" checked={editIsRequired} onChange={(e) => setEditIsRequired(e.target.checked)} className="rounded" />
                       Required
                     </label>
                   </div>
                   <div className="flex gap-2">
-                    <button
-                      onClick={handleUpdateTask}
-                      className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors"
-                    >
-                      Save
-                    </button>
-                    <button
-                      onClick={cancelEdit}
-                      className="text-xs text-gray-600 hover:text-gray-800 border border-gray-200 px-4 py-2 rounded-lg transition-colors"
-                    >
-                      Cancel
-                    </button>
+                    <button onClick={handleUpdateTask} className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors">Save</button>
+                    <button onClick={cancelEdit} className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 border border-gray-200 dark:border-gray-600 px-4 py-2 rounded-lg transition-colors">Cancel</button>
                   </div>
                 </div>
               )}
@@ -187,45 +111,18 @@ export default function TemplateDetailPage() {
         </ul>
 
         {showAddForm && (
-          <div className="px-5 py-5 border-t border-gray-100 space-y-3">
-            <p className="text-sm font-medium text-gray-700">New Task</p>
-            <input
-              value={newTitle}
-              onChange={(e) => setNewTitle(e.target.value)}
-              placeholder="Title"
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            <input
-              value={newDescription}
-              onChange={(e) => setNewDescription(e.target.value)}
-              placeholder="Description (optional)"
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
+          <div className="px-5 py-5 border-t border-gray-100 dark:border-gray-700 space-y-3">
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">New Task</p>
+            <input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} placeholder="Title" className={inputCls} />
+            <input value={newDescription} onChange={(e) => setNewDescription(e.target.value)} placeholder="Description (optional)" className={inputCls} />
             <div className="flex gap-3">
-              <input
-                type="number"
-                min={1}
-                value={newDeadlineDays}
-                onChange={(e) => setNewDeadlineDays(Number(e.target.value))}
-                placeholder="Deadline (days)"
-                className="w-36 border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-              <label className="flex items-center gap-2 text-sm text-gray-700">
-                <input
-                  type="checkbox"
-                  checked={newIsRequired}
-                  onChange={(e) => setNewIsRequired(e.target.checked)}
-                  className="rounded"
-                />
+              <input type="number" min={1} value={newDeadlineDays} onChange={(e) => setNewDeadlineDays(Number(e.target.value))} placeholder="Deadline (days)" className="w-36 border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <input type="checkbox" checked={newIsRequired} onChange={(e) => setNewIsRequired(e.target.checked)} className="rounded" />
                 Required
               </label>
             </div>
-            <button
-              onClick={handleAddTask}
-              className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors"
-            >
-              Add Task
-            </button>
+            <button onClick={handleAddTask} className="text-xs bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors">Add Task</button>
           </div>
         )}
       </div>

--- a/apps/frontend/src/features/template/pages/TemplatesPage.tsx
+++ b/apps/frontend/src/features/template/pages/TemplatesPage.tsx
@@ -34,8 +34,8 @@ export default function TemplatesPage() {
     <div className="max-w-5xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Templates</h2>
-          <p className="text-sm text-gray-500 mt-0.5">Manage onboarding templates per department.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Templates</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Manage onboarding templates per department.</p>
         </div>
         <button
           onClick={() => setShowCreateForm((v) => !v)}
@@ -46,17 +46,17 @@ export default function TemplatesPage() {
       </div>
 
       {showCreateForm && (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-5 py-4 mb-4 flex gap-2">
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-5 py-4 mb-4 flex gap-2">
           <input
             value={newTemplateName}
             onChange={(e) => setNewTemplateName(e.target.value)}
             placeholder="Template name"
-            className="flex-1 border border-gray-300 rounded-lg px-3.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           <select
             value={newTemplateDepartmentId}
             onChange={(e) => setNewTemplateDepartmentId(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="">Select department</option>
             {departments.map((d) => (
@@ -77,7 +77,7 @@ export default function TemplatesPage() {
         <select
           value={filterDepartmentId}
           onChange={(e) => setFilterDepartmentId(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All departments</option>
           {departments.map((d) => (
@@ -88,7 +88,7 @@ export default function TemplatesPage() {
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value as 'active' | 'inactive' | '')}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All statuses</option>
           <option value="active">Active</option>
@@ -97,28 +97,28 @@ export default function TemplatesPage() {
       </div>
 
       {filteredTemplates.length === 0 ? (
-        <p className="text-sm text-gray-400 text-center py-12">No templates found.</p>
+        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-12">No templates found.</p>
       ) : (
         <div className="grid gap-4">
           {filteredTemplates.map((t) => (
-            <div key={t.id} className="relative bg-white rounded-xl border border-gray-200 shadow-sm">
+            <div key={t.id} className="relative bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
               {editingId === t.id ? (
                 <div className="px-6 py-4 flex items-center gap-2">
                   <input
                     value={editingName}
                     onChange={(e) => setEditingName(e.target.value)}
-                    className="flex-1 border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     autoFocus
                   />
                   <button
                     onClick={handleRename}
-                    className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 px-3 py-1.5 rounded-lg transition-colors"
+                    className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 border border-blue-200 dark:border-blue-700 px-3 py-1.5 rounded-lg transition-colors"
                   >
                     Save
                   </button>
                   <button
                     onClick={cancelRename}
-                    className="text-xs text-gray-500 hover:text-gray-700 border border-gray-200 px-3 py-1.5 rounded-lg transition-colors"
+                    className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 border border-gray-200 dark:border-gray-600 px-3 py-1.5 rounded-lg transition-colors"
                   >
                     Cancel
                   </button>
@@ -126,19 +126,19 @@ export default function TemplatesPage() {
               ) : (
                 <Link
                   to={ROUTES.HR_TEMPLATE_DETAIL(t.id)}
-                  className="block px-6 py-5 hover:bg-slate-50 rounded-xl transition-colors pr-14"
+                  className="block px-6 py-5 hover:bg-slate-50 dark:hover:bg-gray-700/50 rounded-xl transition-colors pr-14"
                 >
                   <div className="flex items-center gap-3">
-                    <h3 className="text-sm font-semibold text-gray-900">{t.name}</h3>
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{t.name}</h3>
                     <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${
                       t.is_active
-                        ? 'bg-green-50 text-green-700 border-green-100'
-                        : 'bg-gray-100 text-gray-500 border-gray-200'
+                        ? 'bg-green-50 text-green-700 border-green-100 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+                        : 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
                     }`}>
                       {t.is_active ? 'Active' : 'Inactive'}
                     </span>
                   </div>
-                  <p className="text-xs text-gray-500 mt-1">{getDepartmentName(t.department_id)}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{getDepartmentName(t.department_id)}</p>
                 </Link>
               )}
 

--- a/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
@@ -6,9 +6,9 @@ import { useEmployeeDashboard } from '@/features/dashboard/hooks/useEmployeeDash
 
 function StatCard({ label, value }: { label: string; value: string | number | undefined }) {
   return (
-    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">{value ?? '—'}</p>
     </div>
   )
 }
@@ -23,30 +23,30 @@ export default function EmployeeDashboard() {
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
-          <span className="text-blue-700 text-xl font-bold">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 dark:bg-blue-900/40 rounded-full flex items-center justify-center mb-4">
+          <span className="text-blue-700 dark:text-blue-400 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
-        <p className="text-sm text-gray-500 mt-1">You're signed in as Employee.</p>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">You're signed in as Employee.</p>
       </div>
 
       {stats && stats.total_tasks > 0 ? (
         <>
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
+          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
             <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-medium text-gray-700">Plan Progress</p>
-              <p className="text-sm font-semibold text-gray-900">{progressPct}%</p>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Plan Progress</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{progressPct}%</p>
             </div>
-            <div className="w-full bg-gray-100 rounded-full h-2">
+            <div className="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-2">
               <div
                 className="bg-blue-600 h-2 rounded-full transition-all"
                 style={{ width: `${progressPct}%` }}
               />
             </div>
-            <p className="text-xs text-gray-500 mt-2">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
               {stats.approved_tasks} of {stats.total_tasks} tasks approved
             </p>
           </div>
@@ -61,16 +61,16 @@ export default function EmployeeDashboard() {
           </div>
         </>
       ) : (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
-          <p className="text-sm text-gray-400">No active onboarding plan assigned.</p>
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
+          <p className="text-sm text-gray-400 dark:text-gray-500">No active onboarding plan assigned.</p>
         </div>
       )}
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
-        <h3 className="text-sm font-medium text-gray-700 mb-3">Quick links</h3>
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Quick links</h3>
         <Link
           to={ROUTES.EMPLOYEE_PLAN}
-          className="inline-flex items-center gap-2 text-sm text-blue-700 hover:text-blue-900 font-medium transition-colors"
+          className="inline-flex items-center gap-2 text-sm text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 font-medium transition-colors"
         >
           My Onboarding Plan →
         </Link>

--- a/apps/frontend/src/features/users/pages/HRDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.tsx
@@ -3,9 +3,9 @@ import { useHRDashboard } from '@/features/dashboard/hooks/useHRDashboard'
 
 function StatCard({ label, value }: { label: string; value: number | undefined }) {
   return (
-    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">{value ?? '—'}</p>
     </div>
   )
 }
@@ -16,14 +16,14 @@ export default function HRDashboard() {
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
-          <span className="text-blue-700 text-xl font-bold">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 dark:bg-blue-900/40 rounded-full flex items-center justify-center mb-4">
+          <span className="text-blue-700 dark:text-blue-400 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
-        <p className="text-sm text-gray-500 mt-1">You're signed in as HR Admin.</p>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">You're signed in as HR Admin.</p>
       </div>
 
       <div className="grid grid-cols-2 gap-4">

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -5,9 +5,9 @@ import { useManagerDashboard } from '@/features/dashboard/hooks/useManagerDashbo
 
 function StatCard({ label, value }: { label: string; value: number | undefined }) {
   return (
-    <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="text-2xl font-semibold text-gray-900 mt-1">{value ?? '—'}</p>
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
+      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">{value ?? '—'}</p>
     </div>
   )
 }
@@ -18,14 +18,14 @@ export default function ManagerDashboard() {
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8">
-        <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center mb-4">
-          <span className="text-blue-700 text-xl font-bold">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-8">
+        <div className="w-14 h-14 bg-blue-100 dark:bg-blue-900/40 rounded-full flex items-center justify-center mb-4">
+          <span className="text-blue-700 dark:text-blue-400 text-xl font-bold">
             {user?.first_name?.[0]}{user?.last_name?.[0]}
           </span>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900">Welcome, {user?.first_name}</h2>
-        <p className="text-sm text-gray-500 mt-1">You're signed in as Manager.</p>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Welcome, {user?.first_name}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">You're signed in as Manager.</p>
       </div>
 
       <div className="grid grid-cols-3 gap-4">
@@ -34,11 +34,11 @@ export default function ManagerDashboard() {
         <StatCard label="Employees" value={stats?.total_employees} />
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5">
-        <h3 className="text-sm font-medium text-gray-700 mb-3">Quick links</h3>
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Quick links</h3>
         <Link
           to={ROUTES.MANAGER_APPROVALS}
-          className="inline-flex items-center gap-2 text-sm text-blue-700 hover:text-blue-900 font-medium transition-colors"
+          className="inline-flex items-center gap-2 text-sm text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 font-medium transition-colors"
         >
           Pending Approvals →
         </Link>

--- a/apps/frontend/src/features/users/pages/ProfilePage.tsx
+++ b/apps/frontend/src/features/users/pages/ProfilePage.tsx
@@ -16,65 +16,65 @@ export default function ProfilePage() {
   return (
     <div className="max-w-xl mx-auto">
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">My Profile</h2>
-        <p className="text-sm text-gray-500 mt-0.5">View and update your personal details.</p>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">My Profile</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">View and update your personal details.</p>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-8 py-8 space-y-5">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-8 space-y-5">
         {success && (
-          <div className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+          <div className="text-sm text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg px-4 py-3">
             Profile updated successfully.
           </div>
         )}
         {pageError && (
-          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-3">
             {pageError}
           </div>
         )}
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">First name</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">First name</label>
             <input
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">Last name</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Last name</label>
             <input
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3.5 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">Email</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Email</label>
           <input
             value={user?.email ?? ''}
             readOnly
-            className="w-full border border-gray-200 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 bg-gray-50 cursor-not-allowed"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/50 cursor-not-allowed"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">Role</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Role</label>
           <input
             value={ROLE_LABELS[user?.role ?? ''] ?? user?.role ?? ''}
             readOnly
-            className="w-full border border-gray-200 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 bg-gray-50 cursor-not-allowed"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/50 cursor-not-allowed"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">Department</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Department</label>
           <input
             value={user?.department_name ?? '—'}
             readOnly
-            className="w-full border border-gray-200 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 bg-gray-50 cursor-not-allowed"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3.5 py-2.5 text-sm text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/50 cursor-not-allowed"
           />
         </div>
 

--- a/apps/frontend/src/features/users/pages/UsersPage.tsx
+++ b/apps/frontend/src/features/users/pages/UsersPage.tsx
@@ -25,13 +25,12 @@ export default function UsersPage() {
     handleReactivate,
   } = useUsersPage()
 
-
   return (
     <div className="max-w-6xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Users</h2>
-          <p className="text-sm text-gray-500 mt-0.5">Manage users, roles and department assignments.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Users</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Manage users, roles and department assignments.</p>
         </div>
         <Link
           to={ROUTES.HR_INVITE_USER}
@@ -45,7 +44,7 @@ export default function UsersPage() {
         <select
           value={filterRole}
           onChange={(e) => setFilterRole(e.target.value as UserRole | '')}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All roles</option>
           <option value="hr_admin">HR Admin</option>
@@ -56,7 +55,7 @@ export default function UsersPage() {
         <select
           value={filterDepartmentId}
           onChange={(e) => setFilterDepartmentId(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All departments</option>
           {activeDepartments.map((d) => (
@@ -67,7 +66,7 @@ export default function UsersPage() {
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value as 'active' | 'inactive' | '')}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All statuses</option>
           <option value="active">Active</option>
@@ -75,38 +74,38 @@ export default function UsersPage() {
         </select>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-100 bg-gray-50 text-left">
-              <th className="px-5 py-3.5 font-medium text-gray-600 rounded-tl-xl">Name</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600">Email</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600">Role</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600">Department</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600">Status</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 text-right rounded-tr-xl">Actions</th>
+            <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 text-left">
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 rounded-tl-xl">Name</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Email</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Role</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Department</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Status</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 text-right rounded-tr-xl">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
             {filteredUsers.map((u) => (
-              <tr key={u.id} className="hover:bg-slate-50 transition-colors">
-                <td className="px-5 py-3.5 font-medium text-gray-900">
+              <tr key={u.id} className="hover:bg-slate-50 dark:hover:bg-gray-700/50 transition-colors">
+                <td className="px-5 py-3.5 font-medium text-gray-900 dark:text-gray-100">
                   {u.first_name} {u.last_name}
                   {u.id === currentUser?.id && (
-                    <span className="ml-2 text-xs text-blue-600 font-normal">(you)</span>
+                    <span className="ml-2 text-xs text-blue-600 dark:text-blue-400 font-normal">(you)</span>
                   )}
                 </td>
-                <td className="px-5 py-3.5 text-gray-600">{u.email}</td>
+                <td className="px-5 py-3.5 text-gray-600 dark:text-gray-400">{u.email}</td>
                 <td className="px-5 py-3.5">
                   {u.id === currentUser?.id ? (
-                    <span className="inline-block text-xs bg-blue-50 text-blue-700 border border-blue-100 px-2 py-0.5 rounded-full font-medium">
+                    <span className="inline-block text-xs bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 border border-blue-100 dark:border-blue-800 px-2 py-0.5 rounded-full font-medium">
                       {ROLE_LABELS[u.role] ?? u.role}
                     </span>
                   ) : (
                     <select
                       value={u.role}
                       onChange={(e) => handleChangeRole(u.id, e.target.value as UserRole)}
-                      className="border border-gray-200 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     >
                       <option value="hr_admin">HR Admin</option>
                       <option value="manager">Manager</option>
@@ -118,7 +117,7 @@ export default function UsersPage() {
                   <select
                     value={u.department_id ?? ''}
                     onChange={(e) => handleAssignDepartment(u.id, e.target.value)}
-                    className="border border-gray-200 rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <option value="">No department</option>
                     {activeDepartments.map((d) => (
@@ -129,8 +128,8 @@ export default function UsersPage() {
                 <td className="px-5 py-3.5">
                   <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium border ${
                     u.is_active
-                      ? 'bg-green-50 text-green-700 border-green-100'
-                      : 'bg-gray-100 text-gray-500 border-gray-200'
+                      ? 'bg-green-50 text-green-700 border-green-100 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+                      : 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
                   }`}>
                     {u.is_active ? 'Active' : 'Inactive'}
                   </span>
@@ -148,7 +147,7 @@ export default function UsersPage() {
             ))}
             {filteredUsers.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-5 py-8 text-center text-gray-400 text-sm">
+                <td colSpan={6} className="px-5 py-8 text-center text-gray-400 dark:text-gray-500 text-sm">
                   No users found.
                 </td>
               </tr>

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -3,12 +3,20 @@ import { Outlet, Link } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 import { logout } from '@/features/auth/services/authService'
 import { useAuthStore } from '@/stores/authStore'
+import { useThemeStore, type Theme } from '@/stores/themeStore'
 import { ROUTES } from '@/constants/routes'
 import { USER_ROLES } from '@/constants/userRoles'
+
+const THEME_OPTIONS: { value: Theme; label: string }[] = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
 
 export default function DashboardLayout() {
   const user = useAuthStore((state) => state.user)
   const clearUser = useAuthStore((state) => state.clearUser)
+  const { theme, setTheme } = useThemeStore()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -30,8 +38,8 @@ export default function DashboardLayout() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <nav className="bg-blue-800 text-white px-6 py-3 flex items-center justify-between shadow-md">
+    <div className="min-h-screen bg-slate-50 dark:bg-gray-900">
+      <nav className="bg-blue-800 dark:bg-gray-950 text-white px-6 py-3 flex items-center justify-between shadow-md">
         <span className="text-xl font-bold tracking-tight">StepUp</span>
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
@@ -46,21 +54,41 @@ export default function DashboardLayout() {
             </button>
 
             {open && (
-              <div className="absolute right-0 mt-2 w-44 bg-white rounded-xl shadow-lg border border-gray-200 py-1 z-50">
-                <div className="px-4 py-2 border-b border-gray-100">
-                  <p className="text-xs font-medium text-gray-900">{user?.first_name} {user?.last_name}</p>
-                  <p className="text-xs text-gray-500 truncate">{user?.email}</p>
+              <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
+                <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
+                  <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
                 </div>
                 <Link
                   to={user?.role === USER_ROLES.MANAGER ? ROUTES.MANAGER_PROFILE : ROUTES.EMPLOYEE_PROFILE}
                   onClick={() => setOpen(false)}
-                  className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
                   My Profile
                 </Link>
+
+                <div className="px-4 py-2 border-t border-gray-100 dark:border-gray-700">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Theme</p>
+                  <div className="flex gap-1">
+                    {THEME_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        onClick={() => setTheme(opt.value)}
+                        className={`flex-1 text-xs py-1 rounded transition-colors ${
+                          theme === opt.value
+                            ? 'bg-blue-600 text-white'
+                            : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 <button
                   onClick={handleLogout}
-                  className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                  className="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-t border-gray-100 dark:border-gray-700"
                 >
                   Logout
                 </button>

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -19,12 +19,14 @@ export default function DashboardLayout() {
   const { theme, setTheme } = useThemeStore()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
+  const [showTheme, setShowTheme] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setOpen(false)
+        setShowTheme(false)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
@@ -44,7 +46,7 @@ export default function DashboardLayout() {
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button
-              onClick={() => setOpen((v) => !v)}
+              onClick={() => { setOpen((v) => !v); setShowTheme(false) }}
               className="flex flex-col justify-center items-center gap-1 w-8 h-8 rounded-lg hover:bg-white/10 transition-colors"
               aria-label="User menu"
             >
@@ -59,6 +61,7 @@ export default function DashboardLayout() {
                   <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
                 </div>
+
                 <Link
                   to={user?.role === USER_ROLES.MANAGER ? ROUTES.MANAGER_PROFILE : ROUTES.EMPLOYEE_PROFILE}
                   onClick={() => setOpen(false)}
@@ -67,24 +70,31 @@ export default function DashboardLayout() {
                   My Profile
                 </Link>
 
-                <div className="px-4 py-2 border-t border-gray-100 dark:border-gray-700">
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Theme</p>
-                  <div className="flex gap-1">
+                <button
+                  onClick={() => setShowTheme((v) => !v)}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
+                >
+                  <span>Theme</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500">{showTheme ? '▲' : '▼'}</span>
+                </button>
+
+                {showTheme && (
+                  <div className="px-3 pb-2 flex gap-1">
                     {THEME_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
-                        onClick={() => setTheme(opt.value)}
-                        className={`flex-1 text-xs py-1 rounded transition-colors ${
+                        onClick={() => { setTheme(opt.value); setShowTheme(false) }}
+                        className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           theme === opt.value
                             ? 'bg-blue-600 text-white'
-                            : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
                         }`}
                       >
                         {opt.label}
                       </button>
                     ))}
                   </div>
-                </div>
+                )}
 
                 <button
                   onClick={handleLogout}

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -18,12 +18,14 @@ export default function HRDashboardLayout() {
   const { theme, setTheme } = useThemeStore()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
+  const [showTheme, setShowTheme] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setOpen(false)
+        setShowTheme(false)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
@@ -36,6 +38,13 @@ export default function HRDashboardLayout() {
     navigate(ROUTES.LOGIN)
   }
 
+  const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+      isActive
+        ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+        : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+    }`
+
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-gray-900 flex flex-col">
       <nav className="bg-blue-800 dark:bg-gray-950 text-white px-6 py-3 flex items-center justify-between shadow-md">
@@ -43,7 +52,7 @@ export default function HRDashboardLayout() {
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button
-              onClick={() => setOpen((v) => !v)}
+              onClick={() => { setOpen((v) => !v); setShowTheme(false) }}
               className="flex flex-col justify-center items-center gap-1 w-8 h-8 rounded-lg hover:bg-white/10 transition-colors"
               aria-label="User menu"
             >
@@ -58,6 +67,7 @@ export default function HRDashboardLayout() {
                   <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
                 </div>
+
                 <Link
                   to={ROUTES.PROFILE}
                   onClick={() => setOpen(false)}
@@ -66,24 +76,31 @@ export default function HRDashboardLayout() {
                   My Profile
                 </Link>
 
-                <div className="px-4 py-2 border-t border-gray-100 dark:border-gray-700">
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Theme</p>
-                  <div className="flex gap-1">
+                <button
+                  onClick={() => setShowTheme((v) => !v)}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
+                >
+                  <span>Theme</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500">{showTheme ? '▲' : '▼'}</span>
+                </button>
+
+                {showTheme && (
+                  <div className="px-3 pb-2 flex gap-1">
                     {THEME_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
-                        onClick={() => setTheme(opt.value)}
-                        className={`flex-1 text-xs py-1 rounded transition-colors ${
+                        onClick={() => { setTheme(opt.value); setShowTheme(false) }}
+                        className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           theme === opt.value
                             ? 'bg-blue-600 text-white'
-                            : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
                         }`}
                       >
                         {opt.label}
                       </button>
                     ))}
                   </div>
-                </div>
+                )}
 
                 <button
                   onClick={handleLogout}
@@ -100,90 +117,13 @@ export default function HRDashboardLayout() {
       <div className="flex flex-1">
         <aside className="w-52 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-sm">
           <nav className="flex flex-col p-4 gap-1">
-            <NavLink
-              to={ROUTES.HR_DASHBOARD}
-              className={({ isActive }) =>
-                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`
-              }
-            >
-              Dashboard
-            </NavLink>
-            <NavLink
-              to={ROUTES.HR_USERS}
-              className={({ isActive }) =>
-                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`
-              }
-            >
-              Users
-            </NavLink>
-            <NavLink
-              to={ROUTES.HR_DEPARTMENTS}
-              className={({ isActive }) =>
-                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`
-              }
-            >
-              Departments
-            </NavLink>
-            <NavLink
-              to={ROUTES.HR_TEMPLATES}
-              className={({ isActive }) =>
-                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`
-              }
-            >
-              Templates
-            </NavLink>
-            <NavLink
-              to={ROUTES.HR_PLAN_NEW}
-              className={({ isActive }) =>
-                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`
-              }
-            >
-              Plans
-            </NavLink>
-            <NavLink
-              to={ROUTES.HR_AUDIT}
-              className={({ isActive }) =>
-                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`
-              }
-            >
-              Audit Trail
-            </NavLink>
-            <NavLink
-              to={ROUTES.HR_REPORTS}
-              className={({ isActive }) =>
-                `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
-                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`
-              }
-            >
-              Reports
-            </NavLink>
+            <NavLink to={ROUTES.HR_DASHBOARD} className={navLinkClass}>Dashboard</NavLink>
+            <NavLink to={ROUTES.HR_USERS} className={navLinkClass}>Users</NavLink>
+            <NavLink to={ROUTES.HR_DEPARTMENTS} className={navLinkClass}>Departments</NavLink>
+            <NavLink to={ROUTES.HR_TEMPLATES} className={navLinkClass}>Templates</NavLink>
+            <NavLink to={ROUTES.HR_PLAN_NEW} className={navLinkClass}>Plans</NavLink>
+            <NavLink to={ROUTES.HR_AUDIT} className={navLinkClass}>Audit Trail</NavLink>
+            <NavLink to={ROUTES.HR_REPORTS} className={navLinkClass}>Reports</NavLink>
           </nav>
         </aside>
 

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -3,11 +3,19 @@ import { Outlet, NavLink, Link } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 import { logout } from '@/features/auth/services/authService'
 import { useAuthStore } from '@/stores/authStore'
+import { useThemeStore, type Theme } from '@/stores/themeStore'
 import { ROUTES } from '@/constants/routes'
+
+const THEME_OPTIONS: { value: Theme; label: string }[] = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
 
 export default function HRDashboardLayout() {
   const user = useAuthStore((state) => state.user)
   const clearUser = useAuthStore((state) => state.clearUser)
+  const { theme, setTheme } = useThemeStore()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -29,8 +37,8 @@ export default function HRDashboardLayout() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 flex flex-col">
-      <nav className="bg-blue-800 text-white px-6 py-3 flex items-center justify-between shadow-md">
+    <div className="min-h-screen bg-slate-50 dark:bg-gray-900 flex flex-col">
+      <nav className="bg-blue-800 dark:bg-gray-950 text-white px-6 py-3 flex items-center justify-between shadow-md">
         <span className="text-xl font-bold tracking-tight">StepUp</span>
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
@@ -45,21 +53,41 @@ export default function HRDashboardLayout() {
             </button>
 
             {open && (
-              <div className="absolute right-0 mt-2 w-44 bg-white rounded-xl shadow-lg border border-gray-200 py-1 z-50">
-                <div className="px-4 py-2 border-b border-gray-100">
-                  <p className="text-xs font-medium text-gray-900">{user?.first_name} {user?.last_name}</p>
-                  <p className="text-xs text-gray-500 truncate">{user?.email}</p>
+              <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
+                <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
+                  <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
                 </div>
                 <Link
                   to={ROUTES.PROFILE}
                   onClick={() => setOpen(false)}
-                  className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
                   My Profile
                 </Link>
+
+                <div className="px-4 py-2 border-t border-gray-100 dark:border-gray-700">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Theme</p>
+                  <div className="flex gap-1">
+                    {THEME_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        onClick={() => setTheme(opt.value)}
+                        className={`flex-1 text-xs py-1 rounded transition-colors ${
+                          theme === opt.value
+                            ? 'bg-blue-600 text-white'
+                            : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 <button
                   onClick={handleLogout}
-                  className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                  className="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-t border-gray-100 dark:border-gray-700"
                 >
                   Logout
                 </button>
@@ -70,13 +98,15 @@ export default function HRDashboardLayout() {
       </nav>
 
       <div className="flex flex-1">
-        <aside className="w-52 bg-white border-r border-gray-200 shadow-sm">
+        <aside className="w-52 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-sm">
           <nav className="flex flex-col p-4 gap-1">
             <NavLink
               to={ROUTES.HR_DASHBOARD}
               className={({ isActive }) =>
                 `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                  isActive
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`
               }
             >
@@ -86,7 +116,9 @@ export default function HRDashboardLayout() {
               to={ROUTES.HR_USERS}
               className={({ isActive }) =>
                 `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                  isActive
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`
               }
             >
@@ -96,7 +128,9 @@ export default function HRDashboardLayout() {
               to={ROUTES.HR_DEPARTMENTS}
               className={({ isActive }) =>
                 `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                  isActive
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`
               }
             >
@@ -106,7 +140,9 @@ export default function HRDashboardLayout() {
               to={ROUTES.HR_TEMPLATES}
               className={({ isActive }) =>
                 `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                  isActive
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`
               }
             >
@@ -116,7 +152,9 @@ export default function HRDashboardLayout() {
               to={ROUTES.HR_PLAN_NEW}
               className={({ isActive }) =>
                 `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                  isActive
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`
               }
             >
@@ -126,7 +164,9 @@ export default function HRDashboardLayout() {
               to={ROUTES.HR_AUDIT}
               className={({ isActive }) =>
                 `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                  isActive
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`
               }
             >
@@ -136,7 +176,9 @@ export default function HRDashboardLayout() {
               to={ROUTES.HR_REPORTS}
               className={({ isActive }) =>
                 `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+                  isActive
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                    : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`
               }
             >

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './app/App'
+import ThemeProvider from '@/components/ThemeProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/apps/frontend/src/stores/themeStore.ts
+++ b/apps/frontend/src/stores/themeStore.ts
@@ -8,12 +8,31 @@ interface ThemeState {
   setTheme: (theme: Theme) => void
 }
 
+export function applyTheme(theme: Theme) {
+  const root = document.documentElement
+  if (theme === 'dark') {
+    root.classList.add('dark')
+  } else if (theme === 'light') {
+    root.classList.remove('dark')
+  } else {
+    root.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches)
+  }
+}
+
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set) => ({
       theme: 'system',
-      setTheme: (theme) => set({ theme }),
+      setTheme: (theme) => {
+        applyTheme(theme)
+        set({ theme })
+      },
     }),
-    { name: 'stepup-theme' }
+    {
+      name: 'stepup-theme',
+      onRehydrateStorage: () => (state) => {
+        if (state) applyTheme(state.theme)
+      },
+    }
   )
 )

--- a/apps/frontend/src/stores/themeStore.ts
+++ b/apps/frontend/src/stores/themeStore.ts
@@ -4,7 +4,7 @@ export type Theme = 'light' | 'dark' | 'system'
 
 const KEY = 'stepup-theme'
 
-function readTheme(): Theme {
+export function readTheme(): Theme {
   try {
     const v = localStorage.getItem(KEY)
     if (v === 'light' || v === 'dark' || v === 'system') return v
@@ -16,16 +16,13 @@ export function applyTheme(theme: Theme) {
   const isDark =
     theme === 'dark' ||
     (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
-  document.documentElement.classList.toggle('dark', isDark)
+
+  if (isDark) {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
 }
-
-// Apply immediately when this module loads (before React mounts)
-applyTheme(readTheme())
-
-// Keep dark class in sync when OS preference changes and theme is 'system'
-window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-  if (readTheme() === 'system') applyTheme('system')
-})
 
 interface ThemeState {
   theme: Theme

--- a/apps/frontend/src/stores/themeStore.ts
+++ b/apps/frontend/src/stores/themeStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+interface ThemeState {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: 'system',
+      setTheme: (theme) => set({ theme }),
+    }),
+    { name: 'stepup-theme' }
+  )
+)

--- a/apps/frontend/src/stores/themeStore.ts
+++ b/apps/frontend/src/stores/themeStore.ts
@@ -2,26 +2,30 @@ import { create } from 'zustand'
 
 export type Theme = 'light' | 'dark' | 'system'
 
-const STORAGE_KEY = 'stepup-theme'
+const KEY = 'stepup-theme'
 
-function getStoredTheme(): Theme {
+function readTheme(): Theme {
   try {
-    return (localStorage.getItem(STORAGE_KEY) as Theme) || 'system'
-  } catch {
-    return 'system'
-  }
+    const v = localStorage.getItem(KEY)
+    if (v === 'light' || v === 'dark' || v === 'system') return v
+  } catch {}
+  return 'system'
 }
 
 export function applyTheme(theme: Theme) {
-  const root = document.documentElement
-  if (theme === 'dark') {
-    root.classList.add('dark')
-  } else if (theme === 'light') {
-    root.classList.remove('dark')
-  } else {
-    root.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches)
-  }
+  const isDark =
+    theme === 'dark' ||
+    (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  document.documentElement.classList.toggle('dark', isDark)
 }
+
+// Apply immediately when this module loads (before React mounts)
+applyTheme(readTheme())
+
+// Keep dark class in sync when OS preference changes and theme is 'system'
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  if (readTheme() === 'system') applyTheme('system')
+})
 
 interface ThemeState {
   theme: Theme
@@ -29,9 +33,9 @@ interface ThemeState {
 }
 
 export const useThemeStore = create<ThemeState>()((set) => ({
-  theme: getStoredTheme(),
+  theme: readTheme(),
   setTheme: (theme) => {
-    localStorage.setItem(STORAGE_KEY, theme)
+    localStorage.setItem(KEY, theme)
     applyTheme(theme)
     set({ theme })
   },

--- a/apps/frontend/src/stores/themeStore.ts
+++ b/apps/frontend/src/stores/themeStore.ts
@@ -1,11 +1,15 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
 
 export type Theme = 'light' | 'dark' | 'system'
 
-interface ThemeState {
-  theme: Theme
-  setTheme: (theme: Theme) => void
+const STORAGE_KEY = 'stepup-theme'
+
+function getStoredTheme(): Theme {
+  try {
+    return (localStorage.getItem(STORAGE_KEY) as Theme) || 'system'
+  } catch {
+    return 'system'
+  }
 }
 
 export function applyTheme(theme: Theme) {
@@ -19,20 +23,16 @@ export function applyTheme(theme: Theme) {
   }
 }
 
-export const useThemeStore = create<ThemeState>()(
-  persist(
-    (set) => ({
-      theme: 'system',
-      setTheme: (theme) => {
-        applyTheme(theme)
-        set({ theme })
-      },
-    }),
-    {
-      name: 'stepup-theme',
-      onRehydrateStorage: () => (state) => {
-        if (state) applyTheme(state.theme)
-      },
-    }
-  )
-)
+interface ThemeState {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+export const useThemeStore = create<ThemeState>()((set) => ({
+  theme: getStoredTheme(),
+  setTheme: (theme) => {
+    localStorage.setItem(STORAGE_KEY, theme)
+    applyTheme(theme)
+    set({ theme })
+  },
+}))

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {},

--- a/docs/guides/tutorials/frontend/004-tailwind.md
+++ b/docs/guides/tutorials/frontend/004-tailwind.md
@@ -119,6 +119,64 @@ Three directives that Tailwind replaces with generated CSS:
 
 ---
 
+## Dark Mode
+
+The project uses Tailwind's class-based dark mode strategy.
+
+### Configuration
+
+```javascript
+// tailwind.config.js
+export default {
+  darkMode: 'class',  // ← dark: variants activate when <html> has class="dark"
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  ...
+}
+```
+
+With `darkMode: 'class'`, every `dark:` prefixed utility only applies when an ancestor element has the `dark` class. In practice this means `<html class="dark">`.
+
+> **Important:** After changing `darkMode` in `tailwind.config.js`, you must restart the Vite dev server. PostCSS reads the Tailwind config at startup and caches the CSS. Without a restart, dark: variants may still use the old strategy (`media` or none).
+
+### Applying dark styles
+
+Add a `dark:` variant alongside the light class:
+
+```tsx
+// background
+<div className="bg-white dark:bg-gray-800">
+
+// text
+<p className="text-gray-900 dark:text-gray-100">
+
+// border
+<div className="border-gray-200 dark:border-gray-700">
+
+// hover
+<button className="hover:bg-gray-50 dark:hover:bg-gray-700">
+```
+
+### How the class is set
+
+The `.dark` class on `<html>` is managed by `themeStore.ts`:
+
+```typescript
+export function applyTheme(theme: Theme) {
+  const isDark =
+    theme === 'dark' ||
+    (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  if (isDark) {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
+}
+```
+
+An inline script in `index.html` also runs before React mounts to prevent a flash of the wrong theme on page load.
+
+---
+
 ## The @tailwind Warnings in VSCode
 
 VSCode's built-in CSS linter does not know about `@tailwind`. It shows yellow warnings: "Unknown at rule @tailwind".

--- a/docs/guides/tutorials/frontend/014-zustand.md
+++ b/docs/guides/tutorials/frontend/014-zustand.md
@@ -71,6 +71,71 @@ clearUser()
 
 ---
 
+## Second Store: themeStore
+
+The project has a second Zustand store for theme selection (`src/stores/themeStore.ts`). It is a good example of Zustand used for non-auth global state.
+
+```typescript
+import { create } from 'zustand'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+const KEY = 'stepup-theme'
+
+export function readTheme(): Theme {
+  try {
+    const v = localStorage.getItem(KEY)
+    if (v === 'light' || v === 'dark' || v === 'system') return v
+  } catch {}
+  return 'system'
+}
+
+export function applyTheme(theme: Theme) {
+  const isDark =
+    theme === 'dark' ||
+    (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  if (isDark) {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
+}
+
+export const useThemeStore = create<ThemeState>()((set) => ({
+  theme: readTheme(),
+  setTheme: (theme) => {
+    localStorage.setItem(KEY, theme)
+    applyTheme(theme)
+    set({ theme })
+  },
+}))
+```
+
+**Key design decisions:**
+
+- No `persist` middleware — localStorage is read/written directly inside `setTheme`. This avoids the async rehydration race condition that `persist`'s `onRehydrateStorage` introduces.
+- `applyTheme` is called synchronously before `set()` — the DOM class changes immediately on click, before React re-renders.
+- `readTheme()` validates the stored value strictly (`'light' | 'dark' | 'system'`) — any other value (including stale JSON from a previous format) falls back to `'system'`.
+
+**Usage in layouts:**
+
+```typescript
+const { theme, setTheme } = useThemeStore()
+
+// Render 3 buttons, highlight the active one
+{THEME_OPTIONS.map((opt) => (
+  <button
+    key={opt.value}
+    onClick={() => setTheme(opt.value)}
+    className={theme === opt.value ? 'bg-blue-600 text-white' : '...'}
+  >
+    {opt.label}
+  </button>
+))}
+```
+
+---
+
 ## Important: Clear on Logout
 
 Zustand state persists across route changes but is lost when the browser tab closes.

--- a/docs/guides/tutorials/frontend/018-ui-patterns.md
+++ b/docs/guides/tutorials/frontend/018-ui-patterns.md
@@ -151,9 +151,59 @@ Used to show active/inactive state consistently across all list pages:
 ```tsx
 <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium border ${
   item.is_active
-    ? 'bg-green-50 text-green-700 border-green-100'
-    : 'bg-gray-100 text-gray-500 border-gray-200'
+    ? 'bg-green-50 text-green-700 border-green-100 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+    : 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
 }`}>
   {item.is_active ? 'Active' : 'Inactive'}
 </span>
 ```
+
+Always pair light and dark variants together. The convention used throughout this project:
+
+| Light | Dark |
+|---|---|
+| `bg-white` | `dark:bg-gray-800` |
+| `bg-gray-50` | `dark:bg-gray-700/50` |
+| `text-gray-900` | `dark:text-gray-100` |
+| `text-gray-600` | `dark:text-gray-400` |
+| `border-gray-200` | `dark:border-gray-700` |
+| `hover:bg-gray-50` | `dark:hover:bg-gray-700/50` |
+| `divide-gray-100` | `dark:divide-gray-700` |
+
+---
+
+## Collapsible Theme Toggle
+
+The theme toggle in the hamburger menu uses a local `showTheme` boolean to expand/collapse the three option buttons. The pattern avoids a separate modal or page — it's an accordion inside the existing dropdown.
+
+```tsx
+const [showTheme, setShowTheme] = useState(false)
+const { theme, setTheme } = useThemeStore()
+
+// Inside the dropdown:
+<button
+  onClick={() => setShowTheme((v) => !v)}
+  className="w-full text-left px-4 py-2 text-sm ..."
+>
+  <span>Theme</span>
+  <span>{showTheme ? '▲' : '▼'}</span>
+</button>
+
+{showTheme && (
+  <div className="px-3 pb-2 flex gap-1">
+    {(['light', 'dark', 'system'] as const).map((opt) => (
+      <button
+        key={opt}
+        onClick={() => { setTheme(opt); setShowTheme(false) }}
+        className={theme === opt ? 'bg-blue-600 text-white ...' : '...'}
+      >
+        {opt}
+      </button>
+    ))}
+  </div>
+)}
+```
+
+- Selecting an option immediately applies the theme AND closes the panel
+- The active option is highlighted with `bg-blue-600 text-white`
+- `setTheme` writes to `localStorage` and updates the `.dark` class on `<html>` synchronously

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -770,9 +770,17 @@ ADR-007: Structured logging to GCP Cloud Logging
 
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
-- Dutch + English language support (i18n)
+- Dutch + English language support (i18n) — backlog #197
 - Webhook system for external integrations
 - Full-text search on tasks and templates (PostgreSQL tsvector)
+
+### Feature Branch: US-198 — Dark / Light / System Theme ✅ Done
+- Three-way theme toggle (Light / Dark / System) in hamburger menu
+- `darkMode: 'class'` in Tailwind config; `.dark` class applied to `<html>` root
+- `themeStore` (Zustand) persists selection to `localStorage`
+- `ThemeProvider` applies theme on mount and on every store change; handles OS media query listener for System mode
+- All pages and layouts fully dark-mode styled
+- Theme selection persists across page reloads
 
 ---
 
@@ -842,6 +850,8 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 1.6 | 2026-05-14 | US-016 email notifications done; plan started, task completed/approved/returned emails added via SendGrid |
 | 1.7 | 2026-05-14 | Sprint 9 done; US-017 scheduler (OVERDUE status + APScheduler lifespan + 2 daily jobs), US-020 reports (3 endpoints + CSV + ReportsPage), comprehensive seed data, audit_log migration fix; Sprint 8 closed, Sprint 9 added, Sprint 10 scoped |
 | 1.8 | 2026-05-14 | US-014b done; GCS bucket created, TaskAttachment + TaskComment models, signed URL downloads, EmployeePlanPage expandable panel; Sprint 9 updated, Sprint 10 reduced to US-021 only |
+| 1.9 | 2026-05-15 | Sprint 10 US-021 done; return_comment added to DB schema; Sprint 10 remaining items (pagination, E2E, README) marked pending |
+| 2.0 | 2026-05-15 | US-198 done; Dark/Light/System theme toggle added to hamburger menu; all pages dark-mode styled; ThemeProvider + themeStore implemented |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/scrum/review/sprint-10.md
+++ b/docs/scrum/review/sprint-10.md
@@ -56,6 +56,28 @@ Clicking a task title expands an inline panel (attachments + upload input + comm
 
 Max size: 10 MB
 
+## US-198 — Dark / Light / System Theme ✅ Done
+
+Delivered on `feature/us-198-theme-support` branching from `develop`.
+
+### What was built
+
+- **Three-way theme toggle** (Light / Dark / System) in the hamburger menu on all layouts
+- Theme collapses under a "Theme ▼" row — clicking expands the 3 options; selecting one closes the panel
+- **`themeStore`** (Zustand, no persist middleware) reads/writes `localStorage` key `stepup-theme` directly in `setTheme` — synchronous apply, no async rehydration race conditions
+- **`ThemeProvider`** wraps the app in `main.tsx`; `useEffect([theme])` re-applies the class whenever the store changes; OS media query listener active only in System mode
+- **`index.html` inline script** applies the correct class before React mounts to prevent flash of wrong theme; also clears the old zustand-persist JSON format from localStorage if present
+- **`tailwind.config.js`**: `darkMode: 'class'` — requires Vite/PostCSS restart to pick up on first use
+- All pages fully dark-mode styled: layouts, dashboards, tables, cards, forms, modals, badges
+
+### Root cause of light mode not working (postmortem)
+
+Vite was started before `darkMode: 'class'` was added to `tailwind.config.js`. PostCSS/Tailwind had cached the CSS without class-based dark mode — all `dark:` variants used `@media (prefers-color-scheme: dark)`. Restarting the frontend container forced a CSS rebuild. After restart, removing the `.dark` class from `<html>` immediately switched the page to light mode.
+
+Debug overlay (`ThemeProvider` renders `html.class` + `store theme`) was used to confirm the class was empty but the page was still dark — confirming a CSS/build issue, not a JavaScript issue.
+
+---
+
 ## Notes
 - `gcs-key.json` is gitignored via `*.json` pattern (with exceptions for `package.json`, `tsconfig*.json`, `turbo.json`)
 - `GOOGLE_APPLICATION_CREDENTIALS` env var points to `/app/gcs-key.json` inside the container

--- a/docs/scrum/sprint-goals.md
+++ b/docs/scrum/sprint-goals.md
@@ -40,3 +40,6 @@ APScheduler marks overdue tasks daily and sends deadline reminders. HR Admin rep
 
 ## Sprint 10 — Final Polish
 All list endpoints are paginated. Full E2E regression suite passes in CI. README and Swagger polished for demo. US-021 quality & polish.
+
+## Feature Branch: US-198 — Theme Toggle
+Users can switch between Light, Dark, and System theme from the hamburger menu. The selection persists across page reloads. All pages and layouts are fully styled for dark mode.


### PR DESCRIPTION
## Summary

- Adds a three-way theme toggle (Light / Dark / System) to the hamburger menu on all layouts
- Theme collapses under a \"Theme ▼\" row in the dropdown — clicking expands the 3 options
- Selection persists across page reloads via `localStorage`
- All pages and layouts fully styled for dark mode

## Implementation

**`themeStore` (Zustand, no persist middleware)**
- Reads/writes `localStorage` key `stepup-theme` directly in `setTheme`
- `applyTheme` called synchronously — DOM class changes immediately on click, before React re-renders
- `readTheme()` validates stored value strictly; stale JSON from old format falls back to `system`

**`ThemeProvider`**
- `useEffect([theme])` re-applies class on every store change
- OS media query listener active only in System mode
- Mounts at the top of the tree in `main.tsx`

**`tailwind.config.js`**: `darkMode: 'class'`

**`index.html` inline script**
- Applies correct class before React mounts (no flash of wrong theme)
- Clears old zustand-persist JSON format from localStorage on first load

## Pages updated for dark mode

All layouts, dashboards, list pages, detail pages, forms, modals, dropdowns, and the KebabMenu component.

## Postmortem — light mode not working

Root cause: Vite was started before `darkMode: 'class'` was added to `tailwind.config.js`. PostCSS had cached the CSS with `@media (prefers-color-scheme: dark)` — removing the `.dark` class had no effect. Restarting the frontend container forced a CSS rebuild. Diagnosed with a `MutationObserver` debug overlay that showed `html.class: ""` while the page was still dark — confirming a CSS/build issue, not a JavaScript issue.

## Test plan

- [ ] Open app, confirm default System theme matches OS preference
- [ ] Click hamburger → Theme → Dark → page switches to dark immediately
- [ ] Click hamburger → Theme → Light → page switches to light immediately
- [ ] Reload page → theme persists
- [ ] Switch OS dark mode on/off while System is selected → page updates automatically
- [ ] All pages (Dashboard, Users, Templates, Plans, Audit, Reports, Profile) look correct in both themes

Closes #198

