### PR TITLE
chore: disable dependabot auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,0 @@
-version: 2
-
-updates: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,3 @@
 version: 2
 
-updates:
-  - package-ecosystem: "npm"
-    directory: "/apps/frontend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "frontend"
-
-  - package-ecosystem: "pip"
-    directory: "/apps/backend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "backend"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "ci"
+updates: []


### PR DESCRIPTION
Dependabot PR'larını manuel yönetmek için otomatik güncelleme devre dışı bırakıldı.