### PR TITLE
Feature/optimistic UI updates

### DIFF
--- a/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
+++ b/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
@@ -18,17 +18,17 @@ const ACTION_LABELS: Record<AuditActionType, string> = {
 }
 
 const ACTION_COLORS: Record<AuditActionType, string> = {
-  'user.invited': 'text-blue-700 bg-blue-50',
-  'user.registered': 'text-blue-700 bg-blue-50',
-  'user.deactivated': 'text-red-600 bg-red-50',
-  'user.reactivated': 'text-green-700 bg-green-50',
-  'user.updated': 'text-gray-600 bg-gray-100',
-  'plan.created': 'text-purple-700 bg-purple-50',
-  'plan.task_cancelled': 'text-red-600 bg-red-50',
-  'task.started': 'text-amber-700 bg-amber-50',
-  'task.completed': 'text-green-600 bg-green-50',
-  'task.approved': 'text-green-700 bg-green-100',
-  'task.returned': 'text-orange-600 bg-orange-50',
+  'user.invited': 'text-blue-700 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30',
+  'user.registered': 'text-blue-700 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30',
+  'user.deactivated': 'text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30',
+  'user.reactivated': 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-900/30',
+  'user.updated': 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-700',
+  'plan.created': 'text-purple-700 bg-purple-50 dark:text-purple-400 dark:bg-purple-900/30',
+  'plan.task_cancelled': 'text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30',
+  'task.started': 'text-amber-700 bg-amber-50 dark:text-amber-400 dark:bg-amber-900/30',
+  'task.completed': 'text-green-600 bg-green-50 dark:text-green-400 dark:bg-green-900/30',
+  'task.approved': 'text-green-700 bg-green-100 dark:text-green-400 dark:bg-green-900/30',
+  'task.returned': 'text-orange-600 bg-orange-50 dark:text-orange-400 dark:bg-orange-900/30',
 }
 
 const ACTION_OPTIONS: { value: AuditActionType | ''; label: string }[] = [
@@ -80,20 +80,20 @@ export default function AuditLogPage() {
     <div className="max-w-5xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Audit Trail</h2>
-          <p className="text-sm text-gray-500 mt-0.5">System activity log for all key actions.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Audit Trail</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">System activity log for all key actions.</p>
         </div>
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-5 py-4 mb-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-5 py-4 mb-4">
         <div className="flex flex-wrap gap-3 items-end">
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500">Action</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">Action</label>
             <select
               value={selectedAction}
               onChange={(e) => setSelectedAction(e.target.value as AuditActionType | '')}
-              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {ACTION_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -102,11 +102,11 @@ export default function AuditLogPage() {
           </div>
 
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500">Entity</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">Entity</label>
             <select
               value={selectedEntityType}
               onChange={(e) => setSelectedEntityType(e.target.value as AuditEntityType | '')}
-              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {ENTITY_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -115,29 +115,29 @@ export default function AuditLogPage() {
           </div>
 
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500">From</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
             <input
               type="date"
               value={dateFrom}
               onChange={(e) => setDateFrom(e.target.value)}
-              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500">To</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
             <input
               type="date"
               value={dateTo}
               onChange={(e) => setDateTo(e.target.value)}
-              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
           {hasActiveFilters && (
             <button
               onClick={handleClearFilters}
-              className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 border border-gray-300 rounded-lg hover:border-gray-400 transition-colors"
+              className="px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-lg hover:border-gray-400 dark:hover:border-gray-500 transition-colors"
             >
               Clear filters
             </button>
@@ -145,32 +145,32 @@ export default function AuditLogPage() {
         </div>
 
         {!loading && (
-          <p className="text-xs text-gray-400 mt-3">
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-3">
             {total} {total === 1 ? 'entry' : 'entries'} found
           </p>
         )}
       </div>
 
       {/* Table */}
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
         {loading ? (
-          <p className="text-sm text-gray-400 px-5 py-4">Loading...</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">Loading...</p>
         ) : logs.length === 0 ? (
-          <p className="text-sm text-gray-400 px-5 py-4">No audit logs found.</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">No audit logs found.</p>
         ) : (
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-100">
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Date</th>
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Action</th>
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Entity</th>
-                <th className="text-left text-xs font-medium text-gray-500 px-5 py-3">Detail</th>
+              <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tl-xl">Date</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Action</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Entity</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tr-xl">Detail</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
               {logs.map((log) => (
-                <tr key={log.id} className="hover:bg-gray-50">
-                  <td className="px-5 py-3 text-gray-500 whitespace-nowrap">
+                <tr key={log.id} className="hover:bg-slate-50 dark:hover:bg-gray-700/50 transition-colors">
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
                     {format(new Date(log.created_at), 'dd MMM yyyy HH:mm')}
                   </td>
                   <td className="px-5 py-3">
@@ -178,10 +178,10 @@ export default function AuditLogPage() {
                       {ACTION_LABELS[log.action]}
                     </span>
                   </td>
-                  <td className="px-5 py-3 text-gray-500 font-mono text-xs">
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 font-mono text-xs">
                     {log.entity_type} · {log.entity_id.slice(0, 8)}…
                   </td>
-                  <td className="px-5 py-3 text-gray-500 truncate max-w-[200px]">
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400 truncate max-w-[200px]">
                     {log.detail ?? '—'}
                   </td>
                 </tr>

--- a/apps/frontend/src/features/department/hooks/useDepartmentsPage.ts
+++ b/apps/frontend/src/features/department/hooks/useDepartmentsPage.ts
@@ -50,19 +50,26 @@ export function useDepartmentsPage() {
   }
 
   async function handleDeactivate(id: string) {
+    setDepartments((prev) => prev.map((d) => (d.id === id ? { ...d, is_active: false } : d)))
     try {
       const updated = await deactivateDepartment(id)
       setDepartments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)))
       setPageError('')
     } catch (err: unknown) {
+      setDepartments((prev) => prev.map((d) => (d.id === id ? { ...d, is_active: true } : d)))
       const code = (err as { response?: { data?: { error_code?: string } } }).response?.data?.error_code
       setPageError(ERROR_MESSAGES[code ?? ''] ?? 'Something went wrong.')
     }
   }
 
   async function handleReactivate(id: string) {
-    const updated = await reactivateDepartment(id)
-    setDepartments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)))
+    setDepartments((prev) => prev.map((d) => (d.id === id ? { ...d, is_active: true } : d)))
+    try {
+      const updated = await reactivateDepartment(id)
+      setDepartments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)))
+    } catch {
+      setDepartments((prev) => prev.map((d) => (d.id === id ? { ...d, is_active: false } : d)))
+    }
   }
 
   return {

--- a/apps/frontend/src/features/users/hooks/useUsersPage.ts
+++ b/apps/frontend/src/features/users/hooks/useUsersPage.ts
@@ -35,23 +35,44 @@ export function useUsersPage() {
   }
 
   async function handleAssignDepartment(userId: string, departmentId: string) {
-    const updated = await updateUser(userId, { department_id: departmentId || null })
-    setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)))
+    const prev = users.find((u) => u.id === userId)?.department_id ?? null
+    setUsers((all) => all.map((u) => (u.id === userId ? { ...u, department_id: departmentId || null } : u)))
+    try {
+      const updated = await updateUser(userId, { department_id: departmentId || null })
+      setUsers((all) => all.map((u) => (u.id === updated.id ? updated : u)))
+    } catch {
+      setUsers((all) => all.map((u) => (u.id === userId ? { ...u, department_id: prev } : u)))
+    }
   }
 
   async function handleChangeRole(userId: string, role: UserRole) {
-    const updated = await updateUser(userId, { role })
-    setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)))
+    const prev = users.find((u) => u.id === userId)?.role
+    setUsers((all) => all.map((u) => (u.id === userId ? { ...u, role } : u)))
+    try {
+      const updated = await updateUser(userId, { role })
+      setUsers((all) => all.map((u) => (u.id === updated.id ? updated : u)))
+    } catch {
+      if (prev) setUsers((all) => all.map((u) => (u.id === userId ? { ...u, role: prev } : u)))
+    }
   }
 
   async function handleDeactivate(userId: string) {
-    await deactivateUser(userId)
-    setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, is_active: false } : u)))
+    setUsers((all) => all.map((u) => (u.id === userId ? { ...u, is_active: false } : u)))
+    try {
+      await deactivateUser(userId)
+    } catch {
+      setUsers((all) => all.map((u) => (u.id === userId ? { ...u, is_active: true } : u)))
+    }
   }
 
   async function handleReactivate(userId: string) {
-    const updated = await reactivateUser(userId)
-    setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)))
+    setUsers((all) => all.map((u) => (u.id === userId ? { ...u, is_active: true } : u)))
+    try {
+      const updated = await reactivateUser(userId)
+      setUsers((all) => all.map((u) => (u.id === updated.id ? updated : u)))
+    } catch {
+      setUsers((all) => all.map((u) => (u.id === userId ? { ...u, is_active: false } : u)))
+    }
   }
 
   return {

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -77,7 +77,7 @@ export default function DashboardLayout() {
                   onClick={() => setShowTheme((v) => !v)}
                   className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
                 >
-                  <span>Theme</span>
+                  <span>Appearance</span>
                   <span className="text-xs text-gray-400 dark:text-gray-500">{showTheme ? '▲' : '▼'}</span>
                 </button>
 

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -80,7 +80,7 @@ export default function HRDashboardLayout() {
                   onClick={() => setShowTheme((v) => !v)}
                   className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
                 >
-                  <span>Theme</span>
+                  <span>Appearance</span>
                   <span className="text-xs text-gray-400 dark:text-gray-500">{showTheme ? '▲' : '▼'}</span>
                 </button>
 

--- a/docs/guides/conventions/003-schema-conventions.md
+++ b/docs/guides/conventions/003-schema-conventions.md
@@ -12,6 +12,7 @@ This guide defines how Pydantic schemas are named and structured in this project
 | `Create` | POST request body | When creating a new resource |
 | `Update` | PATCH request body | When partially updating a resource — all fields are `Optional` |
 | `Response` | Data returned to the client | Every endpoint that returns data |
+| `ListResponse` | Paginated collection returned to the client | Every `GET /` list endpoint |
 | `Request` | POST request body for actions | When the operation is an action, not a resource creation (e.g. login, register) |
 
 ---
@@ -116,6 +117,59 @@ app/schemas/
     invitation.py   → InvitationCreate, InvitationResponse
     user.py         → UserCreate, UserUpdate, UserResponse
     token.py        → TokenResponse, RefreshTokenRequest
+```
+
+---
+
+## Pagination — ListResponse
+
+All `GET /` list endpoints return a `ListResponse` envelope, never a bare list.
+This ensures the client always has page metadata without breaking changes later.
+
+```python
+class UserListResponse(BaseModel):
+    items: list[UserResponse]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_next: bool
+    has_prev: bool
+```
+
+The route accepts `page` and `page_size` as query params:
+
+```python
+@router.get("/", response_model=UserListResponse)
+async def get_users(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    ...
+```
+
+The service builds the response:
+
+```python
+items, total = await repository.get_all(db, page=page, page_size=page_size)
+total_pages = (total + page_size - 1) // page_size
+return UserListResponse(
+    items=[UserResponse.model_validate(i) for i in items],
+    total=total,
+    page=page,
+    page_size=page_size,
+    total_pages=total_pages,
+    has_next=page * page_size < total,
+    has_prev=page > 1,
+)
+```
+
+Frontend services unwrap `.items` so hooks and components stay unchanged:
+
+```typescript
+export async function getUsers(): Promise<UserResponse[]> {
+  const res = await apiClient.get(API.USERS.LIST)
+  return res.data.items
+}
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Added server-side pagination to `GET /users/`, `GET /department/`, `GET /invitations/` — endpoints now return a `ListResponse` envelope; frontend services unwrap `.items` so hooks and components are unchanged
- Implemented optimistic UI updates for user and department activate/deactivate/role/department actions — UI responds immediately with automatic rollback on failure
- Fixed `AuditLogPage` missing dark mode classes (white flash in dark theme)
- Fixed audit log `entity_type` values in seeder (`onboarding_plan` → `plan`, `onboarding_plan_task` → `task`) that prevented all audit logs from being seeded
- Fixed `audit_log_repository` filter ordering to match project convention
- Renamed "Theme" to "Appearance" in hamburger menu
- Documented `ListResponse` pagination pattern in schema conventions

## Test plan

- [ ] `GET /api/v1/users/?page=1&page_size=20` returns paginated envelope
- [ ] `GET /api/v1/department/` and `GET /api/v1/invitations/` same
- [ ] Users/Departments pages render correctly; activate/deactivate updates instantly without page refresh
- [ ] Deactivating a department with active users shows error and rolls back optimistically updated state
- [ ] Audit Trail page is fully dark in dark mode
- [ ] Audit Trail shows seeded logs after `alembic upgrade head` + `docker-compose run --rm seeder`
- [ ] All backend tests pass (`pytest`)
- [ ] Ruff lint passes
