### PR TITLE
feat: magic bytes validation for file uploads

### DIFF
--- a/apps/backend/app/services/attachment_service.py
+++ b/apps/backend/app/services/attachment_service.py
@@ -49,6 +49,7 @@ class AttachmentService:
         content = await file.read()
         if len(content) > MAX_FILE_SIZE:
             raise ValidationError(*messages.FILE_TOO_LARGE)
+        storage_service.validate_file_signature(content, file.content_type)
 
         object_name = f"tasks/{task_id}/{uuid.uuid4()}_{file.filename}"
         storage_service.upload(content, object_name, file.content_type)

--- a/apps/backend/app/services/storage_service.py
+++ b/apps/backend/app/services/storage_service.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from google.cloud import storage
 
 from app.core.config import settings
+from app.errors import ValidationError, messages
 
 ALLOWED_CONTENT_TYPES = {
     "image/png",
@@ -11,6 +12,15 @@ ALLOWED_CONTENT_TYPES = {
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 }
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+FILE_SIGNATURES: dict[str, tuple[bytes, ...]] = {
+    "image/jpeg": (b"\xff\xd8\xff",),
+    "image/png": (b"\x89PNG\r\n\x1a\n",),
+    "application/pdf": (b"%PDF",),
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
+        b"PK\x03\x04",
+    ),
+}
 
 
 class StorageService:
@@ -22,6 +32,13 @@ class StorageService:
         if self._client is None:
             self._client = storage.Client()
         return self._client.bucket(settings.GCS_BUCKET_NAME)
+
+    def validate_file_signature(self, content: bytes, content_type: str) -> None:
+        allowed_signatures = FILE_SIGNATURES.get(content_type)
+        if not allowed_signatures:
+            raise ValidationError(*messages.INVALID_FILE_TYPE)
+        if not any(content.startswith(sig) for sig in allowed_signatures):
+            raise ValidationError(*messages.INVALID_FILE_TYPE)
 
     def upload(self, content: bytes, object_name: str, content_type: str) -> str:
         blob = self._get_bucket().blob(object_name)

--- a/apps/backend/tests/unit/services/test_attachment_service.py
+++ b/apps/backend/tests/unit/services/test_attachment_service.py
@@ -67,6 +67,22 @@ class TestUploadAttachment:
                 await service.upload_attachment(db, task.id, file, user)
         assert exc.value.code == "FILE_TOO_LARGE"
 
+    async def test_rejects_file_with_wrong_magic_bytes(self):
+        service = AttachmentService()
+        db = AsyncMock()
+        user = MagicMock()
+        task = _make_task()
+        file = AsyncMock()
+        file.content_type = "application/pdf"
+        file.filename = "evil.pdf"
+        file.read = AsyncMock(return_value=b"MZ\x90\x00" + b"x" * 100)  # EXE magic bytes
+
+        with patch("app.services.attachment_service.plan_task_repository") as repo:
+            repo.get_by_id = AsyncMock(return_value=task)
+            with pytest.raises(ValidationError) as exc:
+                await service.upload_attachment(db, task.id, file, user)
+        assert exc.value.code == "INVALID_FILE_TYPE"
+
     async def test_raises_not_found_for_missing_task(self):
         from app.errors import NotFoundError
         service = AttachmentService()

--- a/apps/backend/tests/unit/services/test_storage_service.py
+++ b/apps/backend/tests/unit/services/test_storage_service.py
@@ -1,0 +1,42 @@
+import pytest
+
+from app.errors import ValidationError
+from app.services.storage_service import StorageService
+
+
+class TestValidateFileSignature:
+
+    def test_valid_jpeg_passes(self):
+        StorageService().validate_file_signature(b"\xff\xd8\xff" + b"x" * 100, "image/jpeg")
+
+    def test_valid_png_passes(self):
+        StorageService().validate_file_signature(b"\x89PNG\r\n\x1a\n" + b"x" * 100, "image/png")
+
+    def test_valid_pdf_passes(self):
+        StorageService().validate_file_signature(b"%PDF" + b"x" * 100, "application/pdf")
+
+    def test_valid_docx_passes(self):
+        StorageService().validate_file_signature(
+            b"PK\x03\x04" + b"x" * 100,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+    def test_wrong_magic_bytes_raises(self):
+        with pytest.raises(ValidationError) as exc:
+            StorageService().validate_file_signature(b"MZ\x90\x00" + b"x" * 100, "application/pdf")
+        assert exc.value.code == "INVALID_FILE_TYPE"
+
+    def test_unknown_content_type_raises(self):
+        with pytest.raises(ValidationError) as exc:
+            StorageService().validate_file_signature(b"%PDF" + b"x" * 100, "text/plain")
+        assert exc.value.code == "INVALID_FILE_TYPE"
+
+    def test_jpeg_disguised_as_pdf_raises(self):
+        with pytest.raises(ValidationError) as exc:
+            StorageService().validate_file_signature(b"\xff\xd8\xff" + b"x" * 100, "application/pdf")
+        assert exc.value.code == "INVALID_FILE_TYPE"
+
+    def test_empty_content_raises(self):
+        with pytest.raises(ValidationError) as exc:
+            StorageService().validate_file_signature(b"", "application/pdf")
+        assert exc.value.code == "INVALID_FILE_TYPE"


### PR DESCRIPTION
## Summary

- Added `FILE_SIGNATURES` map and `validate_file_signature` method to `StorageService` — verifies the actual file content matches its declared `content_type` using magic bytes
- Called from `AttachmentService.upload_attachment` after size check, before GCS upload — a file claiming to be `image/jpeg` but containing EXE bytes is rejected
- Covers JPEG, PNG, PDF, and DOCX formats

## Why

Content-type header alone is client-controlled. A malicious user can upload an `.exe` with `Content-Type: image/jpeg` and bypass the existing check. Magic bytes validation reads the actual file content to confirm the format.

## Test plan

- [ ] Upload a valid PDF → accepted
- [ ] Upload a valid JPEG/PNG → accepted
- [ ] Upload an EXE renamed to `.pdf` with `Content-Type: application/pdf` → rejected with `INVALID_FILE_TYPE`
- [ ] Unit tests pass: 8 `TestValidateFileSignature` cases + 1 `test_rejects_file_with_wrong_magic_bytes`
