### PR TITLE
feat: audit log actor names, optimistic UI updates, and dark mode fixes

### DIFF
--- a/apps/backend/app/models/audit_log.py
+++ b/apps/backend/app/models/audit_log.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import uuid
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, Text
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.user import User
 
 
 class AuditLog(Base):
@@ -37,3 +43,5 @@ class AuditLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
     )
+
+    actor: Mapped[User] = relationship("User", foreign_keys=[actor_id], lazy="noload")

--- a/apps/backend/app/repositories/audit_log_repository.py
+++ b/apps/backend/app/repositories/audit_log_repository.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.models.audit_log import AuditLog
@@ -44,7 +45,7 @@ class AuditLogRepository:
         total = count_result.scalar_one()
 
         offset = (page - 1) * page_size
-        query = select(AuditLog)
+        query = select(AuditLog).options(joinedload(AuditLog.actor))
         if filters:
             query = query.where(and_(*filters))
         query = query.order_by(AuditLog.created_at.desc()).limit(page_size).offset(offset)

--- a/apps/backend/app/repositories/invitation_repository.py
+++ b/apps/backend/app/repositories/invitation_repository.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.invitation import Invitation
@@ -33,13 +33,13 @@ class InvitationRepository:
         ]
 
         count_result = await db.execute(
-            select(func.count()).select_from(Invitation).where(*filters)
+            select(func.count()).select_from(Invitation).where(and_(*filters))
         )
         total = count_result.scalar_one()
 
         query = (
             select(Invitation)
-            .where(*filters)
+            .where(and_(*filters))
             .order_by(Invitation.created_at.desc())
             .limit(page_size)
             .offset((page - 1) * page_size)

--- a/apps/backend/app/schemas/audit_log.py
+++ b/apps/backend/app/schemas/audit_log.py
@@ -9,6 +9,7 @@ from app.enums.audit_enums import AuditActionType, AuditEntityType
 class AuditLogResponse(BaseModel):
     id: uuid.UUID
     actor_id: uuid.UUID
+    actor_name: str
     action: AuditActionType
     entity_type: AuditEntityType
     entity_id: uuid.UUID

--- a/apps/backend/app/services/audit_service.py
+++ b/apps/backend/app/services/audit_service.py
@@ -55,7 +55,19 @@ class AuditService:
         total_pages = (total + page_size - 1) // page_size
 
         return AuditLogListResponse(
-            items=[AuditLogResponse.model_validate(item) for item in items],
+            items=[
+                AuditLogResponse(
+                    id=item.id,
+                    actor_id=item.actor_id,
+                    actor_name=f"{item.actor.first_name} {item.actor.last_name}" if item.actor else str(item.actor_id),
+                    action=item.action,
+                    entity_type=item.entity_type,
+                    entity_id=item.entity_id,
+                    detail=item.detail,
+                    created_at=item.created_at,
+                )
+                for item in items
+            ],
             total=total,
             page=page,
             page_size=page_size,

--- a/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
+++ b/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
@@ -162,6 +162,7 @@ export default function AuditLogPage() {
             <thead>
               <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
                 <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tl-xl">Date</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Actor</th>
                 <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Action</th>
                 <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Entity</th>
                 <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tr-xl">Detail</th>
@@ -172,6 +173,9 @@ export default function AuditLogPage() {
                 <tr key={log.id} className="hover:bg-slate-50 dark:hover:bg-gray-700/50 transition-colors">
                   <td className="px-5 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
                     {format(new Date(log.created_at), 'dd MMM yyyy HH:mm')}
+                  </td>
+                  <td className="px-5 py-3 text-gray-700 dark:text-gray-300 text-xs font-medium whitespace-nowrap">
+                    {log.actor_name}
                   </td>
                   <td className="px-5 py-3">
                     <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${ACTION_COLORS[log.action]}`}>

--- a/apps/frontend/src/features/audit/services/auditService.ts
+++ b/apps/frontend/src/features/audit/services/auditService.ts
@@ -19,6 +19,7 @@ export type AuditEntityType = 'user' | 'invitation' | 'plan' | 'task'
 export interface AuditLog {
   id: string
   actor_id: string
+  actor_name: string
   action: AuditActionType
   entity_type: AuditEntityType
   entity_id: string


### PR DESCRIPTION
## Summary

**Audit Log improvements**
- Added `actor_name` to audit log response via `joinedload` on `AuditLog.actor` — Audit Trail table now shows "HR Admin" / "John Doe" instead of a UUID
- Fixed `invitation_repository` filter to use `and_(*filters)` for consistency with other repositories

**Optimistic UI updates**
- User and department activate/deactivate/role/department actions now update the UI immediately with automatic rollback on failure
- Fixed `AuditLogPage` missing dark mode classes (white background in dark theme)
- Renamed "Theme" to "Appearance" in hamburger menu

**Pagination (carried from previous branch)**
- Server-side pagination on `GET /users/`, `GET /department/`, `GET /invitations/`
- Frontend services unwrap `.items`; hooks and components unchanged
- Fixed audit log `entity_type` values in seeder (`onboarding_plan` → `plan`, `onboarding_plan_task` → `task`)
- Documented `ListResponse` pagination pattern in schema conventions

## Test plan

- [ ] Audit Trail shows actor full name (e.g. "HR Admin") in Actor column
- [ ] Activate/deactivate on Users and Departments updates instantly; rollback shown on error
- [ ] Deactivating a department with active users shows error message and reverts state
- [ ] Audit Trail page renders correctly in dark mode
- [ ] Hamburger menu shows "Appearance" instead of "Theme"
- [ ] `GET /users/?page=1&page_size=20` returns paginated envelope
- [ ] Audit logs visible after `alembic upgrade head` + `docker-compose run --rm seeder`
- [ ] Backend tests pass (`pytest`) and ruff lint clean
