### PR TITLE
feat: Dutch/English language support with hamburger menu switcher

### DIFF
--- a/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
+++ b/apps/frontend/src/features/audit/pages/AuditLogPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { format } from 'date-fns'
 import { useAuditLog } from '@/features/audit/hooks/useAuditLog'
+import { useTranslation } from '@/i18n/useTranslation'
 import type { AuditActionType, AuditEntityType } from '@/features/audit/services/auditService'
 
 const ACTION_LABELS: Record<AuditActionType, string> = {
@@ -55,6 +56,7 @@ const ENTITY_OPTIONS: { value: AuditEntityType | ''; label: string }[] = [
 ]
 
 export default function AuditLogPage() {
+  const t = useTranslation()
   const [selectedAction, setSelectedAction] = useState<AuditActionType | ''>('')
   const [selectedEntityType, setSelectedEntityType] = useState<AuditEntityType | ''>('')
   const [dateFrom, setDateFrom] = useState('')
@@ -80,8 +82,8 @@ export default function AuditLogPage() {
     <div className="max-w-5xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Audit Trail</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">System activity log for all key actions.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{t.audit.title}</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t.audit.subtitle}</p>
         </div>
       </div>
 
@@ -89,7 +91,7 @@ export default function AuditLogPage() {
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-5 py-4 mb-4">
         <div className="flex flex-wrap gap-3 items-end">
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500 dark:text-gray-400">Action</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">{t.audit.filters.action}</label>
             <select
               value={selectedAction}
               onChange={(e) => setSelectedAction(e.target.value as AuditActionType | '')}
@@ -102,7 +104,7 @@ export default function AuditLogPage() {
           </div>
 
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500 dark:text-gray-400">Entity</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">{t.audit.filters.entity}</label>
             <select
               value={selectedEntityType}
               onChange={(e) => setSelectedEntityType(e.target.value as AuditEntityType | '')}
@@ -115,7 +117,7 @@ export default function AuditLogPage() {
           </div>
 
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">{t.audit.filters.from}</label>
             <input
               type="date"
               value={dateFrom}
@@ -125,7 +127,7 @@ export default function AuditLogPage() {
           </div>
 
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
+            <label className="text-xs text-gray-500 dark:text-gray-400">{t.audit.filters.to}</label>
             <input
               type="date"
               value={dateTo}
@@ -139,14 +141,14 @@ export default function AuditLogPage() {
               onClick={handleClearFilters}
               className="px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-lg hover:border-gray-400 dark:hover:border-gray-500 transition-colors"
             >
-              Clear filters
+              {t.audit.filters.clearFilters}
             </button>
           )}
         </div>
 
         {!loading && (
           <p className="text-xs text-gray-400 dark:text-gray-500 mt-3">
-            {total} {total === 1 ? 'entry' : 'entries'} found
+            {t.audit.entries(total)}
           </p>
         )}
       </div>
@@ -154,18 +156,18 @@ export default function AuditLogPage() {
       {/* Table */}
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
         {loading ? (
-          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">Loading...</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">{t.audit.loading}</p>
         ) : logs.length === 0 ? (
-          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">No audit logs found.</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 px-5 py-4">{t.audit.noLogs}</p>
         ) : (
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
-                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tl-xl">Date</th>
-                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Actor</th>
-                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Action</th>
-                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">Entity</th>
-                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tr-xl">Detail</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tl-xl">{t.audit.columns.date}</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">{t.audit.columns.actor}</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">{t.audit.columns.action}</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5">{t.audit.columns.entity}</th>
+                <th className="text-left text-xs font-medium text-gray-600 dark:text-gray-400 px-5 py-3.5 rounded-tr-xl">{t.audit.columns.detail}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100 dark:divide-gray-700">

--- a/apps/frontend/src/features/department/pages/DepartmentsPage.tsx
+++ b/apps/frontend/src/features/department/pages/DepartmentsPage.tsx
@@ -1,7 +1,9 @@
 import { useDepartmentsPage } from '@/features/department/hooks/useDepartmentsPage'
 import KebabMenu from '@/components/KebabMenu'
+import { useTranslation } from '@/i18n/useTranslation'
 
 export default function DepartmentsPage() {
+  const t = useTranslation()
   const {
     departments,
     showAddForm,
@@ -24,14 +26,14 @@ export default function DepartmentsPage() {
     <div className="max-w-3xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Departments</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Manage your organisation's departments.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{t.departments.title}</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t.departments.subtitle}</p>
         </div>
         <button
           onClick={() => setShowAddForm((v) => !v)}
           className="text-sm bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors"
         >
-          {showAddForm ? 'Cancel' : '+ Add Department'}
+          {showAddForm ? t.departments.cancel : t.departments.addDepartment}
         </button>
       </div>
 
@@ -46,14 +48,14 @@ export default function DepartmentsPage() {
           <input
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
-            placeholder="Department name"
+            placeholder={t.departments.departmentName}
             className="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3.5 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           <button
             onClick={handleCreate}
             className="bg-blue-700 hover:bg-blue-800 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
           >
-            Add
+            {t.departments.add}
           </button>
         </div>
       )}
@@ -62,9 +64,9 @@ export default function DepartmentsPage() {
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 text-left">
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 rounded-tl-xl">Name</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Status</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 text-right rounded-tr-xl">Actions</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 rounded-tl-xl">{t.departments.columns.name}</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">{t.departments.columns.status}</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 text-right rounded-tr-xl">{t.departments.columns.actions}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
@@ -97,21 +99,21 @@ export default function DepartmentsPage() {
                         onClick={handleUpdate}
                         className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 border border-blue-200 dark:border-blue-700 hover:border-blue-300 px-3 py-1.5 rounded-lg transition-colors"
                       >
-                        Save
+                        {t.departments.save}
                       </button>
                       <button
                         onClick={cancelEdit}
                         className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 border border-gray-200 dark:border-gray-600 px-3 py-1.5 rounded-lg transition-colors"
                       >
-                        Cancel
+                        {t.departments.cancel}
                       </button>
                     </div>
                   ) : (
                     <KebabMenu items={[
-                      { label: 'Rename', onClick: () => startEdit(d) },
+                      { label: t.departments.actions.rename, onClick: () => startEdit(d) },
                       d.is_active
-                        ? { label: 'Deactivate', onClick: () => handleDeactivate(d.id), variant: 'danger' }
-                        : { label: 'Reactivate', onClick: () => handleReactivate(d.id), variant: 'success' },
+                        ? { label: t.departments.actions.deactivate, onClick: () => handleDeactivate(d.id), variant: 'danger' }
+                        : { label: t.departments.actions.reactivate, onClick: () => handleReactivate(d.id), variant: 'success' },
                     ]} />
                   )}
                 </td>
@@ -120,7 +122,7 @@ export default function DepartmentsPage() {
             {departments.length === 0 && (
               <tr>
                 <td colSpan={3} className="px-5 py-8 text-center text-gray-400 dark:text-gray-500 text-sm">
-                  No departments yet.
+                  {t.departments.noDepartments}
                 </td>
               </tr>
             )}

--- a/apps/frontend/src/features/users/pages/UsersPage.tsx
+++ b/apps/frontend/src/features/users/pages/UsersPage.tsx
@@ -4,12 +4,14 @@ import { ROLE_LABELS } from '@/constants/userRoles'
 import { useUsersPage } from '@/features/users/hooks/useUsersPage'
 import KebabMenu from '@/components/KebabMenu'
 import { ROUTES } from '@/constants/routes'
+import { useTranslation } from '@/i18n/useTranslation'
 import type { components } from '@/types/api'
 
 type UserRole = components['schemas']['UserRole']
 
 export default function UsersPage() {
   const currentUser = useAuthStore((state) => state.user)
+  const t = useTranslation()
   const {
     filteredUsers,
     activeDepartments,
@@ -29,14 +31,14 @@ export default function UsersPage() {
     <div className="max-w-6xl mx-auto">
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Users</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Manage users, roles and department assignments.</p>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{t.users.title}</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t.users.subtitle}</p>
         </div>
         <Link
           to={ROUTES.HR_INVITE_USER}
           className="text-sm bg-blue-700 hover:bg-blue-800 text-white font-medium px-4 py-2 rounded-lg transition-colors"
         >
-          + Invite User
+          {t.users.inviteUser}
         </Link>
       </div>
 
@@ -46,7 +48,7 @@ export default function UsersPage() {
           onChange={(e) => setFilterRole(e.target.value as UserRole | '')}
           className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
-          <option value="">All roles</option>
+          <option value="">{t.users.allRoles}</option>
           <option value="hr_admin">HR Admin</option>
           <option value="manager">Manager</option>
           <option value="employee">Employee</option>
@@ -57,7 +59,7 @@ export default function UsersPage() {
           onChange={(e) => setFilterDepartmentId(e.target.value)}
           className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
-          <option value="">All departments</option>
+          <option value="">{t.users.allDepartments}</option>
           {activeDepartments.map((d) => (
             <option key={d.id} value={d.id}>{d.name}</option>
           ))}
@@ -68,9 +70,9 @@ export default function UsersPage() {
           onChange={(e) => setFilterStatus(e.target.value as 'active' | 'inactive' | '')}
           className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
-          <option value="">All statuses</option>
-          <option value="active">Active</option>
-          <option value="inactive">Inactive</option>
+          <option value="">{t.users.allStatuses}</option>
+          <option value="active">{t.users.active}</option>
+          <option value="inactive">{t.users.inactive}</option>
         </select>
       </div>
 
@@ -78,12 +80,12 @@ export default function UsersPage() {
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50 text-left">
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 rounded-tl-xl">Name</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Email</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Role</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Department</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">Status</th>
-              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 text-right rounded-tr-xl">Actions</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 rounded-tl-xl">{t.users.columns.name}</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">{t.users.columns.email}</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">{t.users.columns.role}</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">{t.users.columns.department}</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400">{t.users.columns.status}</th>
+              <th className="px-5 py-3.5 font-medium text-gray-600 dark:text-gray-400 text-right rounded-tr-xl">{t.users.columns.actions}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
@@ -92,7 +94,7 @@ export default function UsersPage() {
                 <td className="px-5 py-3.5 font-medium text-gray-900 dark:text-gray-100">
                   {u.first_name} {u.last_name}
                   {u.id === currentUser?.id && (
-                    <span className="ml-2 text-xs text-blue-600 dark:text-blue-400 font-normal">(you)</span>
+                    <span className="ml-2 text-xs text-blue-600 dark:text-blue-400 font-normal">{t.users.you}</span>
                   )}
                 </td>
                 <td className="px-5 py-3.5 text-gray-600 dark:text-gray-400">{u.email}</td>
@@ -119,7 +121,7 @@ export default function UsersPage() {
                     onChange={(e) => handleAssignDepartment(u.id, e.target.value)}
                     className="border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-xs bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
-                    <option value="">No department</option>
+                    <option value="">{t.users.noDepartment}</option>
                     {activeDepartments.map((d) => (
                       <option key={d.id} value={d.id}>{d.name}</option>
                     ))}
@@ -138,8 +140,8 @@ export default function UsersPage() {
                   {u.id !== currentUser?.id && (
                     <KebabMenu items={[
                       u.is_active
-                        ? { label: 'Deactivate', onClick: () => handleDeactivate(u.id), variant: 'danger' }
-                        : { label: 'Reactivate', onClick: () => handleReactivate(u.id), variant: 'success' },
+                        ? { label: t.users.actions.deactivate, onClick: () => handleDeactivate(u.id), variant: 'danger' }
+                        : { label: t.users.actions.reactivate, onClick: () => handleReactivate(u.id), variant: 'success' },
                     ]} />
                   )}
                 </td>
@@ -148,7 +150,7 @@ export default function UsersPage() {
             {filteredUsers.length === 0 && (
               <tr>
                 <td colSpan={6} className="px-5 py-8 text-center text-gray-400 dark:text-gray-500 text-sm">
-                  No users found.
+                  {t.users.noUsers}
                 </td>
               </tr>
             )}

--- a/apps/frontend/src/i18n/translations.ts
+++ b/apps/frontend/src/i18n/translations.ts
@@ -1,0 +1,215 @@
+export const translations = {
+  en: {
+    // Nav
+    nav: {
+      dashboard: 'Dashboard',
+      users: 'Users',
+      departments: 'Departments',
+      templates: 'Templates',
+      plans: 'Plans',
+      auditTrail: 'Audit Trail',
+      reports: 'Reports',
+    },
+    // Menu
+    menu: {
+      myProfile: 'My Profile',
+      appearance: 'Appearance',
+      language: 'Language',
+      logout: 'Logout',
+    },
+    // Theme
+    theme: {
+      light: 'Light',
+      dark: 'Dark',
+      system: 'System',
+    },
+    // Language names
+    languages: {
+      en: 'English',
+      nl: 'Nederlands',
+    },
+    // Users page
+    users: {
+      title: 'Users',
+      subtitle: 'Manage users, roles and department assignments.',
+      inviteUser: '+ Invite User',
+      allRoles: 'All roles',
+      allDepartments: 'All departments',
+      allStatuses: 'All statuses',
+      active: 'Active',
+      inactive: 'Inactive',
+      noUsers: 'No users found.',
+      columns: {
+        name: 'Name',
+        email: 'Email',
+        role: 'Role',
+        department: 'Department',
+        status: 'Status',
+        actions: 'Actions',
+      },
+      you: '(you)',
+      noDepartment: 'No department',
+      actions: {
+        deactivate: 'Deactivate',
+        reactivate: 'Reactivate',
+      },
+    },
+    // Departments page
+    departments: {
+      title: 'Departments',
+      subtitle: "Manage your organisation's departments.",
+      addDepartment: '+ Add Department',
+      cancel: 'Cancel',
+      noDepartments: 'No departments yet.',
+      departmentName: 'Department name',
+      add: 'Add',
+      save: 'Save',
+      columns: {
+        name: 'Name',
+        status: 'Status',
+        actions: 'Actions',
+      },
+      actions: {
+        rename: 'Rename',
+        deactivate: 'Deactivate',
+        reactivate: 'Reactivate',
+      },
+    },
+    // Audit Trail
+    audit: {
+      title: 'Audit Trail',
+      subtitle: 'System activity log for all key actions.',
+      noLogs: 'No audit logs found.',
+      loading: 'Loading...',
+      entries: (n: number) => `${n} ${n === 1 ? 'entry' : 'entries'} found`,
+      filters: {
+        action: 'Action',
+        entity: 'Entity',
+        from: 'From',
+        to: 'To',
+        allActions: 'All actions',
+        allEntities: 'All entities',
+        clearFilters: 'Clear filters',
+      },
+      columns: {
+        date: 'Date',
+        actor: 'Actor',
+        action: 'Action',
+        entity: 'Entity',
+        detail: 'Detail',
+      },
+    },
+    // Common
+    common: {
+      active: 'Active',
+      inactive: 'Inactive',
+    },
+  },
+
+  nl: {
+    // Nav
+    nav: {
+      dashboard: 'Dashboard',
+      users: 'Gebruikers',
+      departments: 'Afdelingen',
+      templates: 'Sjablonen',
+      plans: 'Plannen',
+      auditTrail: 'Auditspoor',
+      reports: 'Rapporten',
+    },
+    // Menu
+    menu: {
+      myProfile: 'Mijn profiel',
+      appearance: 'Weergave',
+      language: 'Taal',
+      logout: 'Uitloggen',
+    },
+    // Theme
+    theme: {
+      light: 'Licht',
+      dark: 'Donker',
+      system: 'Systeem',
+    },
+    // Language names
+    languages: {
+      en: 'English',
+      nl: 'Nederlands',
+    },
+    // Users page
+    users: {
+      title: 'Gebruikers',
+      subtitle: 'Beheer gebruikers, rollen en afdelingstoewijzingen.',
+      inviteUser: '+ Gebruiker uitnodigen',
+      allRoles: 'Alle rollen',
+      allDepartments: 'Alle afdelingen',
+      allStatuses: 'Alle statussen',
+      active: 'Actief',
+      inactive: 'Inactief',
+      noUsers: 'Geen gebruikers gevonden.',
+      columns: {
+        name: 'Naam',
+        email: 'E-mail',
+        role: 'Rol',
+        department: 'Afdeling',
+        status: 'Status',
+        actions: 'Acties',
+      },
+      you: '(jij)',
+      noDepartment: 'Geen afdeling',
+      actions: {
+        deactivate: 'Deactiveren',
+        reactivate: 'Reactiveren',
+      },
+    },
+    // Departments page
+    departments: {
+      title: 'Afdelingen',
+      subtitle: 'Beheer de afdelingen van uw organisatie.',
+      addDepartment: '+ Afdeling toevoegen',
+      cancel: 'Annuleren',
+      noDepartments: 'Nog geen afdelingen.',
+      departmentName: 'Afdelingsnaam',
+      add: 'Toevoegen',
+      save: 'Opslaan',
+      columns: {
+        name: 'Naam',
+        status: 'Status',
+        actions: 'Acties',
+      },
+      actions: {
+        rename: 'Hernoemen',
+        deactivate: 'Deactiveren',
+        reactivate: 'Reactiveren',
+      },
+    },
+    // Audit Trail
+    audit: {
+      title: 'Auditspoor',
+      subtitle: 'Systeemactiviteitenlogboek voor alle belangrijke acties.',
+      noLogs: 'Geen auditlogboeken gevonden.',
+      loading: 'Laden...',
+      entries: (n: number) => `${n} ${n === 1 ? 'vermelding' : 'vermeldingen'} gevonden`,
+      filters: {
+        action: 'Actie',
+        entity: 'Entiteit',
+        from: 'Van',
+        to: 'Tot',
+        allActions: 'Alle acties',
+        allEntities: 'Alle entiteiten',
+        clearFilters: 'Filters wissen',
+      },
+      columns: {
+        date: 'Datum',
+        actor: 'Uitvoerder',
+        action: 'Actie',
+        entity: 'Entiteit',
+        detail: 'Detail',
+      },
+    },
+    // Common
+    common: {
+      active: 'Actief',
+      inactive: 'Inactief',
+    },
+  },
+} as const

--- a/apps/frontend/src/i18n/useTranslation.ts
+++ b/apps/frontend/src/i18n/useTranslation.ts
@@ -1,0 +1,7 @@
+import { useLanguageStore } from '@/stores/languageStore'
+import { translations } from '@/i18n/translations'
+
+export function useTranslation() {
+  const language = useLanguageStore((state) => state.language)
+  return translations[language]
+}

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -4,29 +4,40 @@ import { useNavigate } from 'react-router-dom'
 import { logout } from '@/features/auth/services/authService'
 import { useAuthStore } from '@/stores/authStore'
 import { useThemeStore, type Theme } from '@/stores/themeStore'
+import { useLanguageStore, type Language } from '@/stores/languageStore'
+import { useTranslation } from '@/i18n/useTranslation'
 import { ROUTES } from '@/constants/routes'
 import { USER_ROLES } from '@/constants/userRoles'
-
-const THEME_OPTIONS: { value: Theme; label: string }[] = [
-  { value: 'light', label: 'Light' },
-  { value: 'dark', label: 'Dark' },
-  { value: 'system', label: 'System' },
-]
 
 export default function DashboardLayout() {
   const user = useAuthStore((state) => state.user)
   const clearUser = useAuthStore((state) => state.clearUser)
   const { theme, setTheme } = useThemeStore()
+  const { language, setLanguage } = useLanguageStore()
+  const t = useTranslation()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const [showTheme, setShowTheme] = useState(false)
+  const [showLanguage, setShowLanguage] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  const THEME_OPTIONS: { value: Theme; label: string }[] = [
+    { value: 'light', label: t.theme.light },
+    { value: 'dark', label: t.theme.dark },
+    { value: 'system', label: t.theme.system },
+  ]
+
+  const LANGUAGE_OPTIONS: { value: Language; label: string }[] = [
+    { value: 'en', label: t.languages.en },
+    { value: 'nl', label: t.languages.nl },
+  ]
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setOpen(false)
         setShowTheme(false)
+        setShowLanguage(false)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
@@ -49,7 +60,7 @@ export default function DashboardLayout() {
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button
-              onClick={() => { setOpen((v) => !v); setShowTheme(false) }}
+              onClick={() => { setOpen((v) => !v); setShowTheme(false); setShowLanguage(false) }}
               className="flex flex-col justify-center items-center gap-1 w-8 h-8 rounded-lg hover:bg-white/10 transition-colors"
               aria-label="User menu"
             >
@@ -70,14 +81,14 @@ export default function DashboardLayout() {
                   onClick={() => setOpen(false)}
                   className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
-                  My Profile
+                  {t.menu.myProfile}
                 </Link>
 
                 <button
-                  onClick={() => setShowTheme((v) => !v)}
+                  onClick={() => { setShowTheme((v) => !v); setShowLanguage(false) }}
                   className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
                 >
-                  <span>Appearance</span>
+                  <span>{t.menu.appearance}</span>
                   <span className="text-xs text-gray-400 dark:text-gray-500">{showTheme ? '▲' : '▼'}</span>
                 </button>
 
@@ -100,10 +111,36 @@ export default function DashboardLayout() {
                 )}
 
                 <button
+                  onClick={() => { setShowLanguage((v) => !v); setShowTheme(false) }}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
+                >
+                  <span>{t.menu.language}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500">{showLanguage ? '▲' : '▼'}</span>
+                </button>
+
+                {showLanguage && (
+                  <div className="px-3 pb-2 flex gap-1">
+                    {LANGUAGE_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        onClick={() => { setLanguage(opt.value); setShowLanguage(false) }}
+                        className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
+                          language === opt.value
+                            ? 'bg-blue-600 text-white'
+                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                <button
                   onClick={handleLogout}
                   className="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-t border-gray-100 dark:border-gray-700"
                 >
-                  Logout
+                  {t.menu.logout}
                 </button>
               </div>
             )}

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -97,7 +97,7 @@ export default function DashboardLayout() {
                     {THEME_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
-                        onClick={() => { setTheme(opt.value); setShowTheme(false) }}
+                        onClick={() => setTheme(opt.value)}
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           theme === opt.value
                             ? 'bg-blue-600 text-white'
@@ -123,7 +123,7 @@ export default function DashboardLayout() {
                     {LANGUAGE_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
-                        onClick={() => { setLanguage(opt.value); setShowLanguage(false) }}
+                        onClick={() => setLanguage(opt.value)}
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           language === opt.value
                             ? 'bg-blue-600 text-white'

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -93,7 +93,7 @@ export default function DashboardLayout() {
                 </button>
 
                 {showTheme && (
-                  <div className="px-3 pb-2 flex gap-1">
+                  <div className="px-3 py-2 flex gap-1 border-t border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
                     {THEME_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
@@ -101,7 +101,7 @@ export default function DashboardLayout() {
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           theme === opt.value
                             ? 'bg-blue-600 text-white'
-                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                            : 'text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-600 hover:bg-gray-100 dark:hover:bg-gray-500'
                         }`}
                       >
                         {opt.label}
@@ -119,7 +119,7 @@ export default function DashboardLayout() {
                 </button>
 
                 {showLanguage && (
-                  <div className="px-3 pb-2 flex gap-1">
+                  <div className="px-3 py-2 flex gap-1 border-t border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
                     {LANGUAGE_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
@@ -127,7 +127,7 @@ export default function DashboardLayout() {
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           language === opt.value
                             ? 'bg-blue-600 text-white'
-                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                            : 'text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-600 hover:bg-gray-100 dark:hover:bg-gray-500'
                         }`}
                       >
                         {opt.label}

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -96,7 +96,7 @@ export default function HRDashboardLayout() {
                 </button>
 
                 {showTheme && (
-                  <div className="px-3 pb-2 flex gap-1">
+                  <div className="px-3 py-2 flex gap-1 border-t border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
                     {THEME_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
@@ -104,7 +104,7 @@ export default function HRDashboardLayout() {
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           theme === opt.value
                             ? 'bg-blue-600 text-white'
-                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                            : 'text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-600 hover:bg-gray-100 dark:hover:bg-gray-500'
                         }`}
                       >
                         {opt.label}
@@ -122,7 +122,7 @@ export default function HRDashboardLayout() {
                 </button>
 
                 {showLanguage && (
-                  <div className="px-3 pb-2 flex gap-1">
+                  <div className="px-3 py-2 flex gap-1 border-t border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
                     {LANGUAGE_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
@@ -130,7 +130,7 @@ export default function HRDashboardLayout() {
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           language === opt.value
                             ? 'bg-blue-600 text-white'
-                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                            : 'text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-600 hover:bg-gray-100 dark:hover:bg-gray-500'
                         }`}
                       >
                         {opt.label}

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -100,7 +100,7 @@ export default function HRDashboardLayout() {
                     {THEME_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
-                        onClick={() => { setTheme(opt.value); setShowTheme(false) }}
+                        onClick={() => setTheme(opt.value)}
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           theme === opt.value
                             ? 'bg-blue-600 text-white'
@@ -126,7 +126,7 @@ export default function HRDashboardLayout() {
                     {LANGUAGE_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
-                        onClick={() => { setLanguage(opt.value); setShowLanguage(false) }}
+                        onClick={() => setLanguage(opt.value)}
                         className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
                           language === opt.value
                             ? 'bg-blue-600 text-white'

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -4,28 +4,39 @@ import { useNavigate } from 'react-router-dom'
 import { logout } from '@/features/auth/services/authService'
 import { useAuthStore } from '@/stores/authStore'
 import { useThemeStore, type Theme } from '@/stores/themeStore'
+import { useLanguageStore, type Language } from '@/stores/languageStore'
+import { useTranslation } from '@/i18n/useTranslation'
 import { ROUTES } from '@/constants/routes'
-
-const THEME_OPTIONS: { value: Theme; label: string }[] = [
-  { value: 'light', label: 'Light' },
-  { value: 'dark', label: 'Dark' },
-  { value: 'system', label: 'System' },
-]
 
 export default function HRDashboardLayout() {
   const user = useAuthStore((state) => state.user)
   const clearUser = useAuthStore((state) => state.clearUser)
   const { theme, setTheme } = useThemeStore()
+  const { language, setLanguage } = useLanguageStore()
+  const t = useTranslation()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const [showTheme, setShowTheme] = useState(false)
+  const [showLanguage, setShowLanguage] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  const THEME_OPTIONS: { value: Theme; label: string }[] = [
+    { value: 'light', label: t.theme.light },
+    { value: 'dark', label: t.theme.dark },
+    { value: 'system', label: t.theme.system },
+  ]
+
+  const LANGUAGE_OPTIONS: { value: Language; label: string }[] = [
+    { value: 'en', label: t.languages.en },
+    { value: 'nl', label: t.languages.nl },
+  ]
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setOpen(false)
         setShowTheme(false)
+        setShowLanguage(false)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
@@ -52,7 +63,7 @@ export default function HRDashboardLayout() {
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button
-              onClick={() => { setOpen((v) => !v); setShowTheme(false) }}
+              onClick={() => { setOpen((v) => !v); setShowTheme(false); setShowLanguage(false) }}
               className="flex flex-col justify-center items-center gap-1 w-8 h-8 rounded-lg hover:bg-white/10 transition-colors"
               aria-label="User menu"
             >
@@ -73,14 +84,14 @@ export default function HRDashboardLayout() {
                   onClick={() => setOpen(false)}
                   className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
-                  My Profile
+                  {t.menu.myProfile}
                 </Link>
 
                 <button
-                  onClick={() => setShowTheme((v) => !v)}
+                  onClick={() => { setShowTheme((v) => !v); setShowLanguage(false) }}
                   className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
                 >
-                  <span>Appearance</span>
+                  <span>{t.menu.appearance}</span>
                   <span className="text-xs text-gray-400 dark:text-gray-500">{showTheme ? '▲' : '▼'}</span>
                 </button>
 
@@ -103,10 +114,36 @@ export default function HRDashboardLayout() {
                 )}
 
                 <button
+                  onClick={() => { setShowLanguage((v) => !v); setShowTheme(false) }}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between"
+                >
+                  <span>{t.menu.language}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500">{showLanguage ? '▲' : '▼'}</span>
+                </button>
+
+                {showLanguage && (
+                  <div className="px-3 pb-2 flex gap-1">
+                    {LANGUAGE_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        onClick={() => { setLanguage(opt.value); setShowLanguage(false) }}
+                        className={`flex-1 text-xs py-1.5 rounded-lg font-medium transition-colors ${
+                          language === opt.value
+                            ? 'bg-blue-600 text-white'
+                            : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                <button
                   onClick={handleLogout}
                   className="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-t border-gray-100 dark:border-gray-700"
                 >
-                  Logout
+                  {t.menu.logout}
                 </button>
               </div>
             )}
@@ -117,13 +154,13 @@ export default function HRDashboardLayout() {
       <div className="flex flex-1">
         <aside className="w-52 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-sm">
           <nav className="flex flex-col p-4 gap-1">
-            <NavLink to={ROUTES.HR_DASHBOARD} className={navLinkClass}>Dashboard</NavLink>
-            <NavLink to={ROUTES.HR_USERS} className={navLinkClass}>Users</NavLink>
-            <NavLink to={ROUTES.HR_DEPARTMENTS} className={navLinkClass}>Departments</NavLink>
-            <NavLink to={ROUTES.HR_TEMPLATES} className={navLinkClass}>Templates</NavLink>
-            <NavLink to={ROUTES.HR_PLAN_NEW} className={navLinkClass}>Plans</NavLink>
-            <NavLink to={ROUTES.HR_AUDIT} className={navLinkClass}>Audit Trail</NavLink>
-            <NavLink to={ROUTES.HR_REPORTS} className={navLinkClass}>Reports</NavLink>
+            <NavLink to={ROUTES.HR_DASHBOARD} className={navLinkClass}>{t.nav.dashboard}</NavLink>
+            <NavLink to={ROUTES.HR_USERS} className={navLinkClass}>{t.nav.users}</NavLink>
+            <NavLink to={ROUTES.HR_DEPARTMENTS} className={navLinkClass}>{t.nav.departments}</NavLink>
+            <NavLink to={ROUTES.HR_TEMPLATES} className={navLinkClass}>{t.nav.templates}</NavLink>
+            <NavLink to={ROUTES.HR_PLAN_NEW} className={navLinkClass}>{t.nav.plans}</NavLink>
+            <NavLink to={ROUTES.HR_AUDIT} className={navLinkClass}>{t.nav.auditTrail}</NavLink>
+            <NavLink to={ROUTES.HR_REPORTS} className={navLinkClass}>{t.nav.reports}</NavLink>
           </nav>
         </aside>
 

--- a/apps/frontend/src/stores/languageStore.ts
+++ b/apps/frontend/src/stores/languageStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+
+export type Language = 'en' | 'nl'
+
+interface LanguageState {
+  language: Language
+  setLanguage: (language: Language) => void
+}
+
+const STORAGE_KEY = 'stepup-language'
+
+function getInitialLanguage(): Language {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'en' || stored === 'nl') return stored
+  return 'en'
+}
+
+export const useLanguageStore = create<LanguageState>((set) => ({
+  language: getInitialLanguage(),
+  setLanguage: (language) => {
+    localStorage.setItem(STORAGE_KEY, language)
+    set({ language })
+  },
+}))

--- a/docs/adr/ADR-010-multi-language-support.md
+++ b/docs/adr/ADR-010-multi-language-support.md
@@ -1,0 +1,58 @@
+# ADR-010: Custom Translation System over react-i18next
+
+**Date:** 2026-05-16
+**Status:** Accepted
+
+---
+
+## Context
+
+StepUp targets organisations in the Netherlands, so Dutch and English language support was required. The two standard approaches were:
+
+1. **react-i18next** — the de-facto standard library for React i18n (backed by i18next)
+2. **Custom translation system** — a lightweight in-house solution with no external dependency
+
+---
+
+## Decision
+
+We built a custom translation system consisting of three pieces:
+
+- **`languageStore.ts`** — Zustand store that reads/writes `localStorage` key `stepup-language`, following the exact same pattern as `themeStore.ts`
+- **`translations.ts`** — A single `as const` object with `en` and `nl` keys, fully type-safe
+- **`useTranslation()`** — A hook that reads the current language from the store and returns the correct translation object
+
+---
+
+## Reasons
+
+### Against react-i18next
+
+- **Bundle size** — react-i18next adds ~30 KB for two static language files. The benefit does not justify the cost at this scale.
+- **Complexity** — react-i18next introduces an async initialisation step, a provider, namespace configuration, and interpolation syntax (`t('key', { count })`). All of this is overhead for a two-language toggle.
+- **New dependency** — Every new dependency is a maintenance surface. For two languages, it is not worth it.
+
+### For the custom system
+
+- **Zero dependencies** — No new package to install, update, or audit.
+- **Full type safety** — `translations.ts` uses `as const`. TypeScript enforces that every key exists in both languages at compile time. Accessing a missing key is a type error, not a runtime crash.
+- **Same pattern as themeStore** — The language store is structurally identical to the existing theme store. No new patterns for the codebase to absorb.
+- **Trivial to extend** — Adding a third language means adding one top-level key to `translations.ts`.
+
+---
+
+## Consequences
+
+- All UI strings that need translation must be added to `translations.ts` manually — there is no extraction tool.
+- Interpolation (e.g. plurals with counts) is handled by plain TypeScript functions in the translations object: `entries: (n: number) => \`${n} ${n === 1 ? 'entry' : 'entries'} found\``
+- If the app ever needs more than ~3 languages or server-side string loading, migrating to react-i18next becomes the right call.
+
+---
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|--------|----------------|
+| react-i18next | Unnecessary complexity and bundle weight for two static languages |
+| Hardcoded strings with a lang prop | Not scalable, pollutes component signatures |
+| JSON files per language | Requires a loader, loses TypeScript type safety |

--- a/docs/guides/tutorials/frontend/019-multi-language-support.md
+++ b/docs/guides/tutorials/frontend/019-multi-language-support.md
@@ -1,0 +1,103 @@
+# Multi-Language Support
+
+StepUp uses a lightweight custom translation system. No external library is required.
+
+---
+
+## How It Works
+
+Three files form the entire system:
+
+```
+src/
+  stores/languageStore.ts     ← Zustand store, persists to localStorage
+  i18n/
+    translations.ts           ← All strings for every language
+    useTranslation.ts         ← Hook that returns the right translations
+```
+
+The language store reads `localStorage` on init and writes back on every change — the same pattern used by `themeStore`.
+
+---
+
+## Using Translations in a Component
+
+```typescript
+import { useTranslation } from '@/i18n/useTranslation'
+
+export default function MyPage() {
+  const t = useTranslation()
+
+  return <h1>{t.nav.dashboard}</h1>
+}
+```
+
+`t` is fully type-safe — accessing a key that doesn't exist in `translations.ts` is a compile-time error.
+
+---
+
+## Adding a New String
+
+1. Open `src/i18n/translations.ts`
+2. Add the key under **both** `en` and `nl`:
+
+```typescript
+export const translations = {
+  en: {
+    mySection: {
+      myKey: 'Hello',
+    },
+  },
+  nl: {
+    mySection: {
+      myKey: 'Hallo',
+    },
+  },
+} as const
+```
+
+3. Use it in your component: `t.mySection.myKey`
+
+TypeScript will give a compile error if the key is missing in either language.
+
+---
+
+## Strings with Dynamic Values
+
+Use a plain function instead of a string:
+
+```typescript
+// translations.ts
+entries: (n: number) => `${n} ${n === 1 ? 'entry' : 'entries'} found`,
+
+// nl
+entries: (n: number) => `${n} ${n === 1 ? 'vermelding' : 'vermeldingen'} gevonden`,
+```
+
+Call it like a function in the component:
+
+```tsx
+<p>{t.audit.entries(total)}</p>
+```
+
+---
+
+## Adding a Third Language
+
+1. Add a new top-level key to `translations.ts` (e.g. `de`)
+2. Add `'de'` to the `Language` type in `languageStore.ts`
+3. Add the option to `LANGUAGE_OPTIONS` in both layout files
+
+---
+
+## Where Language State Lives
+
+`useLanguageStore` is a Zustand store — no React context, no provider needed. Any component can call `useLanguageStore` directly.
+
+```typescript
+import { useLanguageStore } from '@/stores/languageStore'
+
+const { language, setLanguage } = useLanguageStore()
+```
+
+The selected language persists across page reloads via `localStorage` key `stepup-language`.

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -270,7 +270,7 @@ Invalid transitions return HTTP 400 with a descriptive error message.
 - Rate limiting on authentication endpoints (5 requests/minute)
 - CORS restricted to frontend domain only
 - Secrets managed via GCP Secret Manager — no `.env` files in repository
-- File upload validation: MIME type check, size limit (10MB), allowed types only
+- File upload validation: MIME type check + magic bytes validation, size limit (10MB), allowed types only
 - OWASP ZAP security scan before final release
 
 ### Reliability
@@ -772,9 +772,14 @@ ADR-007: Structured logging to GCP Cloud Logging
 - ⬜ Full E2E regression suite passing in CI
 - ⬜ README and Swagger polish for demo
 
+### Feature Branch: Dutch/English Language Support ✅ Done
+- Language switcher (English / Nederlands) in the hamburger menu on all layouts
+- Custom translation system: `languageStore` (Zustand, persists to `localStorage`) + `translations.ts` + `useTranslation()` hook
+- Nav links, page titles, column headers, buttons, and form labels translated for both languages
+- No external library — custom solution chosen to avoid bundle overhead for two languages
+
 ### Bonus (If Time Allows)
 - Multi-tenancy (organization_id on all tables)
-- Dutch + English language support (i18n) — backlog #197
 - Webhook system for external integrations
 - Full-text search on tasks and templates (PostgreSQL tsvector)
 
@@ -858,6 +863,7 @@ A: Not in MVP. Single-level tasks only. Sub-tasks may be considered post-MVP.
 | 2.0 | 2026-05-15 | US-198 done; Dark/Light/System theme toggle added to hamburger menu; all pages dark-mode styled; ThemeProvider + themeStore implemented |
 | 2.1 | 2026-05-15 | Audit log refactored: AuditActionType + AuditEntityType enums, advanced filters (action, entity_type, actor_id, date_from, date_to), pagination; CI/CD pipeline restructured: deploy-production.yml (Cloud Run) added, deploy-staging auto-trigger removed |
 | 2.2 | 2026-05-15 | CI/CD fully automated: main merge triggers Cloud Run backend deploy + Firebase Hosting frontend deploy; GCP_SA_KEY service account added; Dependabot disabled |
+| 2.3 | 2026-05-16 | Pagination added to users/departments/invitations endpoints; optimistic UI updates for activate/deactivate actions; AuditLogPage dark mode fix; magic bytes validation for file uploads; actor_name added to audit log response; Dutch/English language support added to hamburger menu |
 
 **Review Frequency:** After each sprint  
 **Status:** Living document — will evolve throughout the project

--- a/docs/scrum/sprint-goals.md
+++ b/docs/scrum/sprint-goals.md
@@ -41,5 +41,8 @@ APScheduler marks overdue tasks daily and sends deadline reminders. HR Admin rep
 ## Sprint 10 — Final Polish
 All list endpoints are paginated. Full E2E regression suite passes in CI. README and Swagger polished for demo. US-021 quality & polish.
 
+## Feature Branch: Dutch/English Language Support ✅ Done
+Users can switch between English and Dutch from the hamburger menu. The selection persists across page reloads via `localStorage`. Nav links, page titles, column headers, and buttons are translated for both languages. No external library — custom `languageStore` + `translations.ts` + `useTranslation()` hook, following the same pattern as `themeStore`.
+
 ## Feature Branch: US-198 — Theme Toggle
 Users can switch between Light, Dark, and System theme from the hamburger menu. The selection persists across page reloads. All pages and layouts are fully styled for dark mode.


### PR DESCRIPTION
## Summary

- Added Dutch/English language switcher to the hamburger menu on all layouts — selection persists across reloads via `localStorage`
- Custom translation system: `languageStore` (Zustand) + `translations.ts` (type-safe `as const`) + `useTranslation()` hook — no external library, same pattern as `themeStore`
- Translated: nav links, page titles, column headers, buttons, and labels for Users, Departments, and Audit Trail pages
- Preference panels (Appearance, Language) now stay open after selection with clear visual separation via `border-t/b` and subtle background
- Added magic bytes validation to file uploads — MIME type header alone is no longer sufficient
- Actor name displayed in Audit Trail table instead of UUID
- Optimistic UI updates for activate/deactivate/role/department actions on Users and Departments pages
- AuditLogPage dark mode fix, "Theme" renamed to "Appearance"
- Pagination on `GET /users/`, `GET /department/`, `GET /invitations/`

## Docs
- `ADR-010` — decision to build custom translation system over react-i18next
- `docs/guides/tutorials/frontend/019-multi-language-support.md` — how to add strings, add a language, use dynamic values
- `product-vision.md` — i18n Done, magic bytes in security section, v2.3 history
- `sprint-goals.md` — language support feature branch entry
- `schema-conventions.md` — ListResponse pagination pattern

## Test plan

- [ ] Hamburger menu shows "Language" row; clicking toggles English/Nederlands panel
- [ ] Switching to Nederlands: nav links, page titles, column headers, buttons all translate
- [ ] Language selection persists after page refresh
- [ ] Appearance and Language panels stay open after selecting an option; close on toggle or outside click
- [ ] Upload a valid PDF → accepted; upload EXE with `Content-Type: application/pdf` → rejected
- [ ] Audit Trail shows actor full name in Actor column
- [ ] Activate/deactivate on Users and Departments updates instantly with rollback on error
- [ ] `GET /users/?page=1&page_size=20` returns paginated envelope
- [ ] All backend tests pass (`pytest`) and ruff lint clean
