### PR TITLE
fix: avatar URL display and HR dashboard join error

### DIFF
--- a/apps/frontend/src/features/users/pages/HRDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/HRDashboard.tsx
@@ -3,7 +3,6 @@ import { Users, ClipboardList, Building2, Clock } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
 import { useHRDashboard } from '@/features/dashboard/hooks/useHRDashboard'
 
-const API_URL = import.meta.env.VITE_API_URL ?? ''
 
 type Color = 'blue' | 'emerald' | 'violet' | 'amber'
 
@@ -47,7 +46,7 @@ export default function HRDashboard() {
   const user = useAuthStore((state) => state.user)
   const { stats } = useHRDashboard()
 
-  const avatarSrc = user?.avatar_url ? `${API_URL}${user.avatar_url}` : null
+  const avatarSrc = user?.avatar_url ?? null
   const initials = `${user?.first_name?.[0] ?? ''}${user?.last_name?.[0] ?? ''}`
 
   return (

--- a/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
+++ b/apps/frontend/src/features/users/pages/ManagerDashboard.tsx
@@ -5,7 +5,6 @@ import { useAuthStore } from '@/stores/authStore'
 import { ROUTES } from '@/constants/routes'
 import { useManagerDashboard } from '@/features/dashboard/hooks/useManagerDashboard'
 
-const API_URL = import.meta.env.VITE_API_URL ?? ''
 
 type Color = 'blue' | 'emerald' | 'amber'
 
@@ -48,7 +47,7 @@ export default function ManagerDashboard() {
   const user = useAuthStore((state) => state.user)
   const { stats } = useManagerDashboard()
 
-  const avatarSrc = user?.avatar_url ? `${API_URL}${user.avatar_url}` : null
+  const avatarSrc = user?.avatar_url ?? null
   const initials = `${user?.first_name?.[0] ?? ''}${user?.last_name?.[0] ?? ''}`
 
   return (

--- a/apps/frontend/src/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/layouts/DashboardLayout.tsx
@@ -10,7 +10,6 @@ import { ROUTES } from '@/constants/routes'
 import { USER_ROLES } from '@/constants/userRoles'
 import { StepUpLogo } from '@/components/StepUpLogo'
 
-const API_URL = import.meta.env.VITE_API_URL ?? ''
 
 export default function DashboardLayout() {
   const user = useAuthStore((state) => state.user)
@@ -80,7 +79,7 @@ export default function DashboardLayout() {
                 <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center gap-3">
                   <div className="w-8 h-8 rounded-full overflow-hidden bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center shrink-0">
                     {user?.avatar_url ? (
-                      <img src={`${API_URL}${user.avatar_url}`} alt="Avatar" className="w-full h-full object-cover" />
+                      <img src={user.avatar_url} alt="Avatar" className="w-full h-full object-cover" />
                     ) : (
                       <span className="text-blue-700 dark:text-blue-400 text-xs font-bold">
                         {user?.first_name?.[0]}{user?.last_name?.[0]}

--- a/apps/frontend/src/layouts/HRDashboardLayout.tsx
+++ b/apps/frontend/src/layouts/HRDashboardLayout.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from '@/i18n/useTranslation'
 import { ROUTES } from '@/constants/routes'
 import { StepUpLogo } from '@/components/StepUpLogo'
 
-const API_URL = import.meta.env.VITE_API_URL ?? ''
 
 export default function HRDashboardLayout() {
   const user = useAuthStore((state) => state.user)
@@ -83,7 +82,7 @@ export default function HRDashboardLayout() {
                 <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center gap-3">
                   <div className="w-8 h-8 rounded-full overflow-hidden bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center shrink-0">
                     {user?.avatar_url ? (
-                      <img src={`${API_URL}${user.avatar_url}`} alt="Avatar" className="w-full h-full object-cover" />
+                      <img src={user.avatar_url} alt="Avatar" className="w-full h-full object-cover" />
                     ) : (
                       <span className="text-blue-700 dark:text-blue-400 text-xs font-bold">
                         {user?.first_name?.[0]}{user?.last_name?.[0]}


### PR DESCRIPTION
## Summary

- **Avatar görünmüyor**: 5 dosyada (`ProfilePage`, `HRDashboard`, `ManagerDashboard`, `DashboardLayout`, `HRDashboardLayout`) `${API_URL}${user.avatar_url}` → `user.avatar_url` düzeltildi
- **HR/Manager dashboard 500**: `count_completed_across_active_plans` ve `count_completed_by_manager`'a `select_from(OnboardingPlanTask)` eklendi

## Test plan

- [ ] Avatar yükle → tüm sayfalarda (profile, dashboard header) görünmeli
- [ ] HR ve Manager dashboard yüklenmeli (500 yok)