### PR TITLE
refactor: fix audit log transactions and migrate avatar upload to GCS

### DIFF
--- a/apps/backend/alembic/versions/a2b3c4d5e6f7_add_invitation_resent_audit_action.py
+++ b/apps/backend/alembic/versions/a2b3c4d5e6f7_add_invitation_resent_audit_action.py
@@ -1,0 +1,23 @@
+"""add invitation_resent audit action
+
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-05-16 14:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = 'a2b3c4d5e6f7'
+down_revision: str | None = 'f1a2b3c4d5e6'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE audit_action_type ADD VALUE IF NOT EXISTS 'user.invitation_resent'")
+
+
+def downgrade() -> None:
+    pass

--- a/apps/backend/app/api/v1/invitation.py
+++ b/apps/backend/app/api/v1/invitation.py
@@ -52,6 +52,7 @@ async def resend_invitation(
     invitation = await invitation_service.resend_invitation(
         db=db,
         invitation_id=invitation_id,
+        actor_id=current_user.id,
     )
     return InvitationResponse.model_validate(invitation)
 

--- a/apps/backend/app/enums/audit_enums.py
+++ b/apps/backend/app/enums/audit_enums.py
@@ -3,6 +3,7 @@ import enum
 
 class AuditActionType(enum.StrEnum):
     user_invited = "user.invited"
+    user_invitation_resent = "user.invitation_resent"
     user_registered = "user.registered"
     user_deactivated = "user.deactivated"
     user_reactivated = "user.reactivated"

--- a/apps/backend/app/services/invitation_service.py
+++ b/apps/backend/app/services/invitation_service.py
@@ -51,10 +51,10 @@ class InvitationService:
             department_id=department_id,
         )
         await invitation_repository.create(db, invitation)
-        await db.commit()
-        await db.refresh(invitation)
+        await db.flush()
         await audit_service.log(db, actor_id=invited_by, action=AuditActionType.user_invited, entity_type=AuditEntityType.invitation, entity_id=invitation.id, detail=email)
         await db.commit()
+        await db.refresh(invitation)
 
         try:
             await email_service.send_invitation_email(
@@ -109,10 +109,9 @@ class InvitationService:
         db.add(user)
         invitation.used_at = datetime.now(UTC)
         await db.flush()
-        await db.commit()
-        await db.refresh(user)
         await audit_service.log(db, actor_id=user.id, action=AuditActionType.user_registered, entity_type=AuditEntityType.user, entity_id=user.id)
         await db.commit()
+        await db.refresh(user)
         return user
     
     async def get_invitations(self, db: AsyncSession, page: int = 1, page_size: int = 20) -> InvitationListResponse:
@@ -132,6 +131,7 @@ class InvitationService:
         self,
         db: AsyncSession,
         invitation_id: uuid.UUID,
+        actor_id: uuid.UUID,
     ) -> Invitation:
         invitation = await invitation_repository.get_by_id(db, invitation_id)
         if not invitation:
@@ -142,6 +142,7 @@ class InvitationService:
 
         invitation.token = secrets.token_urlsafe(32)
         invitation.expires_at = datetime.now(UTC) + timedelta(days=INVITATION_EXPIRY_DAYS)
+        await audit_service.log(db, actor_id=actor_id, action=AuditActionType.user_invitation_resent, entity_type=AuditEntityType.invitation, entity_id=invitation_id, detail=invitation.email)
         await db.commit()
         await db.refresh(invitation)
 

--- a/apps/backend/app/services/onboarding_plan_service.py
+++ b/apps/backend/app/services/onboarding_plan_service.py
@@ -74,10 +74,9 @@ class OnboardingPlanService:
                 order=task.order,
             ))
 
-        await db.commit()
         if actor_id:
             await audit_service.log(db, actor_id=actor_id, action=AuditActionType.plan_created, entity_type=AuditEntityType.plan, entity_id=plan.id)
-            await db.commit()
+        await db.commit()
         try:
             employee = await user_repository.get_by_id(db, data.user_id)
             if employee:
@@ -139,8 +138,8 @@ class OnboardingPlanService:
             order=max_order + 1,
         )
         await plan_task_repository.create(db, task)
-        await db.commit()
         await db.flush()
+        await db.commit()
         task = await plan_task_repository.get_by_id(db, task.id)
         return task
 
@@ -157,9 +156,8 @@ class OnboardingPlanService:
             raise ValidationError(*messages.TASK_ALREADY_TERMINAL)
 
         task.status = OnboardingPlanTaskStatus.CANCELLED
+        if actor_id:
+            await audit_service.log(db, actor_id=actor_id, action=AuditActionType.plan_task_cancelled, entity_type=AuditEntityType.task, entity_id=task_id)
         await db.commit()
         task = await plan_task_repository.get_by_id(db, task_id)
-        if actor_id:
-            await audit_service.log(db, actor_id=actor_id, action=AuditActionType.plan_task_cancelled, entity_type=AuditEntityType.task, entity_id=task.id)
-            await db.commit()
         return task

--- a/apps/backend/app/services/user_service.py
+++ b/apps/backend/app/services/user_service.py
@@ -1,8 +1,8 @@
 import uuid
-from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.enums.audit_enums import AuditActionType, AuditEntityType
 from app.enums.user_role import UserRole
 from app.errors import NotFoundError, ValidationError, messages
@@ -16,15 +16,33 @@ from app.schemas.user import (
     UserUpdate,
 )
 from app.services.audit_service import AuditService
+from app.services.storage_service import StorageService
 
 _ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
 _AVATAR_EXT_MAP = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}
-_AVATARS_DIR = Path("uploads/avatars")
 _MAX_AVATAR_BYTES = 5 * 1024 * 1024
+
+
+def _valid_avatar_signature(content: bytes, content_type: str) -> bool:
+    if content_type == "image/jpeg":
+        return content.startswith(b"\xff\xd8\xff")
+    if content_type == "image/png":
+        return content.startswith(b"\x89PNG\r\n\x1a\n")
+    if content_type == "image/webp":
+        return content[:4] == b"RIFF" and content[8:12] == b"WEBP"
+    return False
+
+
+def _gcs_object_name(avatar_url: str) -> str | None:
+    prefix = f"https://storage.googleapis.com/{settings.GCS_BUCKET_NAME}/"
+    if avatar_url.startswith(prefix):
+        return avatar_url[len(prefix):]
+    return None
 
 user_repository = UserRepository()
 refresh_token_repository = RefreshTokenRepository()
 audit_service = AuditService()
+storage_service = StorageService()
 
 
 class UserService:
@@ -68,10 +86,9 @@ class UserService:
         if data.role is not None:
             user.role = data.role
 
-        await db.commit()
         if actor_id:
             await audit_service.log(db, actor_id=actor_id, action=AuditActionType.user_updated, entity_type=AuditEntityType.user, entity_id=user_id)
-            await db.commit()
+        await db.commit()
         return await user_repository.get_by_id(db, user_id)
 
     async def upload_avatar(
@@ -85,11 +102,18 @@ class UserService:
             raise ValidationError(*messages.INVALID_AVATAR_TYPE)
         if len(content) > _MAX_AVATAR_BYTES:
             raise ValidationError(*messages.AVATAR_TOO_LARGE)
-        _AVATARS_DIR.mkdir(parents=True, exist_ok=True)
+        if not _valid_avatar_signature(content, content_type):
+            raise ValidationError(*messages.INVALID_AVATAR_TYPE)
+
+        if user.avatar_url:
+            old_object = _gcs_object_name(user.avatar_url)
+            if old_object:
+                storage_service.delete(old_object)
+
         ext = _AVATAR_EXT_MAP[content_type]
-        filename = f"{user.id}.{ext}"
-        (_AVATARS_DIR / filename).write_bytes(content)
-        user.avatar_url = f"/static/avatars/{filename}"
+        object_name = f"avatars/{user.id}.{ext}"
+        storage_service.upload(content, object_name, content_type)
+        user.avatar_url = f"https://storage.googleapis.com/{settings.GCS_BUCKET_NAME}/{object_name}"
         user_id = user.id
         await db.commit()
         return await user_repository.get_by_id(db, user_id)
@@ -123,7 +147,6 @@ class UserService:
 
         user.is_active = False
         await refresh_token_repository.delete_by_user_id(db, user_id)
-        await db.commit()
         await audit_service.log(db, actor_id=current_user_id, action=AuditActionType.user_deactivated, entity_type=AuditEntityType.user, entity_id=user_id)
         await db.commit()
 
@@ -138,8 +161,7 @@ class UserService:
             raise NotFoundError(*messages.USER_NOT_FOUND)
 
         user.is_active = True
-        await db.commit()
         if actor_id:
             await audit_service.log(db, actor_id=actor_id, action=AuditActionType.user_reactivated, entity_type=AuditEntityType.user, entity_id=user_id)
-            await db.commit()
+        await db.commit()
         return await user_repository.get_by_id(db, user_id)

--- a/apps/backend/tests/unit/services/test_invitation_service.py
+++ b/apps/backend/tests/unit/services/test_invitation_service.py
@@ -213,12 +213,16 @@ class TestResendInvitation:
         ) as mock_inv_repo, patch(
             "app.services.invitation_service.email_service",
             autospec=True,
-        ) as mock_email:
+        ) as mock_email, patch(
+            "app.services.invitation_service.audit_service",
+            autospec=True,
+        ) as mock_audit:
 
             mock_inv_repo.get_by_id = AsyncMock(return_value=mock_invitation)
             mock_email.send_invitation_email = AsyncMock()
+            mock_audit.log = AsyncMock()
 
-            result = await service.resend_invitation(mock_db, MagicMock())
+            result = await service.resend_invitation(mock_db, MagicMock(), actor_id=MagicMock())
 
             assert result is not None
 
@@ -234,7 +238,7 @@ class TestResendInvitation:
             mock_inv_repo.get_by_id = AsyncMock(return_value=None)
 
             with pytest.raises(NotFoundError):
-                await service.resend_invitation(mock_db, MagicMock())
+                await service.resend_invitation(mock_db, MagicMock(), actor_id=MagicMock())
 
 
     async def test_resend_invitation_raises_error_when_invitation_is_already_used(
@@ -251,6 +255,6 @@ class TestResendInvitation:
             mock_inv_repo.get_by_id = AsyncMock(return_value=mock_invitation)
 
             with pytest.raises(ValidationError):
-                await service.resend_invitation(mock_db, MagicMock())
+                await service.resend_invitation(mock_db, MagicMock(), actor_id=MagicMock())
 
 


### PR DESCRIPTION
## Summary

- **Audit log double-commit fixed** — `onboarding_plan_service`, `user_service`, `invitation_service` içindeki tüm audit log çağrıları `commit()`'ten önce yapılır hale getirildi; ikinci `commit()` kaldırıldı
- **Avatar upload GCS'e taşındı** — local disk (`uploads/avatars/`) yerine `StorageService` kullanılıyor; avatar URL artık kalıcı public GCS URL olarak DB'ye yazılıyor; yeni upload öncesi eski GCS object siliniyor; JPEG/PNG/WebP file signature validation eklendi
- **`resend_invitation` audit log eklendi** — `actor_id` parametresi eklendi, `user_invitation_resent` action ile log atılıyor; router güncellendi; testler güncellendi
- **`add_task` flush/commit sırası düzeltildi** — `commit()` öncesi `flush()` gelecek şekilde düzeltildi

## Test plan

- [ ] `pytest tests/unit/services/test_invitation_service.py` — 3 resend testi geçmeli
- [ ] Avatar upload endpoint'i test et — GCS'e yazılmalı, public URL dönmeli
- [ ] Audit log tablosunu kontrol et — plan_created, task_cancelled, invitation_resent kayıtları tek commit'te düşmeli