### PR TITLE
fix: production bug fixes — dashboard join, avatar URL, GCS bucket

### DIFF
--- a/apps/backend/app/repositories/onboarding_plan_task_repository.py
+++ b/apps/backend/app/repositories/onboarding_plan_task_repository.py
@@ -40,6 +40,7 @@ class OnboardingPlanTaskRepository:
     async def count_completed_across_active_plans(self, db: AsyncSession) -> int:
         result = await db.execute(
             select(func.count())
+            .select_from(OnboardingPlanTask)
             .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
             .where(
                 OnboardingPlanTask.status == OnboardingPlanTaskStatus.COMPLETED,
@@ -53,6 +54,7 @@ class OnboardingPlanTaskRepository:
     async def count_completed_by_manager(self, db: AsyncSession, manager_id: uuid.UUID) -> int:
         result = await db.execute(
             select(func.count())
+            .select_from(OnboardingPlanTask)
             .join(OnboardingPlan, OnboardingPlanTask.plan_id == OnboardingPlan.id)
             .where(
                 OnboardingPlanTask.status == OnboardingPlanTaskStatus.COMPLETED,

--- a/apps/frontend/src/features/users/pages/ProfilePage.tsx
+++ b/apps/frontend/src/features/users/pages/ProfilePage.tsx
@@ -2,8 +2,6 @@ import { Camera, Loader } from 'lucide-react'
 import { useProfilePage } from '@/features/users/hooks/useProfilePage'
 import { ROLE_LABELS } from '@/constants/userRoles'
 
-const API_URL = import.meta.env.VITE_API_URL ?? ''
-
 export default function ProfilePage() {
   const {
     user,
@@ -19,7 +17,7 @@ export default function ProfilePage() {
     handleAvatarChange,
   } = useProfilePage()
 
-  const avatarSrc = user?.avatar_url ? `${API_URL}${user.avatar_url}` : null
+  const avatarSrc = user?.avatar_url ?? null
   const initials = `${user?.first_name?.[0] ?? ''}${user?.last_name?.[0] ?? ''}`
 
   return (


### PR DESCRIPTION
## Summary

- **Dashboard 500**: `select_from(OnboardingPlanTask)` eklendi — SQLAlchemy ambiguous join hatasını düzeltiyor
- **Avatar görünmüyor**: `ProfilePage`'de `avatar_url` zaten tam GCS URL'i olduğu için `API_URL` prefix kaldırıldı
- **GCS bucket public erişim**: `stepup-494114-attachments` bucket'ına `allUsers` objectViewer rolü eklendi

## Test plan

- [ ] HR/Manager dashboard yüklenmeli (500 yok)
- [ ] Profile sayfasında JPEG/PNG avatar yüklenebilmeli ve görünmeli
- [ ] `ProfilePage` testleri: 4/4 geçiyor