### PR TITLE
feat: dashboard redesign with hero section, stat cards, and logo

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,14 +22,17 @@
     "@tanstack/react-query": "^5.62.0",
     "axios": "^1.7.9",
     "date-fns": "^4.1.0",
+    "lucide-react": "^1.16.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^6.28.1",
-    "zustand": "^5.0.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.49.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
@@ -39,18 +42,16 @@
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^3.0.0",
     "autoprefixer": "^10.4.20",
-    "@eslint/js": "^9.17.0",
     "eslint": "^9.17.0",
     "eslint-plugin-react-hooks": "^5.1.0",
-    "openapi-typescript": "^7.4.4",
-    "typescript-eslint": "^8.19.0",
     "jsdom": "^25.0.1",
+    "openapi-typescript": "^7.4.4",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
+    "typescript-eslint": "^8.19.0",
     "vite": "^6.0.5",
-    "vitest": "^3.0.0",
-    "@playwright/test": "^1.49.0"
+    "vitest": "^3.0.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/apps/frontend/src/components/StepUpLogo.tsx
+++ b/apps/frontend/src/components/StepUpLogo.tsx
@@ -1,0 +1,15 @@
+export function StepUpLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 28 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect x="0" y="12" width="7" height="8" rx="1.5" fill="currentColor" opacity="0.55" />
+      <rect x="9" y="6" width="7" height="14" rx="1.5" fill="currentColor" opacity="0.8" />
+      <rect x="18" y="0" width="7" height="20" rx="1.5" fill="currentColor" />
+    </svg>
+  )
+}

--- a/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
@@ -1,78 +1,141 @@
+import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { format } from 'date-fns'
+import { Loader, CheckCircle2, Calendar, ArrowRight, ClipboardList } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
 import { useEmployeeDashboard } from '@/features/dashboard/hooks/useEmployeeDashboard'
 
