### PR TITLE
fix: install ruff before linting in CI Main workflow

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Lint (ruff)
         working-directory: apps/backend
-        run: ruff check .
+        run: |
+          pip install ruff
+          ruff check .
 
       - name: Run migrations
         working-directory: apps/backend


### PR DESCRIPTION
ci-main.yml lint adımında ruff yüklenmeden çalıştırılıyordu (command not found). pip install ruff eklendi.