### PR TITLE
feat: add profile photo upload

### DIFF
--- a/apps/backend/alembic/versions/f1a2b3c4d5e6_add_avatar_url_to_users.py
+++ b/apps/backend/alembic/versions/f1a2b3c4d5e6_add_avatar_url_to_users.py
@@ -8,6 +8,7 @@ Create Date: 2026-05-16 12:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = 'f1a2b3c4d5e6'

--- a/apps/backend/alembic/versions/f1a2b3c4d5e6_add_avatar_url_to_users.py
+++ b/apps/backend/alembic/versions/f1a2b3c4d5e6_add_avatar_url_to_users.py
@@ -1,0 +1,24 @@
+"""add avatar_url to users
+
+Revision ID: f1a2b3c4d5e6
+Revises: c0d1e2f3a4b5
+Create Date: 2026-05-16 12:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'f1a2b3c4d5e6'
+down_revision: str = 'c0d1e2f3a4b5'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('avatar_url', sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'avatar_url')

--- a/apps/backend/app/api/v1/user.py
+++ b/apps/backend/app/api/v1/user.py
@@ -1,7 +1,6 @@
 import uuid
-from pathlib import Path
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
@@ -15,11 +14,6 @@ from app.schemas.user import (
     UserUpdate,
 )
 from app.services.user_service import UserService
-
-_ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
-_AVATAR_EXT_MAP = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}
-_AVATARS_DIR = Path("uploads/avatars")
-_MAX_AVATAR_BYTES = 5 * 1024 * 1024
 
 router = APIRouter()
 user_service = UserService()
@@ -53,20 +47,9 @@ async def upload_avatar(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> UserResponse:
-    if file.content_type not in _ALLOWED_AVATAR_TYPES:
-        raise HTTPException(status_code=400, detail="Only JPEG, PNG and WebP images are allowed.")
     content = await file.read()
-    if len(content) > _MAX_AVATAR_BYTES:
-        raise HTTPException(status_code=400, detail="Image must be under 5MB.")
-    _AVATARS_DIR.mkdir(parents=True, exist_ok=True)
-    ext = _AVATAR_EXT_MAP[file.content_type]
-    filename = f"{current_user.id}.{ext}"
-    (_AVATARS_DIR / filename).write_bytes(content)
-    current_user.avatar_url = f"/static/avatars/{filename}"
-    db.add(current_user)
-    await db.commit()
-    await db.refresh(current_user)
-    return UserResponse.model_validate(current_user)
+    user = await user_service.upload_avatar(db, current_user, content, file.content_type or "")
+    return UserResponse.model_validate(user)
 
 
 @router.patch("/me", response_model=UserResponse)

--- a/apps/backend/app/api/v1/user.py
+++ b/apps/backend/app/api/v1/user.py
@@ -1,6 +1,7 @@
 import uuid
+from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
@@ -14,6 +15,11 @@ from app.schemas.user import (
     UserUpdate,
 )
 from app.services.user_service import UserService
+
+_ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_AVATAR_EXT_MAP = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}
+_AVATARS_DIR = Path("uploads/avatars")
+_MAX_AVATAR_BYTES = 5 * 1024 * 1024
 
 router = APIRouter()
 user_service = UserService()
@@ -39,6 +45,28 @@ async def get_users(
     return await user_service.get_users(
         db=db, role=role, department_id=department_id, is_active=is_active, page=page, page_size=page_size
     )
+
+
+@router.post("/me/avatar", response_model=UserResponse)
+async def upload_avatar(
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserResponse:
+    if file.content_type not in _ALLOWED_AVATAR_TYPES:
+        raise HTTPException(status_code=400, detail="Only JPEG, PNG and WebP images are allowed.")
+    content = await file.read()
+    if len(content) > _MAX_AVATAR_BYTES:
+        raise HTTPException(status_code=400, detail="Image must be under 5MB.")
+    _AVATARS_DIR.mkdir(parents=True, exist_ok=True)
+    ext = _AVATAR_EXT_MAP[file.content_type]
+    filename = f"{current_user.id}.{ext}"
+    (_AVATARS_DIR / filename).write_bytes(content)
+    current_user.avatar_url = f"/static/avatars/{filename}"
+    db.add(current_user)
+    await db.commit()
+    await db.refresh(current_user)
+    return UserResponse.model_validate(current_user)
 
 
 @router.patch("/me", response_model=UserResponse)

--- a/apps/backend/app/errors/messages.py
+++ b/apps/backend/app/errors/messages.py
@@ -7,6 +7,8 @@ INVITATION_ALREADY_USED = ("INVITATION_ALREADY_USED", "Invitation has already be
 USER_ALREADY_EXISTS = ("USER_ALREADY_EXISTS", "A user with this email already exists")
 USER_NOT_FOUND = ("USER_NOT_FOUND", "User not found")
 CANNOT_DEACTIVATE_SELF = ("CANNOT_DEACTIVATE_SELF", "You cannot deactivate your own account")
+INVALID_AVATAR_TYPE = ("INVALID_AVATAR_TYPE", "Only JPEG, PNG and WebP images are allowed")
+AVATAR_TOO_LARGE = ("AVATAR_TOO_LARGE", "Image must be under 5MB")
 
 # Authentication
 INVALID_CREDENTIALS = ("INVALID_CREDENTIALS", "Invalid email or password")

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,8 +1,10 @@
+import os
 from contextlib import asynccontextmanager
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
@@ -49,6 +51,9 @@ app.add_middleware(
 )
 
 register_error_handlers(app)
+
+os.makedirs("uploads/avatars", exist_ok=True)
+app.mount("/static", StaticFiles(directory="uploads"), name="static")
 
 app.include_router(api_router, prefix="/api/v1")
 

--- a/apps/backend/app/models/user.py
+++ b/apps/backend/app/models/user.py
@@ -49,6 +49,10 @@ class User(Base, TimestampMixin):
         nullable=True,
     )
     department: Mapped["Department"] = relationship("Department", back_populates="users")
+    avatar_url: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+    )
 
     @property
     def department_name(self) -> str | None:

--- a/apps/backend/app/schemas/user.py
+++ b/apps/backend/app/schemas/user.py
@@ -33,6 +33,7 @@ class UserResponse(BaseModel):
     is_active: bool
     department_id: uuid.UUID | None
     department_name: str | None = None
+    avatar_url: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/backend/app/services/user_service.py
+++ b/apps/backend/app/services/user_service.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,6 +16,11 @@ from app.schemas.user import (
     UserUpdate,
 )
 from app.services.audit_service import AuditService
+
+_ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_AVATAR_EXT_MAP = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}
+_AVATARS_DIR = Path("uploads/avatars")
+_MAX_AVATAR_BYTES = 5 * 1024 * 1024
 
 user_repository = UserRepository()
 refresh_token_repository = RefreshTokenRepository()
@@ -66,6 +72,26 @@ class UserService:
         if actor_id:
             await audit_service.log(db, actor_id=actor_id, action=AuditActionType.user_updated, entity_type=AuditEntityType.user, entity_id=user_id)
             await db.commit()
+        return await user_repository.get_by_id(db, user_id)
+
+    async def upload_avatar(
+        self,
+        db: AsyncSession,
+        user: User,
+        content: bytes,
+        content_type: str,
+    ) -> User:
+        if content_type not in _ALLOWED_AVATAR_TYPES:
+            raise ValidationError(*messages.INVALID_AVATAR_TYPE)
+        if len(content) > _MAX_AVATAR_BYTES:
+            raise ValidationError(*messages.AVATAR_TOO_LARGE)
+        _AVATARS_DIR.mkdir(parents=True, exist_ok=True)
+        ext = _AVATAR_EXT_MAP[content_type]
+        filename = f"{user.id}.{ext}"
+        (_AVATARS_DIR / filename).write_bytes(content)
+        user.avatar_url = f"/static/avatars/{filename}"
+        user_id = user.id
+        await db.commit()
         return await user_repository.get_by_id(db, user_id)
 
     async def update_my_profile(

--- a/apps/frontend/src/constants/apiEndpoints.ts
+++ b/apps/frontend/src/constants/apiEndpoints.ts
@@ -14,6 +14,7 @@ export const API = {
   USERS: {
     ME: '/api/v1/users/me',
     UPDATE_ME: '/api/v1/users/me',
+    UPLOAD_AVATAR: '/api/v1/users/me/avatar',
     LIST: '/api/v1/users/',
     UPDATE: (id: string) => `/api/v1/users/${id}`,
     DEACTIVATE: (id: string) => `/api/v1/users/${id}/deactivate`,

--- a/apps/frontend/src/features/users/hooks/useProfilePage.ts
+++ b/apps/frontend/src/features/users/hooks/useProfilePage.ts
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useAuthStore } from '@/stores/authStore'
-import { updateMe } from '@/features/users/services/userService'
+import { updateMe, uploadAvatar } from '@/features/users/services/userService'
 
 export function useProfilePage() {
   const user = useAuthStore((state) => state.user)
@@ -9,6 +9,8 @@ export function useProfilePage() {
   const [lastName, setLastName] = useState(user?.last_name ?? '')
   const [success, setSuccess] = useState(false)
   const [pageError, setPageError] = useState('')
+  const [avatarUploading, setAvatarUploading] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   async function handleSave() {
     try {
@@ -22,6 +24,22 @@ export function useProfilePage() {
     }
   }
 
+  async function handleAvatarChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setAvatarUploading(true)
+    setPageError('')
+    try {
+      const updated = await uploadAvatar(file)
+      setUser(updated)
+    } catch {
+      setPageError('Avatar upload failed. Please use a JPEG, PNG or WebP image under 5MB.')
+    } finally {
+      setAvatarUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
   return {
     user,
     firstName,
@@ -31,5 +49,8 @@ export function useProfilePage() {
     success,
     pageError,
     handleSave,
+    avatarUploading,
+    fileInputRef,
+    handleAvatarChange,
   }
 }

--- a/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/EmployeeDashboard.tsx
@@ -6,6 +6,8 @@ import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
 import { useEmployeeDashboard } from '@/features/dashboard/hooks/useEmployeeDashboard'
 
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
 type Color = 'blue' | 'emerald' | 'amber'
 
 const colorClasses: Record<Color, string> = {
@@ -47,6 +49,9 @@ export default function EmployeeDashboard() {
   const user = useAuthStore((state) => state.user)
   const { stats } = useEmployeeDashboard()
 
+  const avatarSrc = user?.avatar_url ? `${API_URL}${user.avatar_url}` : null
+  const initials = `${user?.first_name?.[0] ?? ''}${user?.last_name?.[0] ?? ''}`
+
   const progressPct =
     stats && stats.total_tasks > 0
       ? Math.round((stats.approved_tasks / stats.total_tasks) * 100)
@@ -56,10 +61,12 @@ export default function EmployeeDashboard() {
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="bg-gradient-to-br from-blue-600 to-indigo-700 rounded-2xl px-8 py-8 text-white">
         <div className="flex items-center gap-5">
-          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center shrink-0">
-            <span className="text-white text-xl font-bold">
-              {user?.first_name?.[0]}{user?.last_name?.[0]}
-            </span>
+          <div className="w-16 h-16 rounded-full overflow-hidden bg-white/20 flex items-center justify-center shrink-0">
+            {avatarSrc ? (
+              <img src={avatarSrc} alt="Avatar" className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-white text-xl font-bold">{initials}</span>
+            )}
           </div>
           <div>
             <span className="inline-block text-xs font-semibold bg-white/20 px-3 py-1 rounded-full mb-2">

--- a/apps/frontend/src/features/users/pages/HRDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.tsx
@@ -3,6 +3,8 @@ import { Users, ClipboardList, Building2, Clock } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
 import { useHRDashboard } from '@/features/dashboard/hooks/useHRDashboard'
 
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
 type Color = 'blue' | 'emerald' | 'violet' | 'amber'
 
 const colorClasses: Record<Color, string> = {
@@ -45,14 +47,19 @@ export default function HRDashboard() {
   const user = useAuthStore((state) => state.user)
   const { stats } = useHRDashboard()
 
+  const avatarSrc = user?.avatar_url ? `${API_URL}${user.avatar_url}` : null
+  const initials = `${user?.first_name?.[0] ?? ''}${user?.last_name?.[0] ?? ''}`
+
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="bg-gradient-to-br from-blue-600 to-indigo-700 rounded-2xl px-8 py-8 text-white">
         <div className="flex items-center gap-5">
-          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center shrink-0">
-            <span className="text-white text-xl font-bold">
-              {user?.first_name?.[0]}{user?.last_name?.[0]}
-            </span>
+          <div className="w-16 h-16 rounded-full overflow-hidden bg-white/20 flex items-center justify-center shrink-0">
+            {avatarSrc ? (
+              <img src={avatarSrc} alt="Avatar" className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-white text-xl font-bold">{initials}</span>
+            )}
           </div>
           <div>
             <span className="inline-block text-xs font-semibold bg-white/20 px-3 py-1 rounded-full mb-2">

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -5,6 +5,8 @@ import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
 import { useManagerDashboard } from '@/features/dashboard/hooks/useManagerDashboard'
 
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
 type Color = 'blue' | 'emerald' | 'amber'
 
 const colorClasses: Record<Color, string> = {
@@ -46,14 +48,19 @@ export default function ManagerDashboard() {
   const user = useAuthStore((state) => state.user)
   const { stats } = useManagerDashboard()
 
+  const avatarSrc = user?.avatar_url ? `${API_URL}${user.avatar_url}` : null
+  const initials = `${user?.first_name?.[0] ?? ''}${user?.last_name?.[0] ?? ''}`
+
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="bg-gradient-to-br from-blue-600 to-indigo-700 rounded-2xl px-8 py-8 text-white">
         <div className="flex items-center gap-5">
-          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center shrink-0">
-            <span className="text-white text-xl font-bold">
-              {user?.first_name?.[0]}{user?.last_name?.[0]}
-            </span>
+          <div className="w-16 h-16 rounded-full overflow-hidden bg-white/20 flex items-center justify-center shrink-0">
+            {avatarSrc ? (
+              <img src={avatarSrc} alt="Avatar" className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-white text-xl font-bold">{initials}</span>
+            )}
           </div>
           <div>
             <span className="inline-block text-xs font-semibold bg-white/20 px-3 py-1 rounded-full mb-2">

--- a/apps/frontend/src/features/users/pages/ProfilePage.tsx
+++ b/apps/frontend/src/features/users/pages/ProfilePage.tsx
@@ -1,5 +1,8 @@
+import { Camera, Loader } from 'lucide-react'
 import { useProfilePage } from '@/features/users/hooks/useProfilePage'
 import { ROLE_LABELS } from '@/constants/userRoles'
+
+const API_URL = import.meta.env.VITE_API_URL ?? ''
 
 export default function ProfilePage() {
   const {
@@ -11,7 +14,13 @@ export default function ProfilePage() {
     success,
     pageError,
     handleSave,
+    avatarUploading,
+    fileInputRef,
+    handleAvatarChange,
   } = useProfilePage()
+
+  const avatarSrc = user?.avatar_url ? `${API_URL}${user.avatar_url}` : null
+  const initials = `${user?.first_name?.[0] ?? ''}${user?.last_name?.[0] ?? ''}`
 
   return (
     <div className="max-w-xl mx-auto">
@@ -31,6 +40,39 @@ export default function ProfilePage() {
             {pageError}
           </div>
         )}
+
+        {/* Avatar */}
+        <div className="flex justify-center pb-2">
+          <div className="relative group">
+            <div className="w-24 h-24 rounded-full overflow-hidden bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center">
+              {avatarSrc ? (
+                <img src={avatarSrc} alt="Profile photo" className="w-full h-full object-cover" />
+              ) : (
+                <span className="text-blue-700 dark:text-blue-400 text-2xl font-bold">{initials}</span>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={avatarUploading}
+              className="absolute inset-0 rounded-full flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity disabled:cursor-not-allowed"
+              aria-label="Upload photo"
+            >
+              {avatarUploading ? (
+                <Loader size={20} className="text-white animate-spin" />
+              ) : (
+                <Camera size={20} className="text-white" />
+              )}
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="hidden"
+              onChange={handleAvatarChange}
+            />
+          </div>
+        </div>
 
         <div className="grid grid-cols-2 gap-4">
           <div>

--- a/apps/frontend/src/features/users/services/userService.ts
+++ b/apps/frontend/src/features/users/services/userService.ts
@@ -21,6 +21,15 @@ export async function updateUser(id: string, data: UserUpdate): Promise<UserResp
   return res.data
 }
 
+export async function uploadAvatar(file: File): Promise<UserResponse> {
+  const formData = new FormData()
+  formData.append('file', file)
+  const res = await apiClient.post(API.USERS.UPLOAD_AVATAR, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return res.data
+}
+
 export async function deactivateUser(id: string): Promise<void> {
   await apiClient.patch(API.USERS.DEACTIVATE(id))
 }

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -10,6 +10,8 @@ import { ROUTES } from '@/constants/routes'
 import { USER_ROLES } from '@/constants/userRoles'
 import { StepUpLogo } from '@/components/StepUpLogo'
 
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
 export default function DashboardLayout() {
   const user = useAuthStore((state) => state.user)
   const clearUser = useAuthStore((state) => state.clearUser)
@@ -75,9 +77,20 @@ export default function DashboardLayout() {
 
             {open && (
               <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
-                <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
-                  <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
+                <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full overflow-hidden bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center shrink-0">
+                    {user?.avatar_url ? (
+                      <img src={`${API_URL}${user.avatar_url}`} alt="Avatar" className="w-full h-full object-cover" />
+                    ) : (
+                      <span className="text-blue-700 dark:text-blue-400 text-xs font-bold">
+                        {user?.first_name?.[0]}{user?.last_name?.[0]}
+                      </span>
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
+                  </div>
                 </div>
 
                 <Link

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -9,6 +9,8 @@ import { useTranslation } from '@/i18n/useTranslation'
 import { ROUTES } from '@/constants/routes'
 import { StepUpLogo } from '@/components/StepUpLogo'
 
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
 export default function HRDashboardLayout() {
   const user = useAuthStore((state) => state.user)
   const clearUser = useAuthStore((state) => state.clearUser)
@@ -78,9 +80,20 @@ export default function HRDashboardLayout() {
 
             {open && (
               <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
-                <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
-                  <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
+                <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full overflow-hidden bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center shrink-0">
+                    {user?.avatar_url ? (
+                      <img src={`${API_URL}${user.avatar_url}`} alt="Avatar" className="w-full h-full object-cover" />
+                    ) : (
+                      <span className="text-blue-700 dark:text-blue-400 text-xs font-bold">
+                        {user?.first_name?.[0]}{user?.last_name?.[0]}
+                      </span>
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{user?.first_name} {user?.last_name}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.email}</p>
+                  </div>
                 </div>
 
                 <Link

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -934,6 +934,8 @@ export interface components {
             department_id: string | null;
             /** Department Name */
             department_name?: string | null;
+            /** Avatar Url */
+            avatar_url?: string | null;
         };
         /**
          * UserRole

--- a/docs/guides/tutorials/backend/014-file-upload.md
+++ b/docs/guides/tutorials/backend/014-file-upload.md
@@ -1,0 +1,199 @@
+# File Upload with FastAPI
+
+How to accept file uploads in a FastAPI endpoint, validate them, save them to disk, and serve them as static files.
+
+---
+
+## The Moving Parts
+
+A file upload endpoint has three concerns:
+
+1. **Receiving** — FastAPI's `UploadFile` reads the request body as a stream
+2. **Validating** — content type and size must be checked before saving
+3. **Serving** — saved files need a URL the client can fetch
+
+---
+
+## Receiving the File
+
+Use `UploadFile` and `File` from `fastapi`:
+
+```python
+from fastapi import APIRouter, Depends, File, UploadFile
+
+@router.post("/me/avatar", response_model=UserResponse)
+async def upload_avatar(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    ...
+```
+
+`File(...)` makes the parameter required. The client must send `multipart/form-data`, not JSON.
+
+`UploadFile` exposes:
+- `file.content_type` — MIME type reported by the client (`"image/jpeg"`, etc.)
+- `await file.read()` — reads the full content into memory as `bytes`
+- `file.filename` — original filename from the client (do not trust this for saving)
+
+---
+
+## Validating Content Type and Size
+
+**Never trust `content_type` alone** — a client can send any string there. Validate it, but treat it as a hint, not a guarantee.
+
+```python
+_ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_MAX_BYTES = 5 * 1024 * 1024  # 5MB
+
+if file.content_type not in _ALLOWED_TYPES:
+    raise HTTPException(status_code=400, detail="Only JPEG, PNG and WebP images are allowed.")
+
+content = await file.read()
+
+if len(content) > _MAX_BYTES:
+    raise HTTPException(status_code=400, detail="Image must be under 5MB.")
+```
+
+Read the content **after** the type check so you avoid reading a large file unnecessarily.
+
+For stronger validation, consider checking the file's magic bytes (the first few bytes that identify the format). See the existing magic-bytes validation for reference.
+
+---
+
+## Saving to Disk
+
+Use `pathlib.Path` — it is cleaner than `os.path` and works on all platforms:
+
+```python
+from pathlib import Path
+
+_UPLOAD_DIR = Path("uploads/avatars")
+_EXT_MAP = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}
+
+_UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+ext = _EXT_MAP[file.content_type]
+filename = f"{current_user.id}.{ext}"
+(_UPLOAD_DIR / filename).write_bytes(content)
+```
+
+**Filename strategy:** use the user's UUID as the filename, not `file.filename`. This prevents:
+- Path traversal attacks (`../../etc/passwd`)
+- Collisions between users
+- Special characters that break filesystems
+
+Using the user ID also means uploading a new photo overwrites the previous one automatically.
+
+---
+
+## Storing the Path in the Database
+
+Store the URL path (not the filesystem path) so the client can fetch it directly:
+
+```python
+current_user.avatar_url = f"/static/avatars/{filename}"
+db.add(current_user)
+await db.commit()
+await db.refresh(current_user)
+```
+
+`/static/avatars/filename.jpg` is the path FastAPI will serve via `StaticFiles` (see below). The client prepends the backend base URL to get the full URL.
+
+---
+
+## Serving Uploaded Files
+
+Mount a `StaticFiles` handler in `main.py` so FastAPI serves the `uploads/` directory:
+
+```python
+import os
+from fastapi.staticfiles import StaticFiles
+
+os.makedirs("uploads/avatars", exist_ok=True)
+app.mount("/static", StaticFiles(directory="uploads"), name="static")
+```
+
+`app.mount` must be called **before** `app.include_router` — router routes take precedence and would shadow the static mount if registered first.
+
+After this, a file saved at `uploads/avatars/abc123.jpg` is accessible at:
+
+```
+GET http://localhost:8000/static/avatars/abc123.jpg
+```
+
+---
+
+## Full Endpoint Example
+
+```python
+from pathlib import Path
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.models.user import User
+from app.schemas.user import UserResponse
+
+_ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_EXT_MAP = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}
+_UPLOAD_DIR = Path("uploads/avatars")
+_MAX_BYTES = 5 * 1024 * 1024
+
+router = APIRouter()
+
+@router.post("/me/avatar", response_model=UserResponse)
+async def upload_avatar(
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserResponse:
+    if file.content_type not in _ALLOWED_TYPES:
+        raise HTTPException(status_code=400, detail="Only JPEG, PNG and WebP images are allowed.")
+
+    content = await file.read()
+    if len(content) > _MAX_BYTES:
+        raise HTTPException(status_code=400, detail="Image must be under 5MB.")
+
+    _UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    ext = _EXT_MAP[file.content_type]
+    filename = f"{current_user.id}.{ext}"
+    (_UPLOAD_DIR / filename).write_bytes(content)
+
+    current_user.avatar_url = f"/static/avatars/{filename}"
+    db.add(current_user)
+    await db.commit()
+    await db.refresh(current_user)
+
+    return UserResponse.model_validate(current_user)
+```
+
+---
+
+## Displaying on the Frontend
+
+The stored `avatar_url` is a relative path like `/static/avatars/abc123.jpg`. The frontend must prepend the backend base URL:
+
+```typescript
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
+const avatarSrc = user.avatar_url ? `${API_URL}${user.avatar_url}` : null
+```
+
+Then use it in JSX:
+
+```tsx
+{avatarSrc ? (
+  <img src={avatarSrc} alt="Avatar" className="w-full h-full object-cover" />
+) : (
+  <span>{initials}</span>
+)}
+```
+
+---
+
+## Production Note
+
+Local disk storage (`uploads/`) works for development but does not survive container restarts on Cloud Run — the filesystem is ephemeral. Before deploying to production, replace disk writes with GCP Cloud Storage uploads and store the full public GCS URL in `avatar_url` instead. See ADR-002 for the GCP stack decision.

--- a/docs/guides/tutorials/frontend/007-packages.md
+++ b/docs/guides/tutorials/frontend/007-packages.md
@@ -97,6 +97,20 @@ const loginSchema = z.object({
 
 Used with `react-hook-form` via `zodResolver`. The schema validates on submit and provides typed form data — `handleSubmit` receives `{ email: string, password: string }`, not untyped form values.
 
+### `lucide-react`
+
+Icon library. Provides SVG icons as React components.
+
+```tsx
+import { Clock, Users, ArrowRight } from 'lucide-react'
+
+<Clock size={20} className="text-amber-600" />
+```
+
+Each icon is a standalone component — only the icons you import are included in the bundle (tree-shakeable). Icons accept `size`, `className`, `strokeWidth`, and standard SVG props.
+
+Used throughout the dashboard stat cards, quick link rows, and the profile photo upload button.
+
 ### `date-fns`
 
 Date utility library. Formats dates for display.

--- a/docs/guides/tutorials/frontend/009-services-and-constants.md
+++ b/docs/guides/tutorials/frontend/009-services-and-constants.md
@@ -42,6 +42,31 @@ axios.post(API.AUTH.REGISTER, data)
 
 New entries are added as needed — one US at a time. US-002 will add `AUTH.LOGIN`, `AUTH.LOGOUT`, `AUTH.REFRESH`. Not before.
 
+### File Upload Endpoints
+
+File upload endpoints follow the same pattern but the service call uses `FormData` instead of a plain object:
+
+```typescript
+// apiEndpoints.ts
+USERS: {
+  UPLOAD_AVATAR: '/api/v1/users/me/avatar',
+}
+
+// userService.ts
+export async function uploadAvatar(file: File): Promise<UserResponse> {
+  const formData = new FormData()
+  formData.append('file', file)
+  const res = await apiClient.post(API.USERS.UPLOAD_AVATAR, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return res.data
+}
+```
+
+`FormData` is the browser's built-in container for `multipart/form-data` — the format servers expect for file uploads. The field name (`'file'`) must match the parameter name in the FastAPI endpoint (`file: UploadFile = File(...)`).
+
+The `'Content-Type': 'multipart/form-data'` header tells the server how to parse the body. Without it, axios sends JSON by default and the backend cannot find the file.
+
 ---
 
 ## src/constants/routes.ts


### PR DESCRIPTION
## Summary
- Add `avatar_url` column to users table via Alembic migration (`f1a2b3c4d5e6`)
- Add `POST /api/v1/users/me/avatar` endpoint — accepts JPEG/PNG/WebP, max 5MB, saves to `uploads/avatars/`
- Serve uploaded files via FastAPI `StaticFiles` at `/static/avatars/`
- Add `uploadAvatar()` to frontend `userService`
- Update `ProfilePage` with click-to-upload avatar circle (camera icon on hover, spinner while uploading)
- Show avatar image in dashboard hero for all three roles (HR, Manager, Employee) — falls back to initials
- Show avatar in navbar dropdown header for both layouts
- Add docs: `014-file-upload.md` backend tutorial, `lucide-react` to packages doc, FormData pattern to services doc

## Test plan
- [ ] Upload a JPEG/PNG/WebP on Profile page — avatar appears immediately in hero and navbar
- [ ] Upload replaces previous photo (same filename per user ID)
- [ ] Upload a non-image file — error message shown
- [ ] Upload a file over 5MB — error message shown
- [ ] User with no photo — initials shown in all locations
- [ ] Dark mode — avatar circle and camera icon render correctly
- [ ] Run migration: `alembic upgrade head`