### PR TITLE
feat: make StepUp logo a dashboard link in all layouts

### DIFF
--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -42,7 +42,10 @@ export default function DashboardLayout() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-gray-900">
       <nav className="bg-blue-800 dark:bg-gray-950 text-white px-6 py-3 flex items-center justify-between shadow-md">
-        <span className="text-xl font-bold tracking-tight">StepUp</span>
+        <Link
+          to={user?.role === USER_ROLES.MANAGER ? ROUTES.MANAGER_DASHBOARD : ROUTES.EMPLOYEE_DASHBOARD}
+          className="text-xl font-bold tracking-tight hover:opacity-80 transition-opacity"
+        >StepUp</Link>
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -48,7 +48,7 @@ export default function HRDashboardLayout() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-gray-900 flex flex-col">
       <nav className="bg-blue-800 dark:bg-gray-950 text-white px-6 py-3 flex items-center justify-between shadow-md">
-        <span className="text-xl font-bold tracking-tight">StepUp</span>
+        <Link to={ROUTES.HR_DASHBOARD} className="text-xl font-bold tracking-tight hover:opacity-80 transition-opacity">StepUp</Link>
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button

--- a/docs/guides/tutorials/frontend/018-ui-patterns.md
+++ b/docs/guides/tutorials/frontend/018-ui-patterns.md
@@ -172,6 +172,35 @@ Always pair light and dark variants together. The convention used throughout thi
 
 ---
 
+## Logo Navigation
+
+The "StepUp" logo in the navbar is a `<Link>` that takes the user to their dashboard. The destination is role-based:
+
+| Layout | Destination |
+|--------|-------------|
+| `HRDashboardLayout` | `ROUTES.HR_DASHBOARD` |
+| `DashboardLayout` (Manager) | `ROUTES.MANAGER_DASHBOARD` |
+| `DashboardLayout` (Employee) | `ROUTES.EMPLOYEE_DASHBOARD` |
+
+```tsx
+// HRDashboardLayout — always the same destination
+<Link to={ROUTES.HR_DASHBOARD} className="text-xl font-bold tracking-tight hover:opacity-80 transition-opacity">
+  StepUp
+</Link>
+
+// DashboardLayout — role determines destination
+<Link
+  to={user?.role === USER_ROLES.MANAGER ? ROUTES.MANAGER_DASHBOARD : ROUTES.EMPLOYEE_DASHBOARD}
+  className="text-xl font-bold tracking-tight hover:opacity-80 transition-opacity"
+>
+  StepUp
+</Link>
+```
+
+`user` is read from `useAuthStore` — already present in both layouts, no extra import needed.
+
+---
+
 ## Collapsible Theme Toggle
 
 The theme toggle in the hamburger menu uses a local `showTheme` boolean to expand/collapse the three option buttons. The pattern avoids a separate modal or page — it's an accordion inside the existing dropdown.


### PR DESCRIPTION
## Summary

- `HRDashboardLayout`: StepUp logo links to `ROUTES.HR_DASHBOARD`
- `DashboardLayout`: links to `ROUTES.MANAGER_DASHBOARD` or `ROUTES.EMPLOYEE_DASHBOARD` based on `user.role`
- `018-ui-patterns.md`: Logo Navigation pattern documented

## Test plan

- [ ] HR Admin kullanıcısıyla giriş yap → farklı bir sayfadayken logoya tıkla → `/hr/dashboard`'a gitsin
- [ ] Manager kullanıcısıyla giriş yap → logoya tıkla → `/manager/dashboard`'a gitsin
- [ ] Employee kullanıcısıyla giriş yap → logoya tıkla → `/employee/dashboard`'a gitsin