### PR TITLE
feat: refactor audit log with enum types and advanced filters

### DIFF
--- a/apps/backend/alembic/versions/b1c2d3e4f5a6_refactor_audit_log_enums_and_filters.py
+++ b/apps/backend/alembic/versions/b1c2d3e4f5a6_refactor_audit_log_enums_and_filters.py
@@ -1,0 +1,89 @@
+"""refactor_audit_log_enums_and_filters
+
+Revision ID: b1c2d3e4f5a6
+Revises: f2a3b4c5d6e7
+Create Date: 2026-05-15 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = 'b1c2d3e4f5a6'
+down_revision: Union[str, None] = 'f2a3b4c5d6e7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+audit_action_type_values = [
+    "user.invited",
+    "user.registered",
+    "user.deactivated",
+    "user.reactivated",
+    "user.updated",
+    "plan.created",
+    "plan.task_cancelled",
+    "task.started",
+    "task.completed",
+    "task.approved",
+    "task.returned",
+]
+
+audit_entity_type_values = [
+    "user",
+    "invitation",
+    "plan",
+    "task",
+]
+
+
+def upgrade() -> None:
+    audit_action_type = postgresql.ENUM(
+        *audit_action_type_values,
+        name="audit_action_type",
+        create_type=False,
+    )
+    audit_action_type.create(op.get_bind(), checkfirst=True)
+
+    audit_entity_type = postgresql.ENUM(
+        *audit_entity_type_values,
+        name="audit_entity_type",
+        create_type=False,
+    )
+    audit_entity_type.create(op.get_bind(), checkfirst=True)
+
+    op.execute(
+        "ALTER TABLE audit_logs "
+        "ALTER COLUMN action TYPE audit_action_type "
+        "USING action::audit_action_type"
+    )
+
+    op.execute(
+        "ALTER TABLE audit_logs "
+        "ALTER COLUMN entity_type TYPE audit_entity_type "
+        "USING entity_type::audit_entity_type"
+    )
+
+    op.create_index('ix_audit_logs_actor_id', 'audit_logs', ['actor_id'], unique=False)
+    op.create_index('ix_audit_logs_entity_id', 'audit_logs', ['entity_id'], unique=False)
+    op.create_index('ix_audit_logs_entity_type', 'audit_logs', ['entity_type'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_audit_logs_entity_type', table_name='audit_logs')
+    op.drop_index('ix_audit_logs_entity_id', table_name='audit_logs')
+    op.drop_index('ix_audit_logs_actor_id', table_name='audit_logs')
+
+    op.execute(
+        "ALTER TABLE audit_logs "
+        "ALTER COLUMN entity_type TYPE VARCHAR(64) "
+        "USING entity_type::text"
+    )
+    op.execute(
+        "ALTER TABLE audit_logs "
+        "ALTER COLUMN action TYPE VARCHAR(64) "
+        "USING action::text"
+    )
+
+    op.execute("DROP TYPE IF EXISTS audit_entity_type")
+    op.execute("DROP TYPE IF EXISTS audit_action_type")

--- a/apps/backend/app/api/v1/audit.py
+++ b/apps/backend/app/api/v1/audit.py
@@ -1,24 +1,40 @@
+import uuid
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.dependencies import require_role
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.enums.user_role import UserRole
 from app.models.user import User
-from app.schemas.audit_log import AuditLogResponse
+from app.schemas.audit_log import AuditLogListResponse
 from app.services.audit_service import AuditService
 
 router = APIRouter()
 audit_service = AuditService()
 
 
-@router.get("/", response_model=list[AuditLogResponse])
+@router.get("/", response_model=AuditLogListResponse)
 async def get_audit_logs(
-    action: str | None = Query(None),
-    limit: int = Query(100, ge=1, le=500),
-    offset: int = Query(0, ge=0),
+    action: AuditActionType | None = Query(None, description="Filter by action type"),
+    entity_type: AuditEntityType | None = Query(None, description="Filter by entity type"),
+    actor_id: uuid.UUID | None = Query(None, description="Filter by actor (user) ID"),
+    date_from: datetime | None = Query(None, description="Filter from date (ISO 8601)"),
+    date_to: datetime | None = Query(None, description="Filter to date (ISO 8601)"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=200, description="Items per page"),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.HR_ADMIN)),
-) -> list[AuditLogResponse]:
-    logs = await audit_service.get_logs(db=db, action=action, limit=limit, offset=offset)
-    return [AuditLogResponse.model_validate(log) for log in logs]
+) -> AuditLogListResponse:
+    return await audit_service.get_logs(
+        db=db,
+        action=action,
+        entity_type=entity_type,
+        actor_id=actor_id,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        page_size=page_size,
+    )

--- a/apps/backend/app/enums/audit_enums.py
+++ b/apps/backend/app/enums/audit_enums.py
@@ -1,0 +1,24 @@
+import enum
+
+
+class AuditActionType(str, enum.Enum):
+    user_invited = "user.invited"
+    user_registered = "user.registered"
+    user_deactivated = "user.deactivated"
+    user_reactivated = "user.reactivated"
+    user_updated = "user.updated"
+
+    plan_created = "plan.created"
+    plan_task_cancelled = "plan.task_cancelled"
+
+    task_started = "task.started"
+    task_completed = "task.completed"
+    task_approved = "task.approved"
+    task_returned = "task.returned"
+
+
+class AuditEntityType(str, enum.Enum):
+    user = "user"
+    invitation = "invitation"
+    plan = "plan"
+    task = "task"

--- a/apps/backend/app/models/audit_log.py
+++ b/apps/backend/app/models/audit_log.py
@@ -1,23 +1,39 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, ForeignKey, Text
+from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 
 from app.models.base import Base
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 
 
 class AuditLog(Base):
     __tablename__ = "audit_logs"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    actor_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    action: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
-    entity_type: Mapped[str] = mapped_column(String(64), nullable=False)
-    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    actor_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+    action: Mapped[AuditActionType] = mapped_column(
+        SAEnum(AuditActionType, name="audit_action_type", values_callable=lambda obj: [e.value for e in obj]),
+        nullable=False,
+        index=True,
+    )
+    entity_type: Mapped[AuditEntityType] = mapped_column(
+        SAEnum(AuditEntityType, name="audit_entity_type", values_callable=lambda obj: [e.value for e in obj]),
+        nullable=False,
+        index=True,
+    )
+    entity_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
     detail: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
     )

--- a/apps/backend/app/repositories/audit_log_repository.py
+++ b/apps/backend/app/repositories/audit_log_repository.py
@@ -1,6 +1,10 @@
-from sqlalchemy import select
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select, func, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.models.audit_log import AuditLog
 
 
@@ -12,13 +16,44 @@ class AuditLogRepository:
     async def get_all(
         self,
         db: AsyncSession,
-        action: str | None = None,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> list[AuditLog]:
-        query = select(AuditLog).order_by(AuditLog.created_at.desc())
+        action: AuditActionType | None = None,
+        entity_type: AuditEntityType | None = None,
+        actor_id: uuid.UUID | None = None,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> tuple[list[AuditLog], int]:
+        filters = []
+
         if action:
-            query = query.where(AuditLog.action == action)
-        query = query.limit(limit).offset(offset)
+            filters.append(AuditLog.action == action)
+        if entity_type:
+            filters.append(AuditLog.entity_type == entity_type)
+        if actor_id:
+            filters.append(AuditLog.actor_id == actor_id)
+        if date_from:
+            filters.append(AuditLog.created_at >= date_from)
+        if date_to:
+            filters.append(AuditLog.created_at <= date_to)
+
+        count_query = select(func.count()).select_from(AuditLog)
+        if filters:
+            count_query = count_query.where(and_(*filters))
+        count_result = await db.execute(count_query)
+        total = count_result.scalar_one()
+
+        offset = (page - 1) * page_size
+        query = (
+            select(AuditLog)
+            .order_by(AuditLog.created_at.desc())
+            .limit(page_size)
+            .offset(offset)
+        )
+        if filters:
+            query = query.where(and_(*filters))
+
         result = await db.execute(query)
-        return list(result.scalars().all())
+        items = list(result.scalars().all())
+
+        return items, total

--- a/apps/backend/app/schemas/audit_log.py
+++ b/apps/backend/app/schemas/audit_log.py
@@ -3,14 +3,26 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from app.enums.audit_enums import AuditActionType, AuditEntityType
+
 
 class AuditLogResponse(BaseModel):
     id: uuid.UUID
     actor_id: uuid.UUID
-    action: str
-    entity_type: str
+    action: AuditActionType
+    entity_type: AuditEntityType
     entity_id: uuid.UUID
     detail: str | None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class AuditLogListResponse(BaseModel):
+    items: list[AuditLogResponse]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_next: bool
+    has_prev: bool

--- a/apps/backend/app/services/audit_service.py
+++ b/apps/backend/app/services/audit_service.py
@@ -1,9 +1,12 @@
 import uuid
+from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.models.audit_log import AuditLog
 from app.repositories.audit_log_repository import AuditLogRepository
+from app.schemas.audit_log import AuditLogListResponse, AuditLogResponse
 
 audit_log_repository = AuditLogRepository()
 
@@ -14,8 +17,8 @@ class AuditService:
         self,
         db: AsyncSession,
         actor_id: uuid.UUID,
-        action: str,
-        entity_type: str,
+        action: AuditActionType,
+        entity_type: AuditEntityType,
         entity_id: uuid.UUID,
         detail: str | None = None,
     ) -> None:
@@ -31,8 +34,32 @@ class AuditService:
     async def get_logs(
         self,
         db: AsyncSession,
-        action: str | None = None,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> list[AuditLog]:
-        return await audit_log_repository.get_all(db, action=action, limit=limit, offset=offset)
+        action: AuditActionType | None = None,
+        entity_type: AuditEntityType | None = None,
+        actor_id: uuid.UUID | None = None,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> AuditLogListResponse:
+        items, total = await audit_log_repository.get_all(
+            db,
+            action=action,
+            entity_type=entity_type,
+            actor_id=actor_id,
+            date_from=date_from,
+            date_to=date_to,
+            page=page,
+            page_size=page_size,
+        )
+        total_pages = (total + page_size - 1) // page_size
+
+        return AuditLogListResponse(
+            items=[AuditLogResponse.model_validate(item) for item in items],
+            total=total,
+            page=page,
+            page_size=page_size,
+            total_pages=total_pages,
+            has_next=page * page_size < total,
+            has_prev=page > 1,
+        )

--- a/apps/backend/app/services/invitation_service.py
+++ b/apps/backend/app/services/invitation_service.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from passlib.context import CryptContext
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.enums.user_role import UserRole
 from app.errors import NotFoundError, ValidationError, messages
 from app.models.invitation import Invitation
@@ -51,7 +52,7 @@ class InvitationService:
         await invitation_repository.create(db, invitation)
         await db.commit()
         await db.refresh(invitation)
-        await audit_service.log(db, actor_id=invited_by, action="user.invited", entity_type="invitation", entity_id=invitation.id, detail=email)
+        await audit_service.log(db, actor_id=invited_by, action=AuditActionType.user_invited, entity_type=AuditEntityType.invitation, entity_id=invitation.id, detail=email)
         await db.commit()
 
         try:
@@ -109,7 +110,7 @@ class InvitationService:
         await db.flush()
         await db.commit()
         await db.refresh(user)
-        await audit_service.log(db, actor_id=user.id, action="user.registered", entity_type="user", entity_id=user.id)
+        await audit_service.log(db, actor_id=user.id, action=AuditActionType.user_registered, entity_type=AuditEntityType.user, entity_id=user.id)
         await db.commit()
         return user
     

--- a/apps/backend/app/services/onboarding_plan_service.py
+++ b/apps/backend/app/services/onboarding_plan_service.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 from app.errors import NotFoundError, ValidationError, messages
 from app.models.onboarding_plan import OnboardingPlan
@@ -75,7 +76,7 @@ class OnboardingPlanService:
 
         await db.commit()
         if actor_id:
-            await audit_service.log(db, actor_id=actor_id, action="plan.created", entity_type="plan", entity_id=plan.id)
+            await audit_service.log(db, actor_id=actor_id, action=AuditActionType.plan_created, entity_type=AuditEntityType.plan, entity_id=plan.id)
             await db.commit()
         try:
             employee = await user_repository.get_by_id(db, data.user_id)
@@ -158,6 +159,6 @@ class OnboardingPlanService:
         await db.commit()
         await db.refresh(task)
         if actor_id:
-            await audit_service.log(db, actor_id=actor_id, action="plan.task_cancelled", entity_type="task", entity_id=task.id)
+            await audit_service.log(db, actor_id=actor_id, action=AuditActionType.plan_task_cancelled, entity_type=AuditEntityType.task, entity_id=task.id)
             await db.commit()
         return task

--- a/apps/backend/app/services/task_workflow_service.py
+++ b/apps/backend/app/services/task_workflow_service.py
@@ -3,6 +3,7 @@ import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.enums.onboarding_plan_task_status import OnboardingPlanTaskStatus
 from app.errors import NotFoundError, ValidationError, messages
 from app.models.onboarding_plan import OnboardingPlan
@@ -47,7 +48,7 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.IN_PROGRESS
         await db.commit()
         await db.refresh(task)
-        await audit_service.log(db, actor_id=current_user.id, action="task.started", entity_type="task", entity_id=task.id)
+        await audit_service.log(db, actor_id=current_user.id, action=AuditActionType.task_started, entity_type=AuditEntityType.task, entity_id=task.id)
         await db.commit()
         return task
 
@@ -59,7 +60,7 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.COMPLETED
         await db.commit()
         await db.refresh(task)
-        await audit_service.log(db, actor_id=current_user.id, action="task.completed", entity_type="task", entity_id=task.id)
+        await audit_service.log(db, actor_id=current_user.id, action=AuditActionType.task_completed, entity_type=AuditEntityType.task, entity_id=task.id)
         await db.commit()
         try:
             plan = await plan_repository.get_by_id(db, task.plan_id)
@@ -109,7 +110,7 @@ class TaskWorkflowService:
         task.status = OnboardingPlanTaskStatus.APPROVED
         await db.commit()
         await db.refresh(task)
-        await audit_service.log(db, actor_id=current_user.id, action="task.approved", entity_type="task", entity_id=task.id)
+        await audit_service.log(db, actor_id=current_user.id, action=AuditActionType.task_approved, entity_type=AuditEntityType.task, entity_id=task.id)
         await db.commit()
         try:
             plan = await plan_repository.get_by_id(db, task.plan_id)
@@ -137,7 +138,7 @@ class TaskWorkflowService:
         task.return_comment = data.content
         await db.commit()
         await db.refresh(task)
-        await audit_service.log(db, actor_id=current_user.id, action="task.returned", entity_type="task", entity_id=task.id, detail=data.content)
+        await audit_service.log(db, actor_id=current_user.id, action=AuditActionType.task_returned, entity_type=AuditEntityType.task, entity_id=task.id, detail=data.content)
         await db.commit()
         try:
             plan = await plan_repository.get_by_id(db, task.plan_id)

--- a/apps/backend/app/services/user_service.py
+++ b/apps/backend/app/services/user_service.py
@@ -2,6 +2,7 @@ import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.enums.user_role import UserRole
 from app.errors import NotFoundError, ValidationError, messages
 from app.models.user import User
@@ -44,7 +45,7 @@ class UserService:
 
         await db.commit()
         if actor_id:
-            await audit_service.log(db, actor_id=actor_id, action="user.updated", entity_type="user", entity_id=user_id)
+            await audit_service.log(db, actor_id=actor_id, action=AuditActionType.user_updated, entity_type=AuditEntityType.user, entity_id=user_id)
             await db.commit()
         return await user_repository.get_by_id(db, user_id)
 
@@ -78,7 +79,7 @@ class UserService:
         user.is_active = False
         await refresh_token_repository.delete_by_user_id(db, user_id)
         await db.commit()
-        await audit_service.log(db, actor_id=current_user_id, action="user.deactivated", entity_type="user", entity_id=user_id)
+        await audit_service.log(db, actor_id=current_user_id, action=AuditActionType.user_deactivated, entity_type=AuditEntityType.user, entity_id=user_id)
         await db.commit()
 
     async def reactivate_user(
@@ -94,6 +95,6 @@ class UserService:
         user.is_active = True
         await db.commit()
         if actor_id:
-            await audit_service.log(db, actor_id=actor_id, action="user.reactivated", entity_type="user", entity_id=user_id)
+            await audit_service.log(db, actor_id=actor_id, action=AuditActionType.user_reactivated, entity_type=AuditEntityType.user, entity_id=user_id)
             await db.commit()
         return await user_repository.get_by_id(db, user_id)

--- a/apps/frontend/src/features/audit/hooks/useAuditLog.ts
+++ b/apps/frontend/src/features/audit/hooks/useAuditLog.ts
@@ -1,16 +1,33 @@
 import { useEffect, useState } from 'react'
-import { getAuditLogs, type AuditLog } from '@/features/audit/services/auditService'
+import {
+  getAuditLogs,
+  type AuditLog,
+  type AuditLogFilters,
+  type AuditLogListResponse,
+} from '@/features/audit/services/auditService'
 
-export function useAuditLog(action?: string) {
-  const [logs, setLogs] = useState<AuditLog[]>([])
+const DEFAULT_PAGE_SIZE = 50
+
+export function useAuditLog(filters: AuditLogFilters = {}) {
+  const [data, setData] = useState<AuditLogListResponse | null>(null)
   const [loading, setLoading] = useState(true)
+
+  const filtersKey = JSON.stringify(filters)
 
   useEffect(() => {
     setLoading(true)
-    getAuditLogs({ action: action || undefined, limit: 200 })
-      .then(setLogs)
+    getAuditLogs({ page_size: DEFAULT_PAGE_SIZE, ...filters })
+      .then(setData)
       .finally(() => setLoading(false))
-  }, [action])
+  }, [filtersKey])
 
-  return { logs, loading }
+  return {
+    logs: data?.items ?? [] as AuditLog[],
+    total: data?.total ?? 0,
+    page: data?.page ?? 1,
+    totalPages: data?.total_pages ?? 1,
+    hasNext: data?.has_next ?? false,
+    hasPrev: data?.has_prev ?? false,
+    loading,
+  }
 }

--- a/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
+++ b/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import { format } from 'date-fns'
 import { useAuditLog } from '@/features/audit/hooks/useAuditLog'
+import type { AuditActionType, AuditEntityType } from '@/features/audit/services/auditService'
 
-const ACTION_LABELS: Record<string, string> = {
+const ACTION_LABELS: Record<AuditActionType, string> = {
   'user.invited': 'User Invited',
   'user.registered': 'User Registered',
   'user.deactivated': 'User Deactivated',
@@ -16,15 +17,21 @@ const ACTION_LABELS: Record<string, string> = {
   'task.returned': 'Task Returned',
 }
 
-const ACTION_COLORS: Record<string, string> = {
-  'user.deactivated': 'text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30',
-  'user.reactivated': 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-900/30',
-  'task.approved': 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-900/30',
-  'task.returned': 'text-orange-600 bg-orange-50 dark:text-orange-400 dark:bg-orange-900/30',
-  'plan.task_cancelled': 'text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30',
+const ACTION_COLORS: Record<AuditActionType, string> = {
+  'user.invited': 'text-blue-700 bg-blue-50',
+  'user.registered': 'text-blue-700 bg-blue-50',
+  'user.deactivated': 'text-red-600 bg-red-50',
+  'user.reactivated': 'text-green-700 bg-green-50',
+  'user.updated': 'text-gray-600 bg-gray-100',
+  'plan.created': 'text-purple-700 bg-purple-50',
+  'plan.task_cancelled': 'text-red-600 bg-red-50',
+  'task.started': 'text-amber-700 bg-amber-50',
+  'task.completed': 'text-green-600 bg-green-50',
+  'task.approved': 'text-green-700 bg-green-100',
+  'task.returned': 'text-orange-600 bg-orange-50',
 }
 
-const ACTION_OPTIONS = [
+const ACTION_OPTIONS: { value: AuditActionType | ''; label: string }[] = [
   { value: '', label: 'All actions' },
   { value: 'user.invited', label: 'User Invited' },
   { value: 'user.registered', label: 'User Registered' },
@@ -39,58 +46,142 @@ const ACTION_OPTIONS = [
   { value: 'task.returned', label: 'Task Returned' },
 ]
 
+const ENTITY_OPTIONS: { value: AuditEntityType | ''; label: string }[] = [
+  { value: '', label: 'All entities' },
+  { value: 'user', label: 'User' },
+  { value: 'invitation', label: 'Invitation' },
+  { value: 'plan', label: 'Plan' },
+  { value: 'task', label: 'Task' },
+]
+
 export default function AuditLogPage() {
-  const [selectedAction, setSelectedAction] = useState('')
-  const { logs, loading } = useAuditLog(selectedAction || undefined)
+  const [selectedAction, setSelectedAction] = useState<AuditActionType | ''>('')
+  const [selectedEntityType, setSelectedEntityType] = useState<AuditEntityType | ''>('')
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+
+  const { logs, total, loading } = useAuditLog({
+    action: selectedAction || undefined,
+    entity_type: selectedEntityType || undefined,
+    date_from: dateFrom ? `${dateFrom}T00:00:00` : undefined,
+    date_to: dateTo ? `${dateTo}T23:59:59` : undefined,
+  })
+
+  function handleClearFilters() {
+    setSelectedAction('')
+    setSelectedEntityType('')
+    setDateFrom('')
+    setDateTo('')
+  }
+
+  const hasActiveFilters = selectedAction || selectedEntityType || dateFrom || dateTo
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-5xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Audit Trail</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">System activity log for all key actions.</p>
+          <h2 className="text-xl font-semibold text-gray-900">Audit Trail</h2>
+          <p className="text-sm text-gray-500 mt-0.5">System activity log for all key actions.</p>
         </div>
-        <select
-          value={selectedAction}
-          onChange={(e) => setSelectedAction(e.target.value)}
-          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          {ACTION_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>{opt.label}</option>
-          ))}
-        </select>
       </div>
 
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+      {/* Filters */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-5 py-4 mb-4">
+        <div className="flex flex-wrap gap-3 items-end">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-gray-500">Action</label>
+            <select
+              value={selectedAction}
+              onChange={(e) => setSelectedAction(e.target.value as AuditActionType | '')}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {ACTION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-gray-500">Entity</label>
+            <select
+              value={selectedEntityType}
+              onChange={(e) => setSelectedEntityType(e.target.value as AuditEntityType | '')}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {ENTITY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-gray-500">From</label>
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-gray-500">To</label>
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {hasActiveFilters && (
+            <button
+              onClick={handleClearFilters}
+              className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 border border-gray-300 rounded-lg hover:border-gray-400 transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        {!loading && (
+          <p className="text-xs text-gray-400 mt-3">
+            {total} {total === 1 ? 'entry' : 'entries'} found
+          </p>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
         {loading ? (
-          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">Loading...</p>
+          <p className="text-sm text-gray-400 px-5 py-4">Loading...</p>
         ) : logs.length === 0 ? (
-          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">No audit logs found.</p>
+          <p className="text-sm text-gray-400 px-5 py-4">No audit logs found.</p>
         ) : (
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-100 dark:border-gray-700">
-                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Date</th>
-                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Action</th>
-                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Entity</th>
-                <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-400 px-5 py-3">Detail</th>
+              <tr className="border-b border-gray-100">
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Date</th>
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Action</th>
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Entity</th>
+                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Detail</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+            <tbody className="divide-y divide-gray-100">
               {logs.map((log) => (
-                <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                <tr key={log.id} className="hover:bg-gray-50">
+                  <td className="px-5 py-3 text-gray-500 whitespace-nowrap">
                     {format(new Date(log.created_at), 'dd MMM yyyy HH:mm')}
                   </td>
                   <td className="px-5 py-3">
-                    <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${ACTION_COLORS[log.action] ?? 'text-blue-700 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30'}`}>
-                      {ACTION_LABELS[log.action] ?? log.action}
+                    <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${ACTION_COLORS[log.action]}`}>
+                      {ACTION_LABELS[log.action]}
                     </span>
                   </td>
-                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 font-mono text-xs truncate max-w-[180px]">
+                  <td className="px-5 py-3 text-gray-500 font-mono text-xs">
                     {log.entity_type} · {log.entity_id.slice(0, 8)}…
                   </td>
-                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 truncate max-w-[200px]">
+                  <td className="px-5 py-3 text-gray-500 truncate max-w-[200px]">
                     {log.detail ?? '—'}
                   </td>
                 </tr>

--- a/apps/frontend/src/features/audit/services/auditService.ts
+++ b/apps/frontend/src/features/audit/services/auditService.ts
@@ -1,17 +1,52 @@
 import apiClient from '@/lib/apiClient'
 import { API } from '@/constants/apiEndpoints'
 
+export type AuditActionType =
+  | 'user.invited'
+  | 'user.registered'
+  | 'user.deactivated'
+  | 'user.reactivated'
+  | 'user.updated'
+  | 'plan.created'
+  | 'plan.task_cancelled'
+  | 'task.started'
+  | 'task.completed'
+  | 'task.approved'
+  | 'task.returned'
+
+export type AuditEntityType = 'user' | 'invitation' | 'plan' | 'task'
+
 export interface AuditLog {
   id: string
   actor_id: string
-  action: string
-  entity_type: string
+  action: AuditActionType
+  entity_type: AuditEntityType
   entity_id: string
   detail: string | null
   created_at: string
 }
 
-export async function getAuditLogs(params?: { action?: string; limit?: number; offset?: number }): Promise<AuditLog[]> {
-  const res = await apiClient.get(API.AUDIT.LIST, { params })
+export interface AuditLogListResponse {
+  items: AuditLog[]
+  total: number
+  page: number
+  page_size: number
+  total_pages: number
+  has_next: boolean
+  has_prev: boolean
+}
+
+export interface AuditLogFilters {
+  action?: AuditActionType
+  entity_type?: AuditEntityType
+  actor_id?: string
+  date_from?: string
+  date_to?: string
+  page?: number
+  page_size?: number
+}
+
+export async function getAuditLogs(filters?: AuditLogFilters): Promise<AuditLogListResponse> {
+  const res = await apiClient.get(API.AUDIT.LIST, { params: filters })
   return res.data
 }


### PR DESCRIPTION
## Summary

- Add `AuditActionType` and `AuditEntityType` enums; migrate `action` and `entity_type` columns from `VARCHAR` to PostgreSQL enum types via Alembic migration
- Extend `GET /api/v1/audit/` with `action`, `entity_type`, `actor_id`, `date_from`, `date_to` query filters and proper pagination (`page`, `page_size`, `total`, `total_pages`)
- Update all `audit_service.log()` call sites (invitation, user, plan, task services) to use enum values instead of raw strings
- Update frontend with typed filter bar (action dropdown, entity dropdown, date range) and result count display

## Test plan

- [ ] Run migration: `docker exec stepup-backend python -m alembic upgrade head`
- [ ] Verify existing audit data survives migration (check with `SELECT DISTINCT action FROM audit_logs;`)
- [ ] Restart backend, confirm `/docs` shows new query parameters on `GET /audit/`
- [ ] Test each filter individually and in combination on the Audit Trail page
- [ ] Run unit and integration test suites: `pytest`