### PR TITLE
fix: initialise loading state as false and set true when fetch starts

### DIFF
--- a/apps/frontend/src/features/audit/hooks/useAuditLog.ts
+++ b/apps/frontend/src/features/audit/hooks/useAuditLog.ts
@@ -10,7 +10,7 @@ const DEFAULT_PAGE_SIZE = 50
 
 export function useAuditLog(filters: AuditLogFilters = {}) {
   const [data, setData] = useState<AuditLogListResponse | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
 
   const filtersKey = JSON.stringify(filters)
 

--- a/apps/frontend/src/features/plan/hooks/useManagerApprovalsPage.ts
+++ b/apps/frontend/src/features/plan/hooks/useManagerApprovalsPage.ts
@@ -9,9 +9,10 @@ type ApprovalTaskResponse = components['schemas']['ApprovalTaskResponse']
 export function useManagerApprovalsPage() {
   const navigate = useNavigate()
   const [tasks, setTasks] = useState<ApprovalTaskResponse[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
+    setIsLoading(true)
     getPendingApprovals()
       .then(setTasks)
       .catch(() => {})

--- a/apps/frontend/src/features/reports/hooks/useReports.ts
+++ b/apps/frontend/src/features/reports/hooks/useReports.ts
@@ -13,7 +13,7 @@ export function useReports(filters: ReportFilters) {
   const [completionTime, setCompletionTime] = useState<DepartmentCompletionRow[]>([])
   const [taskRates, setTaskRates] = useState<TemplateCompletionRow[]>([])
   const [bottlenecks, setBottlenecks] = useState<BottleneckRow[]>([])
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
 
   const load = useCallback(async () => {
     setLoading(true)


### PR DESCRIPTION
## Summary

- `useAuditLog`, `useManagerApprovalsPage`, `useReports` hooks were initialising
  `loading` as `true`, causing a spinner flash on mount before any fetch started
- Changed initial state to `false` in all three hooks
- Added `setIsLoading(true)` at the top of `useEffect` in `useManagerApprovalsPage`
  (the other two already set loading to `true` inside their fetch functions)

## Test plan

- [ ] Audit Trail page — no spinner on initial mount before data loads
- [ ] Manager Approvals page — no spinner on initial mount
- [ ] Reports page — no spinner on initial mount