-function StatCard({ label, value }: { label: string; value: string | number | undefined }) {
+type Color = 'blue' | 'emerald' | 'amber'
+
+const colorClasses: Record<Color, string> = {
+  blue: 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
+  emerald: 'bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400',
+  amber: 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  color,
+}: {
+  label: string
+  value: number | string | undefined
+  icon: ReactNode
+  color: Color
+}) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
-      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
-      <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">{value ?? '—'}</p>
+      <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-4 ${colorClasses[color]}`}>
+        {icon}
+      </div>
+      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value ?? '—'}</p>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{label}</p>
     </div>
   )
+}
+
+function getGreeting() {
+  const hour = new Date().getHours()
+  if (hour < 12) return 'Good morning'
+  if (hour < 17) return 'Good afternoon'
+  return 'Good evening'
 }
 
 export default function EmployeeDashboard() {
   const user = useAuthStore((state) => state.user)
   const { stats } = useEmployeeDashboard()
 
-  const progressPct = stats && stats.total_tasks > 0
-    ? Math.round(((stats.approved_tasks) / stats.total_tasks) * 100)
-    : null
+  const progressPct =
+    stats && stats.total_tasks > 0
+      ? Math.round((stats.approved_tasks / stats.total_tasks) * 100)
+      : null
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-8">
-        <div className="w-14 h-14 bg-blue-100 dark:bg-blue-900/40 rounded-full flex items-center justify-center mb-4">
-          <span className="text-blue-700 dark:text-blue-400 text-xl font-bold">
-            {user?.first_name?.[0]}{user?.last_name?.[0]}
-          </span>
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div className="bg-gradient-to-br from-blue-600 to-indigo-700 rounded-2xl px-8 py-8 text-white">
+        <div className="flex items-center gap-5">
+          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center shrink-0">
+            <span className="text-white text-xl font-bold">
+              {user?.first_name?.[0]}{user?.last_name?.[0]}
+            </span>
+          </div>
+          <div>
+            <span className="inline-block text-xs font-semibold bg-white/20 px-3 py-1 rounded-full mb-2">
+              Employee
+            </span>
+            <h2 className="text-2xl font-bold">{getGreeting()}, {user?.first_name}</h2>
+            <p className="text-blue-100 text-sm mt-1">Track your onboarding progress here.</p>
+          </div>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Welcome, {user?.first_name}</h2>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">You're signed in as Employee.</p>
-      </div>
 
-      {stats && stats.total_tasks > 0 ? (
-        <>
-          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
+        {progressPct !== null && (
+          <div className="mt-6 pt-6 border-t border-white/20">
             <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Plan Progress</p>
-              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{progressPct}%</p>
+              <span className="text-sm font-medium text-blue-100">Onboarding Progress</span>
+              <span className="text-lg font-bold">{progressPct}%</span>
             </div>
-            <div className="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-2">
+            <div className="w-full bg-white/20 rounded-full h-2.5">
               <div
-                className="bg-blue-600 h-2 rounded-full transition-all"
+                className="bg-white h-2.5 rounded-full transition-all duration-500"
                 style={{ width: `${progressPct}%` }}
               />
             </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-              {stats.approved_tasks} of {stats.total_tasks} tasks approved
+            <p className="text-xs text-blue-100 mt-2">
+              {stats?.approved_tasks} of {stats?.total_tasks} tasks approved
             </p>
           </div>
+        )}
+      </div>
 
-          <div className="grid grid-cols-3 gap-4">
-            <StatCard label="In Progress" value={stats.in_progress_tasks} />
-            <StatCard label="Completed" value={stats.completed_tasks} />
-            <StatCard
-              label="Next Deadline"
-              value={stats.next_deadline ? format(new Date(stats.next_deadline), 'dd MMM yyyy') : 'None'}
-            />
-          </div>
-        </>
+      {stats && stats.total_tasks > 0 ? (
+        <div className="grid grid-cols-3 gap-4">
+          <StatCard
+            label="In Progress"
+            value={stats.in_progress_tasks}
+            icon={<Loader size={20} />}
+            color="blue"
+          />
+          <StatCard
+            label="Completed"
+            value={stats.completed_tasks}
+            icon={<CheckCircle2 size={20} />}
+            color="emerald"
+          />
+          <StatCard
+            label="Next Deadline"
+            value={stats.next_deadline ? format(new Date(stats.next_deadline), 'dd MMM yyyy') : 'None'}
+            icon={<Calendar size={20} />}
+            color="amber"
+          />
+        </div>
       ) : (
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
-          <p className="text-sm text-gray-400 dark:text-gray-500">No active onboarding plan assigned.</p>
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-10 text-center">
+          <div className="w-12 h-12 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-3">
+            <ClipboardList size={20} className="text-gray-400" />
+          </div>
+          <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            No active onboarding plan assigned yet.
+          </p>
         </div>
       )}
 
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
-        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Quick links</h3>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-4">
+          Quick Links
+        </h3>
         <Link
           to={ROUTES.EMPLOYEE_PLAN}
-          className="inline-flex items-center gap-2 text-sm text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 font-medium transition-colors"
+          className="flex items-center justify-between group px-4 py-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
         >
-          My Onboarding Plan →
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-blue-50 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
+              <ClipboardList size={16} className="text-blue-600 dark:text-blue-400" />
+            </div>
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">My Onboarding Plan</span>
+          </div>
+          <ArrowRight size={16} className="text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
         </Link>
       </div>
     </div>

--- a/apps/frontend/src/features/users/pages/HRDashboard.test.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.test.tsx
@@ -22,7 +22,7 @@ describe('HRDashboard', () => {
 
   it('displays welcome message with user name', () => {
     renderPage()
-    expect(screen.getByText(/welcome, hr/i)).toBeInTheDocument()
+    expect(screen.getByText(/good (morning|afternoon|evening), hr/i)).toBeInTheDocument()
     expect(screen.getByText(/hr admin/i)).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/features/users/pages/HRDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.tsx
@@ -1,13 +1,44 @@
+import type { ReactNode } from 'react'
+import { Users, ClipboardList, Building2, Clock } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
 import { useHRDashboard } from '@/features/dashboard/hooks/useHRDashboard'
 
-function StatCard({ label, value }: { label: string; value: number | undefined }) {
+type Color = 'blue' | 'emerald' | 'violet' | 'amber'
+
+const colorClasses: Record<Color, string> = {
+  blue: 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
+  emerald: 'bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400',
+  violet: 'bg-violet-50 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400',
+  amber: 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  color,
+}: {
+  label: string
+  value: number | string | undefined
+  icon: ReactNode
+  color: Color
+}) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
-      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
-      <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">{value ?? '—'}</p>
+      <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-4 ${colorClasses[color]}`}>
+        {icon}
+      </div>
+      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value ?? '—'}</p>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{label}</p>
     </div>
   )
+}
+
+function getGreeting() {
+  const hour = new Date().getHours()
+  if (hour < 12) return 'Good morning'
+  if (hour < 17) return 'Good afternoon'
+  return 'Good evening'
 }
 
 export default function HRDashboard() {
@@ -15,22 +46,29 @@ export default function HRDashboard() {
   const { stats } = useHRDashboard()
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-8">
-        <div className="w-14 h-14 bg-blue-100 dark:bg-blue-900/40 rounded-full flex items-center justify-center mb-4">
-          <span className="text-blue-700 dark:text-blue-400 text-xl font-bold">
-            {user?.first_name?.[0]}{user?.last_name?.[0]}
-          </span>
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div className="bg-gradient-to-br from-blue-600 to-indigo-700 rounded-2xl px-8 py-8 text-white">
+        <div className="flex items-center gap-5">
+          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center shrink-0">
+            <span className="text-white text-xl font-bold">
+              {user?.first_name?.[0]}{user?.last_name?.[0]}
+            </span>
+          </div>
+          <div>
+            <span className="inline-block text-xs font-semibold bg-white/20 px-3 py-1 rounded-full mb-2">
+              HR Admin
+            </span>
+            <h2 className="text-2xl font-bold">{getGreeting()}, {user?.first_name}</h2>
+            <p className="text-blue-100 text-sm mt-1">Here's an overview of your platform today.</p>
+          </div>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Welcome, {user?.first_name}</h2>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">You're signed in as HR Admin.</p>
       </div>
 
       <div className="grid grid-cols-2 gap-4">
-        <StatCard label="Active Users" value={stats?.active_users} />
-        <StatCard label="Active Plans" value={stats?.active_plans} />
-        <StatCard label="Active Departments" value={stats?.active_departments} />
-        <StatCard label="Pending Approvals" value={stats?.pending_approvals} />
+        <StatCard label="Active Users" value={stats?.active_users} icon={<Users size={20} />} color="blue" />
+        <StatCard label="Active Plans" value={stats?.active_plans} icon={<ClipboardList size={20} />} color="emerald" />
+        <StatCard label="Active Departments" value={stats?.active_departments} icon={<Building2 size={20} />} color="violet" />
+        <StatCard label="Pending Approvals" value={stats?.pending_approvals} icon={<Clock size={20} />} color="amber" />
       </div>
     </div>
   )

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -1,15 +1,45 @@
+import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import { ClipboardList, Clock, Users, ArrowRight } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
 import { useManagerDashboard } from '@/features/dashboard/hooks/useManagerDashboard'
 
-function StatCard({ label, value }: { label: string; value: number | undefined }) {
+type Color = 'blue' | 'emerald' | 'amber'
+
+const colorClasses: Record<Color, string> = {
+  blue: 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400',
+  emerald: 'bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400',
+  amber: 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  color,
+}: {
+  label: string
+  value: number | string | undefined
+  icon: ReactNode
+  color: Color
+}) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
-      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
-      <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">{value ?? '—'}</p>
+      <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-4 ${colorClasses[color]}`}>
+        {icon}
+      </div>
+      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value ?? '—'}</p>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{label}</p>
     </div>
   )
+}
+
+function getGreeting() {
+  const hour = new Date().getHours()
+  if (hour < 12) return 'Good morning'
+  if (hour < 17) return 'Good afternoon'
+  return 'Good evening'
 }
 
 export default function ManagerDashboard() {
@@ -17,30 +47,45 @@ export default function ManagerDashboard() {
   const { stats } = useManagerDashboard()
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-8 py-8">
-        <div className="w-14 h-14 bg-blue-100 dark:bg-blue-900/40 rounded-full flex items-center justify-center mb-4">
-          <span className="text-blue-700 dark:text-blue-400 text-xl font-bold">
-            {user?.first_name?.[0]}{user?.last_name?.[0]}
-          </span>
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div className="bg-gradient-to-br from-blue-600 to-indigo-700 rounded-2xl px-8 py-8 text-white">
+        <div className="flex items-center gap-5">
+          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center shrink-0">
+            <span className="text-white text-xl font-bold">
+              {user?.first_name?.[0]}{user?.last_name?.[0]}
+            </span>
+          </div>
+          <div>
+            <span className="inline-block text-xs font-semibold bg-white/20 px-3 py-1 rounded-full mb-2">
+              Manager
+            </span>
+            <h2 className="text-2xl font-bold">{getGreeting()}, {user?.first_name}</h2>
+            <p className="text-blue-100 text-sm mt-1">Here's your team overview for today.</p>
+          </div>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Welcome, {user?.first_name}</h2>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">You're signed in as Manager.</p>
       </div>
 
       <div className="grid grid-cols-3 gap-4">
-        <StatCard label="Active Plans" value={stats?.active_plans} />
-        <StatCard label="Pending Approvals" value={stats?.pending_approvals} />
-        <StatCard label="Employees" value={stats?.total_employees} />
+        <StatCard label="Active Plans" value={stats?.active_plans} icon={<ClipboardList size={20} />} color="emerald" />
+        <StatCard label="Pending Approvals" value={stats?.pending_approvals} icon={<Clock size={20} />} color="amber" />
+        <StatCard label="Employees" value={stats?.total_employees} icon={<Users size={20} />} color="blue" />
       </div>
 
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-6 py-5">
-        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Quick links</h3>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-4">
+          Quick Links
+        </h3>
         <Link
           to={ROUTES.MANAGER_APPROVALS}
-          className="inline-flex items-center gap-2 text-sm text-blue-700 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300 font-medium transition-colors"
+          className="flex items-center justify-between group px-4 py-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
         >
-          Pending Approvals →
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-amber-50 dark:bg-amber-900/30 rounded-lg flex items-center justify-center">
+              <Clock size={16} className="text-amber-600 dark:text-amber-400" />
+            </div>
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Pending Approvals</span>
+          </div>
+          <ArrowRight size={16} className="text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors" />
         </Link>
       </div>
     </div>

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -8,6 +8,7 @@ import { useLanguageStore, type Language } from '@/stores/languageStore'
 import { useTranslation } from '@/i18n/useTranslation'
 import { ROUTES } from '@/constants/routes'
 import { USER_ROLES } from '@/constants/userRoles'
+import { StepUpLogo } from '@/components/StepUpLogo'
 
 export default function DashboardLayout() {
   const user = useAuthStore((state) => state.user)
@@ -55,8 +56,11 @@ export default function DashboardLayout() {
       <nav className="bg-blue-800 dark:bg-gray-950 text-white px-6 py-3 flex items-center justify-between shadow-md">
         <Link
           to={user?.role === USER_ROLES.MANAGER ? ROUTES.MANAGER_DASHBOARD : ROUTES.EMPLOYEE_DASHBOARD}
-          className="text-xl font-bold tracking-tight hover:opacity-80 transition-opacity"
-        >StepUp</Link>
+          className="flex items-center gap-2.5 hover:opacity-80 transition-opacity"
+        >
+          <StepUpLogo className="h-5 w-auto text-white" />
+          <span className="text-xl font-bold tracking-tight">StepUp</span>
+        </Link>
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -7,6 +7,7 @@ import { useThemeStore, type Theme } from '@/stores/themeStore'
 import { useLanguageStore, type Language } from '@/stores/languageStore'
 import { useTranslation } from '@/i18n/useTranslation'
 import { ROUTES } from '@/constants/routes'
+import { StepUpLogo } from '@/components/StepUpLogo'
 
 export default function HRDashboardLayout() {
   const user = useAuthStore((state) => state.user)
@@ -59,7 +60,10 @@ export default function HRDashboardLayout() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-gray-900 flex flex-col">
       <nav className="bg-blue-800 dark:bg-gray-950 text-white px-6 py-3 flex items-center justify-between shadow-md">
-        <Link to={ROUTES.HR_DASHBOARD} className="text-xl font-bold tracking-tight hover:opacity-80 transition-opacity">StepUp</Link>
+        <Link to={ROUTES.HR_DASHBOARD} className="flex items-center gap-2.5 hover:opacity-80 transition-opacity">
+          <StepUpLogo className="h-5 w-auto text-white" />
+          <span className="text-xl font-bold tracking-tight">StepUp</span>
+        </Link>
         <div className="flex items-center gap-3">
           <div className="relative" ref={menuRef}>
             <button

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1534,6 +1537,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3602,6 +3610,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.16.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary
- Gradient hero banner on all dashboards (HR, Manager, Employee) with time-based greeting and role badge
- Colored stat cards with lucide-react icons — each metric has a distinct color (blue/emerald/violet/amber)
- Employee progress bar moved inside the hero card for better visual flow
- Quick Links section redesigned with icon rows and arrow indicators
- New `StepUpLogo` SVG component (ascending steps icon) added to both navbars

## Test plan
- [ ] Log in as HR Admin — verify hero, 4 stat cards, logo in sidebar nav
- [ ] Log in as Manager — verify hero, 3 stat cards, Quick Links row, logo in top nav
- [ ] Log in as Employee (with active plan) — verify hero with progress bar, 3 stat cards
- [ ] Log in as Employee (no plan) — verify empty state card renders correctly
- [ ] Toggle dark mode — verify all cards and logo render correctly
- [ ] Check time-based greeting (morning / afternoon / evening)